### PR TITLE
Fix redemption deletion impact check

### DIFF
--- a/docs/status/CHANGELOG.md
+++ b/docs/status/CHANGELOG.md
@@ -40,6 +40,20 @@ Notes:
 - **Problem:** Clicking "Close Position" could raise an `AttributeError` because the UI referenced `pos.current_sc` but the model uses `total_sc`.
 - **Fix:** Use `pos.total_sc` for the close-balance confirmation and close call.
 
+```yaml
+id: 2026-02-05-03
+type: fix
+areas: [services, ui, tests]
+summary: "Fix redemption deletion impact check on DBs without fifo_allocations"
+files_changed:
+  - services/redemption_service.py
+  - tests/unit/test_redemption_deletion_impact.py
+```
+
+Notes:
+- **Problem:** Deleting a redemption could log `no such table: fifo_allocations` while checking deletion impact.
+- **Fix:** `RedemptionService.get_deletion_impact()` now queries `redemption_allocations` (the real FIFO allocation table).
+
 ---
 
 ## 2026-02-04

--- a/services/redemption_service.py
+++ b/services/redemption_service.py
@@ -331,10 +331,16 @@ class RedemptionService:
             return ""
 
         try:
-            # Check FIFO allocations
             cursor = self.db._connection.cursor()
+
+            # Check FIFO allocations (redemption_allocations)
             cursor.execute(
-                "SELECT COUNT(*) as count, SUM(amount_allocated) as total FROM fifo_allocations WHERE redemption_id = ?",
+                """
+                SELECT COUNT(*) as count,
+                       COALESCE(SUM(CAST(allocated_amount AS REAL)), 0) as total
+                FROM redemption_allocations
+                WHERE redemption_id = ?
+                """,
                 (redemption_id,),
             )
             alloc_result = cursor.fetchone()
@@ -347,9 +353,10 @@ class RedemptionService:
                 SELECT COUNT(*) as count
                 FROM game_sessions gs
                 WHERE EXISTS (
-                    SELECT 1 FROM fifo_allocations fa
-                    JOIN purchases p ON fa.purchase_id = p.id
-                    WHERE fa.redemption_id = ?
+                    SELECT 1
+                    FROM redemption_allocations ra
+                    JOIN purchases p ON ra.purchase_id = p.id
+                    WHERE ra.redemption_id = ?
                       AND p.user_id = gs.user_id AND p.site_id = gs.site_id
                       AND gs.session_date >= p.purchase_date
                       AND gs.end_date IS NOT NULL
@@ -366,6 +373,7 @@ class RedemptionService:
                     msg += f"{session_count} closed game session(s) may be affected.\n"
                 msg += "Deleting will recalculate all affected sessions."
                 return msg
+
             return ""
         except Exception as e:
             print(f"Error checking redemption deletion impact: {e}")

--- a/tests/unit/test_redemption_deletion_impact.py
+++ b/tests/unit/test_redemption_deletion_impact.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+
+def test_get_deletion_impact_empty_when_no_allocations(redemption_service, sample_user, sample_site):
+    redemption = redemption_service.create_redemption(
+        user_id=sample_user.id,
+        site_id=sample_site.id,
+        amount=Decimal("10.00"),
+        redemption_date=date(2026, 1, 15),
+        processed=True,
+        more_remaining=True,
+        apply_fifo=False,
+    )
+
+    impact = redemption_service.get_deletion_impact(redemption.id)
+    assert impact == ""
+
+
+def test_get_deletion_impact_mentions_allocations(redemption_service, purchase_service, sample_user, sample_site):
+    purchase_service.create_purchase(
+        user_id=sample_user.id,
+        site_id=sample_site.id,
+        amount=Decimal("100.00"),
+        purchase_date=date(2026, 1, 10),
+    )
+
+    # Full redemption consumes all remaining basis via FIFO, creating redemption_allocations
+    redemption = redemption_service.create_redemption(
+        user_id=sample_user.id,
+        site_id=sample_site.id,
+        amount=Decimal("0.00"),
+        redemption_date=date(2026, 1, 15),
+        processed=True,
+        more_remaining=False,
+        apply_fifo=True,
+        redemption_time="12:00:00",
+    )
+
+    impact = redemption_service.get_deletion_impact(redemption.id)
+    assert "FIFO allocation" in impact


### PR DESCRIPTION
Fixes error when checking deletion impact: was querying missing table fifo_allocations. Now uses redemption_allocations. Adds unit tests and changelog entry.