### PR TITLE
Default date filter presets per tab

### DIFF
--- a/docs/PROJECT_SPEC.md
+++ b/docs/PROJECT_SPEC.md
@@ -110,6 +110,14 @@ UI rules:
 - Prefer View-first dialog flows; edits are deliberate.
 - Bulk actions and destructive actions require confirmation.
 
+### Default Date Filter Presets
+
+Many primary tabs use `DateFilterWidget` as the first-level time scoping control.
+
+Default presets (on initial tab load):
+- Purchases / Redemptions / Game Sessions / Daily Sessions / Realized / Expenses: **current calendar year**
+- Unrealized: **all time** (implemented as 2000-01-01 → today)
+
 ### 5.1 Spreadsheet UX (Issue #14, Phase 1)
 
 **Purpose:**
@@ -228,6 +236,7 @@ Tools are accessible via Setup → Tools sub-tab and provide "production readine
 - `DatabaseResetWorker`: Resets database in background thread with own DB connection
 - All workers use `QRunnable` pattern with `WorkerSignals` for progress/completion/error
 - Workers receive `db_path` (not connection object) to create thread-local connections
+- Workers must close their thread-local database connections in a `finally:` block to avoid leaked resources and test warning noise
 - AppFacade provides worker factory methods with exclusive lock management
 
 **Exclusive Operation Lock:**

--- a/docs/status/CHANGELOG.md
+++ b/docs/status/CHANGELOG.md
@@ -9,6 +9,39 @@ Rules:
 
 ---
 
+## 2026-02-04
+
+```yaml
+id: 2026-02-04-01
+type: feature
+areas: [ui, tests, cleanup]
+summary: "Default date filter presets per tab + close SQLite resources in workers/tests."
+files_changed:
+  - ui/tabs/purchases_tab.py
+  - ui/tabs/redemptions_tab.py
+  - ui/tabs/game_sessions_tab.py
+  - ui/tabs/expenses_tab.py
+  - ui/tabs/unrealized_tab.py
+  - ui/tools_workers.py
+  - tests/integration/test_default_date_filter_presets.py
+  - tests/integration/test_issue_20_recalc_completion.py
+  - tests/integration/test_issue_9_global_refresh.py
+  - tests/integration/test_reset_database_flow.py
+  - tests/integration/test_settings_dialog_smoke.py
+  - tests/integration/test_csv_import_integration.py
+  - tests/integration/test_csv_import_user_scoped_methods.py
+  - tests/unit/test_database_write_blocking.py
+  - tests/unit/test_tools_workers.py
+issue: null
+```
+
+Notes:
+- **UX:** Tabs now start with consistent default date ranges:
+  - Purchases / Redemptions / Game Sessions / Expenses: current calendar year
+  - Unrealized: all time (2000-01-01 → today)
+- **Regression coverage:** Added a headless integration test asserting these tab defaults.
+- **Test hygiene:** Ensured worker and test-created SQLite connections/temp files are closed deterministically to avoid `ResourceWarning` noise under newer Python versions.
+
 ## 2026-02-03
 
 ```yaml

--- a/tests/integration/test_csv_import_integration.py
+++ b/tests/integration/test_csv_import_integration.py
@@ -132,8 +132,13 @@ def import_service(db):
 def temp_csv():
     """Create temporary CSV file."""
     temp_file = tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.csv', newline='')
-    yield temp_file.name
-    Path(temp_file.name).unlink(missing_ok=True)
+    try:
+        temp_path = temp_file.name
+    finally:
+        temp_file.close()
+
+    yield temp_path
+    Path(temp_path).unlink(missing_ok=True)
 
 
 class TestCSVImportWorkflow:

--- a/tests/integration/test_csv_import_user_scoped_methods.py
+++ b/tests/integration/test_csv_import_user_scoped_methods.py
@@ -135,8 +135,13 @@ def import_service(db):
 def temp_csv():
     """Create temporary CSV file."""
     temp_file = tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.csv', newline='')
-    yield temp_file.name
-    Path(temp_file.name).unlink(missing_ok=True)
+    try:
+        temp_path = temp_file.name
+    finally:
+        temp_file.close()
+
+    yield temp_path
+    Path(temp_path).unlink(missing_ok=True)
 
 
 class TestUserScopedMethodResolution:

--- a/tests/integration/test_default_date_filter_presets.py
+++ b/tests/integration/test_default_date_filter_presets.py
@@ -1,0 +1,50 @@
+"""Regression: tabs should start with the correct default date filter presets."""
+
+from datetime import date
+
+import pytest
+
+from app_facade import AppFacade
+from ui.tabs.purchases_tab import PurchasesTab
+from ui.tabs.redemptions_tab import RedemptionsTab
+from ui.tabs.game_sessions_tab import GameSessionsTab
+from ui.tabs.daily_sessions_tab import DailySessionsTab
+from ui.tabs.unrealized_tab import UnrealizedTab
+from ui.tabs.realized_tab import RealizedTab
+from ui.tabs.expenses_tab import ExpensesTab
+
+
+@pytest.fixture
+def app_facade():
+    facade = AppFacade(":memory:")
+    yield facade
+    facade.db.close()
+
+
+def _assert_date_filter_widget(widget, expected_start: date, expected_end: date):
+    assert widget.start_date.text() == expected_start.strftime("%m/%d/%y")
+    assert widget.end_date.text() == expected_end.strftime("%m/%d/%y")
+
+
+@pytest.mark.parametrize(
+    "tab_factory,attr_name,expected_start_factory",
+    [
+        (lambda facade: PurchasesTab(facade), "date_filter", lambda today: date(today.year, 1, 1)),
+        (lambda facade: RedemptionsTab(facade), "date_filter", lambda today: date(today.year, 1, 1)),
+        (lambda facade: GameSessionsTab(facade), "date_filter", lambda today: date(today.year, 1, 1)),
+        (lambda facade: DailySessionsTab(facade), "date_filter_widget", lambda today: date(today.year, 1, 1)),
+        (lambda facade: RealizedTab(facade), "date_filter_widget", lambda today: date(today.year, 1, 1)),
+        (lambda facade: ExpensesTab(facade), "date_filter", lambda today: date(today.year, 1, 1)),
+        (lambda facade: UnrealizedTab(facade), "date_filter", lambda _today: date(2000, 1, 1)),
+    ],
+)
+def test_tab_date_filter_defaults(qtbot, app_facade, tab_factory, attr_name, expected_start_factory):
+    tab = tab_factory(app_facade)
+    qtbot.addWidget(tab)
+
+    today = date.today()
+    expected_start = expected_start_factory(today)
+    expected_end = today
+
+    widget = getattr(tab, attr_name)
+    _assert_date_filter_widget(widget, expected_start, expected_end)

--- a/tests/integration/test_issue_20_recalc_completion.py
+++ b/tests/integration/test_issue_20_recalc_completion.py
@@ -66,8 +66,11 @@ class TestRecalculationWorkerOperationPropagation:
         """Create temporary database for worker tests"""
         db_file = tmp_path / "test.db"
         db = DatabaseManager(str(db_file))
-        # Minimal setup for worker to run
-        return str(db_file)
+        try:
+            # Minimal setup for worker to run
+            return str(db_file)
+        finally:
+            db.close()
     
     def test_worker_all_operation_includes_operation_in_result(self, db_path):
         """Worker with operation='all' should produce result with operation='all'"""
@@ -86,9 +89,12 @@ class TestRecalculationWorkerOperationPropagation:
         """Worker with operation='pair' should produce result with operation='pair'"""
         # Setup minimal user/site data
         db = DatabaseManager(db_path)
-        db._connection.execute("INSERT INTO users (id, name) VALUES (1, 'Test')")
-        db._connection.execute("INSERT INTO sites (id, name) VALUES (1, 'Site')")
-        db._connection.commit()
+        try:
+            db._connection.execute("INSERT INTO users (id, name) VALUES (1, 'Test')")
+            db._connection.execute("INSERT INTO sites (id, name) VALUES (1, 'Site')")
+            db._connection.commit()
+        finally:
+            db.close()
         
         worker = RecalculationWorker(
             db_path,
@@ -121,7 +127,8 @@ class TestToolsTabCompletionHandling:
         db_file = tmp_path / "test.db"
         # AppFacade expects db_path string, not DatabaseManager instance
         facade = AppFacade(str(db_file))
-        return facade
+        yield facade
+        facade.db.close()
     
     def test_on_recalculation_finished_with_operation_field(self, qapp, facade):
         """_on_recalculation_finished should handle result.operation correctly"""
@@ -235,7 +242,8 @@ class TestGamesTabAutoRefresh:
         db_file = tmp_path / "test.db"
         # AppFacade expects db_path string, not DatabaseManager instance
         facade = AppFacade(str(db_file))
-        return facade
+        yield facade
+        facade.db.close()
     
     def test_games_tab_has_refresh_data_method(self, qapp, facade):
         """Games tab should implement refresh_data() for event-driven refresh"""

--- a/tests/integration/test_issue_9_global_refresh.py
+++ b/tests/integration/test_issue_9_global_refresh.py
@@ -25,7 +25,7 @@ def app_facade(tmp_path):
     db_path = str(tmp_path / "test.db")
     facade = AppFacade(db_path)
     yield facade
-    # AppFacade doesn't have close method - DB closes on __del__
+    facade.db.close()
 
 
 @pytest.fixture

--- a/tests/integration/test_reset_database_flow.py
+++ b/tests/integration/test_reset_database_flow.py
@@ -32,7 +32,7 @@ def app_facade(tmp_path):
     db_path = str(tmp_path / "test_reset.db")
     facade = AppFacade(db_path)
     yield facade
-    # Cleanup happens on __del__
+    facade.db.close()
 
 
 @pytest.fixture

--- a/tests/integration/test_settings_dialog_smoke.py
+++ b/tests/integration/test_settings_dialog_smoke.py
@@ -70,3 +70,4 @@ def test_settings_gear_and_dialog_open_close(qtbot, temp_db_path):
     
     # Cleanup
     window.close()
+    facade.db.close()

--- a/tests/unit/test_database_write_blocking.py
+++ b/tests/unit/test_database_write_blocking.py
@@ -18,6 +18,8 @@ def test_writes_are_blocked_when_enabled():
     with pytest.raises(DatabaseWritesBlockedError):
         db.execute_no_commit("UPDATE users SET name = name")
 
+    db.close()
+
 
 def test_writes_work_again_after_unblocked():
     db = DatabaseManager(":memory:")
@@ -32,3 +34,5 @@ def test_writes_work_again_after_unblocked():
     row = db.fetch_one("SELECT name FROM users WHERE name = ?", ("ok",))
     assert row is not None
     assert row["name"] == "ok"
+
+    db.close()

--- a/tests/unit/test_tools_workers.py
+++ b/tests/unit/test_tools_workers.py
@@ -28,6 +28,8 @@ class TestExclusiveOperationLock:
         
         facade.release_tools_lock()
         assert facade.is_tools_operation_active() is False
+
+        facade.db.close()
     
     def test_cannot_acquire_lock_when_active(self):
         """Lock cannot be acquired when operation is already active."""
@@ -45,6 +47,8 @@ class TestExclusiveOperationLock:
         assert facade.acquire_tools_lock() is True
         
         facade.release_tools_lock()
+
+        facade.db.close()
     
     def test_lock_is_thread_safe(self):
         """Lock operations are thread-safe."""
@@ -74,6 +78,8 @@ class TestExclusiveOperationLock:
         assert True in results  # At least one succeeded
         assert False in results  # At least one failed
 
+        facade.db.close()
+
 
 class TestDatabaseBackupWorker:
     """Test DatabaseBackupWorker creates read-only connection."""
@@ -86,6 +92,7 @@ class TestDatabaseBackupWorker:
         # Create a simple database
         from repositories.database import DatabaseManager
         db = DatabaseManager(db_path)
+        db.close()
         
         # Create worker with db_path (not db_connection)
         worker = DatabaseBackupWorker(db_path, backup_path, include_audit_log=True)
@@ -177,6 +184,8 @@ class TestAppFacadeWorkerCreation:
         assert worker.db_path == facade.db_path
         assert worker.backup_path == backup_path
         assert worker.include_audit_log is False
+
+        facade.db.close()
     
     def test_create_restore_worker(self):
         """Facade creates restore worker with correct parameters."""
@@ -189,6 +198,8 @@ class TestAppFacadeWorkerCreation:
         assert worker.db_path == facade.db_path
         assert worker.backup_path == backup_path
         assert worker.restore_mode == RestoreMode.MERGE_ALL
+
+        facade.db.close()
     
     def test_create_reset_worker(self):
         """Facade creates reset worker with correct parameters."""
@@ -200,6 +211,8 @@ class TestAppFacadeWorkerCreation:
         assert worker.db_path == facade.db_path
         assert worker.keep_setup_data is True
         assert worker.keep_audit_log is False
+
+        facade.db.close()
 
 
 class TestWorkerIndependence:

--- a/ui/tabs/expenses_tab.py
+++ b/ui/tabs/expenses_tab.py
@@ -92,7 +92,11 @@ class ExpensesTab(QtWidgets.QWidget):
         info.setStyleSheet("color: #666; font-style: italic;")
         layout.addWidget(info)
 
-        self.date_filter = DateFilterWidget()
+        year_start = date(date.today().year, 1, 1)
+        self.date_filter = DateFilterWidget(
+            default_start=year_start,
+            default_end=date.today(),
+        )
         self.date_filter.filter_changed.connect(self.refresh_data)
         layout.addWidget(self.date_filter)
 

--- a/ui/tabs/game_sessions_tab.py
+++ b/ui/tabs/game_sessions_tab.py
@@ -103,7 +103,11 @@ class GameSessionsTab(QWidget):
         info.setStyleSheet("color: #666; font-style: italic;")
         layout.addWidget(info)
 
-        self.date_filter = DateFilterWidget()
+        year_start = date(date.today().year, 1, 1)
+        self.date_filter = DateFilterWidget(
+            default_start=year_start,
+            default_end=date.today(),
+        )
         self.date_filter.filter_changed.connect(self.apply_filters)
         layout.addWidget(self.date_filter)
 

--- a/ui/tabs/purchases_tab.py
+++ b/ui/tabs/purchases_tab.py
@@ -75,7 +75,11 @@ class PurchasesTab(QtWidgets.QWidget):
         layout.addWidget(info)
         
         # Date Filter
-        self.date_filter = DateFilterWidget()
+        year_start = date(date.today().year, 1, 1)
+        self.date_filter = DateFilterWidget(
+            default_start=year_start,
+            default_end=date.today(),
+        )
         self.date_filter.filter_changed.connect(self.refresh_data)
         layout.addWidget(self.date_filter)
         

--- a/ui/tabs/redemptions_tab.py
+++ b/ui/tabs/redemptions_tab.py
@@ -56,7 +56,11 @@ class RedemptionsTab(QtWidgets.QWidget):
         layout.addWidget(info)
         
         # Date Filter
-        self.date_filter = DateFilterWidget()
+        year_start = date(date.today().year, 1, 1)
+        self.date_filter = DateFilterWidget(
+            default_start=year_start,
+            default_end=date.today(),
+        )
         self.date_filter.filter_changed.connect(self.refresh_data)
         layout.addWidget(self.date_filter)
         

--- a/ui/tabs/unrealized_tab.py
+++ b/ui/tabs/unrealized_tab.py
@@ -57,7 +57,10 @@ class UnrealizedTab(QtWidgets.QWidget):
         layout.addWidget(info)
         
         # Date Filter
-        self.date_filter = DateFilterWidget()
+        self.date_filter = DateFilterWidget(
+            default_start=date(2000, 1, 1),
+            default_end=date.today(),
+        )
         self.date_filter.filter_changed.connect(self.refresh_data)
         layout.addWidget(self.date_filter)
         

--- a/ui/tools_workers.py
+++ b/ui/tools_workers.py
@@ -60,6 +60,7 @@ class RecalculationWorker(QRunnable):
     @Slot()
     def run(self):
         """Execute the recalculation operation"""
+        db = None
         try:
             # Create database connection in this thread (SQLite thread safety)
             from repositories.database import DatabaseManager
@@ -115,6 +116,12 @@ class RecalculationWorker(QRunnable):
         except Exception as e:
             error_msg = f"{type(e).__name__}: {str(e)}\n\n{traceback.format_exc()}"
             self.signals.error.emit(error_msg)
+        finally:
+            if db is not None:
+                try:
+                    db.close()
+                except Exception:
+                    pass
 
 
 class CSVImportWorker(QRunnable):


### PR DESCRIPTION
Summary:
- Sets default date filter ranges per tab (current-year for Purchases/Redemptions/Game Sessions/Expenses; all-time for Unrealized).
- Adds headless regression test covering tab defaults.
- Closes worker/test SQLite resources deterministically to eliminate leaked-connection ResourceWarnings.

Test Plan:
- pytest -q

Pitfalls / Follow-ups:
- Remaining warnings include SQLite adapter DeprecationWarnings + one PytestCollectionWarning; not addressed here.