### PR TITLE
docs: enforce test-first agent workflow

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -35,6 +35,60 @@ You are assisting with **Sezzions**, the standalone desktop app in this reposito
 7. Move the item to "Ready for Review" and wait for owner approval.
 8. After approval/merge, close the Issue (and only then update/remove any related TODO mirror item).
 
+## Agent Quality Bar (Test-First + Headless Smoke + Pitfalls)
+
+When you are assigned a GitHub Issue (e.g., Issue #8), you must execute the work in a way that minimizes after-the-fact troubleshooting.
+
+### 1) Mandatory Red → Green → Review
+
+Before implementing production code changes:
+
+1. **Translate acceptance criteria into automated tests first** (integration + unit where appropriate).
+2. **Run the tests and confirm at least one fails for the intended reason** (feature not implemented yet).
+3. Implement the smallest, cleanest change set to satisfy the tests.
+4. Re-run tests and confirm **100% pass**.
+5. Only then open/update the PR.
+
+### 2) Torture-Test Matrix (Edge Cases + Failure Injection)
+
+For each Issue, create a short test matrix *before* implementation:
+
+- **Happy path(s)**: proves core feature behavior.
+- **Edge cases** (at least 2): boundaries, empty DB, partial data, invalid selections.
+- **Failure injection** (at least 1): force a mid-operation failure and assert rollback/invariants.
+- **Invariants**: assert what must not change (e.g., “only selected tables changed”, “no partial writes”).
+
+### 3) Headless Usability Smoke Tests (When UI is touched)
+
+If the Issue touches UI behavior/flows:
+
+- Add or update at least one **headless smoke test** that:
+   - creates a `QApplication`,
+   - instantiates the main window (`MainWindow(AppFacade(...))`),
+   - processes events briefly,
+   - and exits cleanly.
+- Prefer running in headless mode via `QT_QPA_PLATFORM=offscreen` (or equivalent) in CI/local.
+
+Goal: catch startup crashes, missing widgets/actions, signal/slot mismatches, and menu/dialog lifetime issues early.
+
+### 4) Post-Implementation Pitfalls Scan (No scope creep)
+
+After tests pass and before requesting review:
+
+- Add a short **“Pitfalls / Follow-ups”** section in the PR description.
+- Identify risks or likely next fixes discovered during implementation (performance, UX confusion, concurrency, data integrity).
+- Do **not** implement follow-ups outside the Issue scope; instead propose them as:
+   - a new GitHub Issue, and/or
+   - an item to mirror into `docs/TODO.md`.
+
+### 5) “No Surprise Regressions” Checklist
+
+Before moving to “Ready for Review”:
+
+- Run full `pytest`.
+- Run headless UI smoke tests if UI was touched.
+- Perform one minimal manual verification step (≤5 minutes) and note it in the PR.
+
 ## Issues (Templates)
 
 - Prefer GitHub Issues for new work items.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,50 @@ See [docs/adr/0001-docs-governance.md](docs/adr/0001-docs-governance.md).
 - Do not change core accounting logic just to satisfy an old test expectation.
 - For accounting changes: add a small, explicit “golden scenario” test first.
 
+## Agent Execution Standard (Test-First + Usability + Pitfalls)
+
+This section exists to reduce post-PR troubleshooting (runtime issues, UI regressions, and cascading bugs).
+When assigned an Issue, agents must follow these standards.
+
+### 1) Red → Green → Review (Mandatory)
+
+1. Convert the Issue acceptance criteria into automated tests.
+2. Run the tests and confirm at least one fails for the intended reason (feature not implemented yet).
+3. Implement minimal, surgical changes until tests pass.
+4. Re-run the full suite and confirm **100% pass**.
+5. Only then open/update the PR.
+
+### 2) Torture-Test Matrix (Required for each Issue)
+
+Before writing production code, document (in the PR description or issue notes) a short matrix and implement tests for it:
+
+- Happy path(s)
+- At least 2 edge cases
+- At least 1 failure-injection case proving rollback/invariants
+- Explicit invariants (what must not change)
+
+Example (data tools / restore-like issues):
+- “Only selected tables change”
+- “Atomic rollback on any failure”
+- “Audit log entries created for affected tables”
+
+### 3) Headless Usability Smoke Tests (If UI is touched)
+
+If an Issue touches UI flows, dialogs, menus, or threading/lifetime behavior:
+
+- Add/update a headless smoke test that boots a `QApplication`, instantiates `MainWindow(AppFacade(...))`, processes events briefly, and exits cleanly.
+- Prefer `QT_QPA_PLATFORM=offscreen` (or equivalent) so tests can run in CI/headless.
+
+Goal: catch startup and wiring regressions early (missing menu actions, signal/slot mismatches, dialog lifetime issues).
+
+### 4) Pitfalls / Follow-ups (No scope creep)
+
+After implementation is complete and tests are green:
+
+- Perform a brief “pitfalls scan”: what could break later, what is confusing, what risks remain.
+- Do **not** fix items outside the Issue scope.
+- Record follow-ups as new GitHub Issues (preferred) and optionally mirror into `docs/TODO.md`.
+
 ## Legacy Rule
 
 - Avoid editing `.LEGACY/` unless explicitly requested.


### PR DESCRIPTION
## Summary\n\nTightens agent execution standards so Issues ship with fewer runtime/UI regressions and less after-the-fact troubleshooting.\n\n## What changed\n- Adds mandatory Red → Green → Review (tests first, prove failure, then implement, then 100% pass)\n- Requires a per-Issue torture-test matrix (happy path + edge cases + failure injection + invariants)\n- Requires headless UI smoke tests when UI is touched (QApplication + MainWindow(AppFacade(...)) + process events)\n- Requires a Pitfalls / Follow-ups section (no scope creep; capture risks as new Issues/TODO)\n\n## Files\n- .github/copilot-instructions.md\n- AGENTS.md\n\n## Pitfalls / Follow-ups\n- None; this is guidance-only.\n