### PR TITLE
Issue #18: Add tests for ResetDialog regression prevention

### DIFF
--- a/tests/integration/test_reset_database_flow.py
+++ b/tests/integration/test_reset_database_flow.py
@@ -1,0 +1,186 @@
+"""
+Integration smoke tests for Tools -> Reset Database flow
+
+Prevents regressions in the reset workflow (Issue #18).
+Tests that the dialog can be constructed, options can be read, and the flow
+completes without exceptions in a headless environment.
+"""
+
+import pytest
+import sys
+from unittest.mock import Mock, patch, MagicMock
+from PySide6.QtWidgets import QApplication
+from PySide6.QtCore import QTimer
+
+from app_facade import AppFacade
+from ui.tabs.tools_tab import ToolsTab
+from ui.tools_dialogs import ResetDialog
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    """Create QApplication for Qt widget tests."""
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication(sys.argv)
+    yield app
+
+
+@pytest.fixture
+def app_facade(tmp_path):
+    """Create a test AppFacade with temporary database."""
+    db_path = str(tmp_path / "test_reset.db")
+    facade = AppFacade(db_path)
+    yield facade
+    # Cleanup happens on __del__
+
+
+@pytest.fixture
+def tools_tab(qapp, app_facade):
+    """Create ToolsTab with test facade."""
+    tab = ToolsTab(app_facade)
+    yield tab
+    # No explicit cleanup needed
+
+
+class TestResetFlowSmoke:
+    """Headless smoke tests for reset database workflow."""
+    
+    def test_reset_dialog_construction(self, qapp):
+        """ResetDialog can be constructed without exceptions."""
+        table_counts = {
+            'users': 5,
+            'sites': 3,
+            'purchases': 100
+        }
+        
+        try:
+            dialog = ResetDialog(table_counts, parent=None)
+            dialog.close()
+        except Exception as e:
+            pytest.fail(f"ResetDialog construction failed: {e}")
+    
+    def test_reset_dialog_has_required_api(self, qapp):
+        """ResetDialog has all required methods for reset flow."""
+        table_counts = {'purchases': 10}
+        dialog = ResetDialog(table_counts, parent=None)
+        
+        # API contract: Tools tab expects these methods
+        assert hasattr(dialog, 'should_preserve_setup'), \
+            "ResetDialog missing should_preserve_setup() (Issue #18)"
+        assert callable(dialog.should_preserve_setup), \
+            "should_preserve_setup must be callable"
+        
+        # Should not raise AttributeError
+        try:
+            preserve = dialog.should_preserve_setup()
+            assert isinstance(preserve, bool)
+        except AttributeError as e:
+            pytest.fail(f"ResetDialog API broken: {e}")
+        finally:
+            dialog.close()
+    
+    def test_reset_dialog_button_state_no_exceptions(self, qapp):
+        """ResetDialog._update_button_state() does not raise exceptions."""
+        table_counts = {'purchases': 10}
+        dialog = ResetDialog(table_counts, parent=None)
+        
+        try:
+            # Should not raise AttributeError about _is_updating_size or similar
+            dialog._update_button_state()
+        except AttributeError as e:
+            pytest.fail(f"ResetDialog._update_button_state() raised AttributeError: {e}")
+        finally:
+            dialog.close()
+    
+    def test_tools_tab_can_construct_reset_dialog(self, tools_tab):
+        """Tools tab can construct ResetDialog with table counts."""
+        from services.tools.reset_service import ResetService
+        
+        # Get table counts like the real flow does
+        reset_service = ResetService(tools_tab.facade.db)
+        table_counts = reset_service.get_table_counts()
+        
+        # Verify we can construct the dialog (doesn't require exec())
+        try:
+            from ui.tools_dialogs import ResetDialog
+            dialog = ResetDialog(table_counts, tools_tab)
+            
+            # Verify API exists
+            assert hasattr(dialog, 'should_preserve_setup')
+            preserve = dialog.should_preserve_setup()
+            assert isinstance(preserve, bool)
+            
+            dialog.close()
+        except AttributeError as e:
+            pytest.fail(f"Reset dialog API broken: {e}")
+    
+    def test_tools_tab_reset_service_accessible(self, tools_tab):
+        """Tools tab can access ResetService without exceptions."""
+        from services.tools.reset_service import ResetService
+        
+        try:
+            reset_service = ResetService(tools_tab.facade.db)
+            table_counts = reset_service.get_table_counts()
+            assert isinstance(table_counts, dict)
+        except Exception as e:
+            pytest.fail(f"ResetService instantiation failed: {e}")
+    
+    def test_reset_dialog_confirmation_text_updates_button(self, qapp):
+        """Typing DELETE in confirmation field enables button (when checkbox checked)."""
+        table_counts = {'purchases': 10}
+        dialog = ResetDialog(table_counts, parent=None)
+        
+        try:
+            # Enable checkbox
+            dialog.confirm_checkbox.setChecked(True)
+            
+            # Type DELETE
+            dialog.type_confirm_input.setText("DELETE")
+            
+            # Trigger update (happens automatically via signal, but we call manually)
+            dialog._update_button_state()
+            
+            # Button should be enabled now
+            assert dialog.reset_btn.isEnabled(), \
+                "Reset button should enable when checkbox + DELETE text are satisfied"
+        finally:
+            dialog.close()
+
+
+class TestResetDialogInvariants:
+    """Test invariants that prevent copy/paste regressions from other dialogs."""
+    
+    def test_no_restore_attributes_in_reset_dialog(self, qapp):
+        """ResetDialog should not reference RestoreDialog-specific attributes."""
+        table_counts = {'purchases': 10}
+        dialog = ResetDialog(table_counts, parent=None)
+        
+        try:
+            # Should NOT have restore-only attributes
+            restore_only_attrs = [
+                '_is_updating_size',  # RestoreDialog sizing state
+                'restore_mode_group',  # RestoreDialog mode selector
+                'backup_file_path',   # RestoreDialog file picker
+            ]
+            
+            for attr in restore_only_attrs:
+                assert not hasattr(dialog, attr), \
+                    f"ResetDialog should not have RestoreDialog attribute: {attr}"
+        finally:
+            dialog.close()
+    
+    def test_reset_dialog_has_reset_specific_widgets(self, qapp):
+        """ResetDialog should have its own specific widgets."""
+        table_counts = {'purchases': 10}
+        dialog = ResetDialog(table_counts, parent=None)
+        
+        try:
+            # Reset-specific widgets
+            assert hasattr(dialog, 'preserve_setup_checkbox')
+            assert hasattr(dialog, 'full_reset_warning')
+            assert hasattr(dialog, 'confirm_checkbox')
+            assert hasattr(dialog, 'type_confirm_input')
+            assert hasattr(dialog, 'reset_btn')
+        finally:
+            dialog.close()

--- a/tests/unit/test_reset_dialog.py
+++ b/tests/unit/test_reset_dialog.py
@@ -1,0 +1,221 @@
+"""
+Unit tests for ResetDialog
+
+Tests the button gating logic and API contract to prevent regressions
+observed in Issue #18.
+"""
+
+import pytest
+import sys
+from unittest.mock import Mock, patch
+from PySide6.QtWidgets import QApplication
+from PySide6.QtCore import Qt
+
+from ui.tools_dialogs import ResetDialog
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    """Create QApplication for Qt widget tests."""
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication(sys.argv)
+    yield app
+
+
+@pytest.fixture
+def dialog(qapp):
+    """Create ResetDialog with sample table counts."""
+    table_counts = {
+        'users': 5,
+        'sites': 3,
+        'cards': 10,
+        'redemption_methods': 4,
+        'game_types': 8,
+        'games': 20,
+        'purchases': 100,
+        'redemptions': 50,
+        'game_sessions': 75,
+        'daily_sessions': 30
+    }
+    dlg = ResetDialog(table_counts, parent=None)
+    yield dlg
+    dlg.close()
+
+
+class TestResetButtonGating:
+    """Test reset button enable logic (Issue #18 regression prevention)."""
+    
+    def test_button_disabled_by_default(self, dialog):
+        """Reset button should be disabled on dialog open."""
+        assert not dialog.reset_btn.isEnabled()
+    
+    def test_button_disabled_with_only_checkbox(self, dialog):
+        """Checkbox alone should not enable button."""
+        dialog.confirm_checkbox.setChecked(True)
+        # Trigger update
+        dialog._update_button_state()
+        assert not dialog.reset_btn.isEnabled()
+    
+    def test_button_disabled_with_only_text(self, dialog):
+        """Text 'DELETE' alone should not enable button."""
+        dialog.type_confirm_input.setText("DELETE")
+        # Trigger update
+        dialog._update_button_state()
+        assert not dialog.reset_btn.isEnabled()
+    
+    def test_button_enabled_with_both_confirmations(self, dialog):
+        """Button should enable when checkbox is checked AND text is 'DELETE'."""
+        dialog.confirm_checkbox.setChecked(True)
+        dialog.type_confirm_input.setText("DELETE")
+        # Trigger update
+        dialog._update_button_state()
+        assert dialog.reset_btn.isEnabled()
+    
+    def test_button_case_insensitive_delete(self, dialog):
+        """Text confirmation should be case-insensitive."""
+        dialog.confirm_checkbox.setChecked(True)
+        
+        # Test lowercase
+        dialog.type_confirm_input.setText("delete")
+        dialog._update_button_state()
+        assert dialog.reset_btn.isEnabled()
+        
+        # Test mixed case
+        dialog.type_confirm_input.setText("DeLeTe")
+        dialog._update_button_state()
+        assert dialog.reset_btn.isEnabled()
+    
+    def test_button_handles_whitespace(self, dialog):
+        """Text confirmation should ignore leading/trailing whitespace."""
+        dialog.confirm_checkbox.setChecked(True)
+        
+        dialog.type_confirm_input.setText("  DELETE  ")
+        dialog._update_button_state()
+        assert dialog.reset_btn.isEnabled()
+        
+        dialog.type_confirm_input.setText("\tDELETE\n")
+        dialog._update_button_state()
+        assert dialog.reset_btn.isEnabled()
+    
+    def test_button_rejects_wrong_text(self, dialog):
+        """Button should remain disabled if text is not 'DELETE'."""
+        dialog.confirm_checkbox.setChecked(True)
+        
+        # Wrong word
+        dialog.type_confirm_input.setText("REMOVE")
+        dialog._update_button_state()
+        assert not dialog.reset_btn.isEnabled()
+        
+        # Partial match
+        dialog.type_confirm_input.setText("DEL")
+        dialog._update_button_state()
+        assert not dialog.reset_btn.isEnabled()
+        
+        # Extra chars
+        dialog.type_confirm_input.setText("DELETE NOW")
+        dialog._update_button_state()
+        assert not dialog.reset_btn.isEnabled()
+    
+    def test_button_disabled_when_unchecking(self, dialog):
+        """Button should disable if checkbox is unchecked after being enabled."""
+        # First enable
+        dialog.confirm_checkbox.setChecked(True)
+        dialog.type_confirm_input.setText("DELETE")
+        dialog._update_button_state()
+        assert dialog.reset_btn.isEnabled()
+        
+        # Then uncheck
+        dialog.confirm_checkbox.setChecked(False)
+        dialog._update_button_state()
+        assert not dialog.reset_btn.isEnabled()
+    
+    def test_button_disabled_when_clearing_text(self, dialog):
+        """Button should disable if text is cleared after being enabled."""
+        # First enable
+        dialog.confirm_checkbox.setChecked(True)
+        dialog.type_confirm_input.setText("DELETE")
+        dialog._update_button_state()
+        assert dialog.reset_btn.isEnabled()
+        
+        # Then clear text
+        dialog.type_confirm_input.setText("")
+        dialog._update_button_state()
+        assert not dialog.reset_btn.isEnabled()
+
+
+class TestShouldPreserveSetupAPI:
+    """Test the should_preserve_setup() API (Issue #18 regression prevention)."""
+    
+    def test_api_exists(self, dialog):
+        """Dialog must have should_preserve_setup() method."""
+        assert hasattr(dialog, 'should_preserve_setup')
+        assert callable(dialog.should_preserve_setup)
+    
+    def test_returns_true_when_checked(self, dialog):
+        """should_preserve_setup() returns True when checkbox is checked."""
+        dialog.preserve_setup_checkbox.setChecked(True)
+        assert dialog.should_preserve_setup() is True
+    
+    def test_returns_false_when_unchecked(self, dialog):
+        """should_preserve_setup() returns False when checkbox is unchecked."""
+        dialog.preserve_setup_checkbox.setChecked(False)
+        assert dialog.should_preserve_setup() is False
+    
+    def test_default_state_is_checked(self, dialog):
+        """Preserve setup checkbox should be checked by default (safer default)."""
+        # Check the actual checkbox state
+        assert dialog.preserve_setup_checkbox.isChecked()
+        assert dialog.should_preserve_setup() is True
+    
+    def test_api_reflects_checkbox_state_changes(self, dialog):
+        """API should always reflect current checkbox state."""
+        # Start unchecked
+        dialog.preserve_setup_checkbox.setChecked(False)
+        assert dialog.should_preserve_setup() is False
+        
+        # Toggle on
+        dialog.preserve_setup_checkbox.setChecked(True)
+        assert dialog.should_preserve_setup() is True
+        
+        # Toggle off
+        dialog.preserve_setup_checkbox.setChecked(False)
+        assert dialog.should_preserve_setup() is False
+        
+        # Toggle on again
+        dialog.preserve_setup_checkbox.setChecked(True)
+        assert dialog.should_preserve_setup() is True
+
+
+class TestDialogInvariants:
+    """Test that dialog invariants hold (prevent restore-dialog bleed)."""
+    
+    def test_no_restore_sizing_logic_in_update_button_state(self, dialog):
+        """_update_button_state should not reference restore-only attributes."""
+        # This test prevents regression where restore dialog's _is_updating_size
+        # logic was copied into reset dialog
+        
+        # Call should not raise AttributeError
+        try:
+            dialog._update_button_state()
+        except AttributeError as e:
+            if '_is_updating_size' in str(e):
+                pytest.fail(f"ResetDialog._update_button_state references restore-only attribute: {e}")
+            raise
+    
+    def test_dialog_has_required_widgets(self, dialog):
+        """Dialog should have all required widgets."""
+        assert hasattr(dialog, 'confirm_checkbox')
+        assert hasattr(dialog, 'type_confirm_input')
+        assert hasattr(dialog, 'reset_btn')
+        assert hasattr(dialog, 'preserve_setup_checkbox')
+    
+    def test_table_summary_displays(self, dialog):
+        """Dialog should display table count summary."""
+        # The dialog should have formatted table info
+        # Check via the window text/title or verify widgets exist
+        assert dialog.windowTitle() == "Reset Database"
+        
+        # The dialog layout should contain labels
+        # (summary_label is a local var, not stored on self)
+        assert dialog.layout() is not None


### PR DESCRIPTION
## Summary
Adds comprehensive automated tests for ResetDialog to prevent future regressions (Issue #18).

The actual bugs were already fixed in PR #17, but Issue #18 requested tests to lock the API and prevent copy/paste regressions from other dialogs.

## Changes
- **Unit tests** ():
  - 9 tests for button gating logic (checkbox + DELETE confirmation)
  - 5 tests for `should_preserve_setup()` API contract
  - 3 tests for dialog invariants (no restore-only attributes)

- **Integration smoke tests** ():
  - Headless dialog construction and API validation
  - Tools tab can access ResetService and construct dialog
  - Dialog confirmation flow works without exceptions
  - Invariants verified (no restore-dialog attribute bleed)

## Test Coverage
- All 496 tests pass (100% pass rate)
- Tests explicitly guard against the AttributeErrors reported in Issue #18:
  - Missing `_is_updating_size` (restore-dialog sizing logic)
  - Missing `should_preserve_setup()` API method

## Acceptance Criteria (Issue #18)
- [x] Unit tests for ResetDialog button enable logic (checkbox + DELETE)
- [x] Unit tests for should_preserve_setup() API
- [x] Integration/headless smoke tests for reset flow
- [x] All tests pass

Fixes #18