### PR TITLE
Game Sessions: End & Start New flow

### DIFF
--- a/docs/PROJECT_SPEC.md
+++ b/docs/PROJECT_SPEC.md
@@ -184,6 +184,11 @@ UI rules:
 - Prefer View-first dialog flows; edits are deliberate.
 - Bulk actions and destructive actions require confirmation.
 
+Game Sessions convenience:
+- Sezzions keeps **1 game per session** (accounting clarity), but provides a fast workflow to chain sessions across games:
+  - End Session dialog: **"End & Start New"**
+  - New Start Session dialog is prefilled with the ended session’s ending balances (same user/site); game selection is intentionally left blank.
+
 ### Default Date Filter Presets
 
 Many primary tabs use `DateFilterWidget` as the first-level time scoping control.

--- a/docs/status/CHANGELOG.md
+++ b/docs/status/CHANGELOG.md
@@ -12,6 +12,22 @@ Rules:
 ## 2026-02-05
 
 ```yaml
+id: 2026-02-05-05
+type: feature
+areas: [ui]
+summary: "Game Sessions: End & Start New convenience flow"
+files_changed:
+  - ui/tabs/game_sessions_tab.py
+  - tests/integration/test_switch_game_flow.py
+```
+
+Notes:
+- Adds a fast workflow to end an Active session and immediately start a new session with carried-forward starting balances.
+- End Session dialog now includes **"🎮 End & Start New"**.
+- The Start Session dialog is prefilled with same User/Site and starting balances equal to the ended session’s ending balances; game selection is intentionally left blank.
+- Validation: scenario-based pytest-qt integration tests cover happy path, cancel, and failure injection.
+
+```yaml
 id: 2026-02-05-04
 type: feature
 areas: [ui, facades, services]

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -1,6 +1,6 @@
 # Sezzions — TODO (Offline Mirror)
 
-Last updated: 2026-01-28
+Last updated: 2026-02-05
 
 Rules:
 - Primary work tracking lives in GitHub Issues.
@@ -14,6 +14,7 @@ Rules:
 ## Now
 
 
+- [ ] Add “🎮 End & Start New” flow (auto-carry balances; pick game; start new session)
 - [ ] Define 3–6 “golden scenario” accounting tests (basis + cashflow P/L + taxable P/L)
 - [ ] Reconcile Game Session taxable P/L algorithm vs current implementation
 - [ ] Confirm whether UI still fetches via repos (enforce UI→services only)

--- a/tests/integration/test_switch_game_flow.py
+++ b/tests/integration/test_switch_game_flow.py
@@ -1,0 +1,230 @@
+import os
+import tempfile
+from datetime import date
+from decimal import Decimal
+
+import pytest
+from PySide6.QtCore import QTimer, Qt
+from PySide6.QtWidgets import QApplication, QMessageBox
+
+from app_facade import AppFacade
+from ui.tabs.game_sessions_tab import EndSessionDialog, GameSessionsTab, StartSessionDialog
+
+
+@pytest.fixture
+def temp_db_path():
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    yield path
+    if os.path.exists(path):
+        os.unlink(path)
+
+
+def _stub_message_boxes(monkeypatch):
+    monkeypatch.setattr(QMessageBox, "information", lambda *args, **kwargs: None)
+    monkeypatch.setattr(QMessageBox, "warning", lambda *args, **kwargs: None)
+    monkeypatch.setattr(QMessageBox, "critical", lambda *args, **kwargs: None)
+    monkeypatch.setattr(QMessageBox, "question", lambda *args, **kwargs: QMessageBox.Yes)
+
+
+def _find_visible_dialog(dialog_type):
+    for widget in QApplication.topLevelWidgets():
+        if isinstance(widget, dialog_type) and widget.isVisible():
+            return widget
+    return None
+
+
+def test_end_and_start_new_game_prefills_and_creates_new_session(qtbot, temp_db_path, monkeypatch):
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    _stub_message_boxes(monkeypatch)
+
+    facade = AppFacade(temp_db_path)
+
+    user = facade.create_user("Test User")
+    site = facade.create_site("Test Site", "https://example.com", sc_rate=1.0)
+    gtype = facade.create_game_type("Slots")
+    old_game = facade.create_game("Old Game", gtype.id, rtp=96.0)
+    new_game = facade.create_game("New Game", gtype.id, rtp=96.0)
+
+    session = facade.create_game_session(
+        user_id=user.id,
+        site_id=site.id,
+        game_id=old_game.id,
+        session_date=date(2026, 2, 5),
+        starting_balance=Decimal("100.00"),
+        ending_balance=Decimal("0.00"),
+        starting_redeemable=Decimal("20.00"),
+        ending_redeemable=Decimal("0.00"),
+        purchases_during=Decimal("0.00"),
+        redemptions_during=Decimal("0.00"),
+        session_time="12:00:00",
+        notes="",
+        calculate_pl=False,
+    )
+
+    tab = GameSessionsTab(facade)
+    qtbot.addWidget(tab)
+
+    def drive_end_dialog():
+        dlg = _find_visible_dialog(EndSessionDialog)
+        if dlg is None:
+            QTimer.singleShot(10, drive_end_dialog)
+            return
+        dlg.end_total_edit.setText("150.00")
+        dlg.end_redeem_edit.setText("50.00")
+        qtbot.mouseClick(dlg.end_and_start_btn, Qt.LeftButton)
+
+    def drive_start_dialog():
+        dlg = _find_visible_dialog(StartSessionDialog)
+        if dlg is None:
+            QTimer.singleShot(10, drive_start_dialog)
+            return
+
+        assert dlg.user_combo.currentText() == "Test User"
+        assert dlg.site_combo.currentText() == "Test Site"
+        assert Decimal(dlg.start_total_edit.text()) == Decimal("150.00")
+        assert Decimal(dlg.start_redeem_edit.text()) == Decimal("50.00")
+
+        dlg.game_type_combo.setCurrentText("Slots")
+        dlg.game_name_combo.setCurrentText(new_game.name)
+        qtbot.mouseClick(dlg.save_btn, Qt.LeftButton)
+
+    QTimer.singleShot(0, drive_end_dialog)
+    QTimer.singleShot(0, drive_start_dialog)
+
+    tab._end_session_by_id(session.id)
+
+    sessions = facade.get_all_game_sessions(user_id=user.id, site_id=site.id)
+    assert len(sessions) == 2
+
+    closed = [s for s in sessions if (s.status or "Active") == "Closed"]
+    active = [s for s in sessions if (s.status or "Active") != "Closed"]
+    assert len(closed) == 1
+    assert len(active) == 1
+
+    closed_session = closed[0]
+    new_session = active[0]
+
+    assert closed_session.ending_balance == Decimal("150.00")
+    assert closed_session.ending_redeemable == Decimal("50.00")
+
+    assert new_session.starting_balance == Decimal("150.00")
+    assert new_session.starting_redeemable == Decimal("50.00")
+    assert new_session.game_id == new_game.id
+
+    facade.db.close()
+
+
+def test_end_and_start_new_game_cancel_start_creates_no_new_session(qtbot, temp_db_path, monkeypatch):
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    _stub_message_boxes(monkeypatch)
+
+    facade = AppFacade(temp_db_path)
+
+    user = facade.create_user("Test User")
+    site = facade.create_site("Test Site", "https://example.com", sc_rate=1.0)
+    gtype = facade.create_game_type("Slots")
+    game = facade.create_game("Old Game", gtype.id, rtp=96.0)
+
+    session = facade.create_game_session(
+        user_id=user.id,
+        site_id=site.id,
+        game_id=game.id,
+        session_date=date(2026, 2, 5),
+        starting_balance=Decimal("100.00"),
+        ending_balance=Decimal("0.00"),
+        starting_redeemable=Decimal("20.00"),
+        ending_redeemable=Decimal("0.00"),
+        purchases_during=Decimal("0.00"),
+        redemptions_during=Decimal("0.00"),
+        session_time="12:00:00",
+        notes="",
+        calculate_pl=False,
+    )
+
+    tab = GameSessionsTab(facade)
+    qtbot.addWidget(tab)
+
+    def drive_end_dialog():
+        dlg = _find_visible_dialog(EndSessionDialog)
+        if dlg is None:
+            QTimer.singleShot(10, drive_end_dialog)
+            return
+        dlg.end_total_edit.setText("150.00")
+        dlg.end_redeem_edit.setText("50.00")
+        qtbot.mouseClick(dlg.end_and_start_btn, Qt.LeftButton)
+
+    def drive_start_dialog_cancel():
+        dlg = _find_visible_dialog(StartSessionDialog)
+        if dlg is None:
+            QTimer.singleShot(10, drive_start_dialog_cancel)
+            return
+        qtbot.mouseClick(dlg.cancel_btn, Qt.LeftButton)
+
+    QTimer.singleShot(0, drive_end_dialog)
+    QTimer.singleShot(0, drive_start_dialog_cancel)
+
+    tab._end_session_by_id(session.id)
+
+    sessions = facade.get_all_game_sessions(user_id=user.id, site_id=site.id)
+    assert len(sessions) == 1
+    assert (sessions[0].status or "Active") == "Closed"
+    assert sessions[0].ending_balance == Decimal("150.00")
+
+    facade.db.close()
+
+
+def test_end_and_start_new_game_failure_injection_does_not_start_next(qtbot, temp_db_path, monkeypatch):
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    _stub_message_boxes(monkeypatch)
+
+    facade = AppFacade(temp_db_path)
+
+    user = facade.create_user("Test User")
+    site = facade.create_site("Test Site", "https://example.com", sc_rate=1.0)
+    gtype = facade.create_game_type("Slots")
+    game = facade.create_game("Old Game", gtype.id, rtp=96.0)
+
+    session = facade.create_game_session(
+        user_id=user.id,
+        site_id=site.id,
+        game_id=game.id,
+        session_date=date(2026, 2, 5),
+        starting_balance=Decimal("100.00"),
+        ending_balance=Decimal("0.00"),
+        starting_redeemable=Decimal("20.00"),
+        ending_redeemable=Decimal("0.00"),
+        purchases_during=Decimal("0.00"),
+        redemptions_during=Decimal("0.00"),
+        session_time="12:00:00",
+        notes="",
+        calculate_pl=False,
+    )
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(facade, "update_game_session", boom)
+
+    tab = GameSessionsTab(facade)
+    qtbot.addWidget(tab)
+
+    def drive_end_dialog_then_cancel():
+        dlg = _find_visible_dialog(EndSessionDialog)
+        if dlg is None:
+            QTimer.singleShot(10, drive_end_dialog_then_cancel)
+            return
+        dlg.end_total_edit.setText("150.00")
+        dlg.end_redeem_edit.setText("50.00")
+        qtbot.mouseClick(dlg.end_and_start_btn, Qt.LeftButton)
+        QTimer.singleShot(0, lambda: qtbot.mouseClick(dlg.cancel_btn, Qt.LeftButton))
+
+    QTimer.singleShot(0, drive_end_dialog_then_cancel)
+
+    tab._end_session_by_id(session.id)
+
+    sessions = facade.get_all_game_sessions(user_id=user.id, site_id=site.id)
+    assert len(sessions) == 1
+    assert (sessions[0].status or "Active") == "Active"
+
+    facade.db.close()

--- a/ui/tabs/game_sessions_tab.py
+++ b/ui/tabs/game_sessions_tab.py
@@ -539,7 +539,75 @@ class GameSessionsTab(QWidget):
 
         dialog = EndSessionDialog(self.facade, session, parent=self)
 
-        def handle_save():
+        def open_prefilled_next_session_dialog(ending_total_sc: Decimal, ending_redeemable_sc: Decimal) -> None:
+            start_dialog = StartSessionDialog(self.facade, parent=self)
+
+            user = None
+            site = None
+            try:
+                user = self.facade.get_user(session.user_id)
+                site = self.facade.get_site(session.site_id)
+            except Exception:
+                user = None
+                site = None
+
+            if user and getattr(user, "name", None):
+                start_dialog.user_combo.setCurrentText(user.name)
+            if site and getattr(site, "name", None):
+                start_dialog.site_combo.setCurrentText(site.name)
+
+            start_dialog.start_total_edit.setText(str(ending_total_sc))
+            start_dialog.start_redeem_edit.setText(str(ending_redeemable_sc))
+
+            # Force explicit game selection for the next session.
+            start_dialog.game_type_combo.blockSignals(True)
+            start_dialog.game_type_combo.setCurrentIndex(-1)
+            if start_dialog.game_type_combo.isEditable():
+                start_dialog.game_type_combo.setEditText("")
+            start_dialog.game_type_combo.blockSignals(False)
+
+            start_dialog.game_name_combo.blockSignals(True)
+            start_dialog.game_name_combo.clear()
+            start_dialog.game_name_combo.setEditText("")
+            if start_dialog.game_name_combo.lineEdit() is not None:
+                start_dialog.game_name_combo.lineEdit().setPlaceholderText("Select a game type first")
+            start_dialog.game_name_combo.blockSignals(False)
+
+            start_dialog._update_game_names()
+            start_dialog._update_balance_check()
+            start_dialog.game_type_combo.setFocus()
+
+            def handle_start_save():
+                data, error = start_dialog.collect_data()
+                if error:
+                    QMessageBox.warning(self, "Invalid Entry", error)
+                    return
+                try:
+                    self.facade.create_game_session(
+                        user_id=data["user_id"],
+                        site_id=data["site_id"],
+                        game_id=data["game_id"],
+                        session_date=data["session_date"],
+                        starting_balance=data["starting_total_sc"],
+                        ending_balance=Decimal("0.00"),
+                        starting_redeemable=data["starting_redeemable_sc"],
+                        ending_redeemable=Decimal("0.00"),
+                        purchases_during=Decimal("0.00"),
+                        redemptions_during=Decimal("0.00"),
+                        session_time=data["start_time"],
+                        notes=data["notes"],
+                        calculate_pl=False,
+                    )
+                    start_dialog.accept()
+                    self.load_data()
+                    QMessageBox.information(self, "Success", "Session started successfully!")
+                except Exception as e:
+                    QMessageBox.critical(self, "Error", f"Failed to start session: {e}")
+
+            start_dialog.save_btn.clicked.connect(handle_start_save)
+            start_dialog.exec()
+
+        def handle_close(then_start_new: bool):
             data, error = dialog.collect_data()
             if error:
                 QMessageBox.warning(self, "Invalid Entry", error)
@@ -558,11 +626,16 @@ class GameSessionsTab(QWidget):
                 )
                 dialog.accept()
                 self.load_data()
-                QMessageBox.information(self, "Success", "Session closed successfully!")
+                if then_start_new:
+                    open_prefilled_next_session_dialog(data["ending_total_sc"], data["ending_redeemable_sc"])
+                else:
+                    QMessageBox.information(self, "Success", "Session closed successfully!")
             except Exception as e:
                 QMessageBox.critical(self, "Error", f"Failed to close session: {e}")
 
-        dialog.save_btn.clicked.connect(handle_save)
+        dialog.save_btn.clicked.connect(lambda: handle_close(False))
+        if hasattr(dialog, "end_and_start_btn"):
+            dialog.end_and_start_btn.clicked.connect(lambda: handle_close(True))
         dialog.exec()
 
     def _open_purchase_by_id(self, purchase_id: int):
@@ -3920,9 +3993,12 @@ class EndSessionDialog(QDialog):
         btn_row = QHBoxLayout()
         btn_row.addStretch(1)
         self.cancel_btn = QPushButton("✖️ Cancel")
+        # Note: Qt uses '&' to denote mnemonics; use '&&' to render a literal '&'.
+        self.end_and_start_btn = QPushButton("🎮 End && Start New")
         self.save_btn = QPushButton("💾 End Session")
         self.save_btn.setObjectName("PrimaryButton")
         btn_row.addWidget(self.cancel_btn)
+        btn_row.addWidget(self.end_and_start_btn)
         btn_row.addWidget(self.save_btn)
         layout.addLayout(btn_row)
 


### PR DESCRIPTION
Adds an "🎮 End & Start New" button to the End Session dialog to close the current session and immediately open a prefilled Start Session dialog (same user/site, starting balances carried forward; game selection left blank).\n\nValidation:\n- pytest -q (648 passed)\n- pytest -q tests/integration/test_switch_game_flow.py