### PR TITLE
Fix: Game Sessions search now filters by user/site/game names (Issue #71)

### DIFF
--- a/docs/status/CHANGELOG.md
+++ b/docs/status/CHANGELOG.md
@@ -12,6 +12,24 @@ Rules:
 ## 2026-02-06
 
 ```yaml
+id: 2026-02-06-03
+type: bugfix
+areas: [ui, tests]
+summary: "Game Sessions tab search now filters by user/site/game names (resolves Issue #71)"
+issue: "#71"
+files_changed:
+  - ui/tabs/game_sessions_tab.py
+  - tests/integration/test_game_sessions_search.py (new)
+```
+
+Notes:
+- Fixed Game Sessions search to resolve user/site/game names using lookup dictionaries (same as table display logic).
+- Previously searched non-existent model attributes (`user_name`, `site_name`, `game_name`), causing empty results.
+- Search now matches displayed text: searching "Alice" finds sessions by that user, "CasinoX" finds sessions at that site, etc.
+- Added comprehensive integration tests (7 test cases): search by user/site/game name, numeric values, case-insensitive, clear search, no results.
+- Tests set date filter to "All Time" to ensure visibility of test data.
+
+```yaml
 id: 2026-02-06-02
 type: bugfix
 areas: [services, ui, app_facade, tests]

--- a/tests/integration/test_game_sessions_search.py
+++ b/tests/integration/test_game_sessions_search.py
@@ -1,0 +1,212 @@
+"""Integration test for Game Sessions tab search (Issue #71)."""
+
+import pytest
+from decimal import Decimal
+from datetime import date
+from PySide6.QtWidgets import QApplication
+
+from app_facade import AppFacade
+from ui.tabs.game_sessions_tab import GameSessionsTab
+
+
+@pytest.fixture
+def app(qapp):
+    """Ensure QApplication exists."""
+    return qapp
+
+
+@pytest.fixture
+def facade():
+    """Create AppFacade with test database."""
+    return AppFacade(":memory:")
+
+
+@pytest.fixture
+def populated_facade(facade):
+    """Create facade with sample data for search testing."""
+    # Create users
+    user1 = facade.create_user(name="Alice Smith", email="alice@test.com")
+    user2 = facade.create_user(name="Bob Jones", email="bob@test.com")
+    
+    # Create sites
+    site1 = facade.create_site(name="CasinoX", url="https://casinox.com")
+    site2 = facade.create_site(name="LuckyY", url="https://luckyy.com")
+    
+    # Create game type and games
+    game_type = facade.create_game_type(name="Slots")
+    game1 = facade.create_game(
+        name="Mega Fortune",
+        game_type_id=game_type.id,
+    )
+    game2 = facade.create_game(
+        name="Lucky Stars",
+        game_type_id=game_type.id,
+    )
+    
+    # Create game sessions
+    facade.create_game_session(
+        user_id=user1.id,
+        site_id=site1.id,
+        game_id=game1.id,
+        session_date=date(2024, 1, 15),
+        starting_balance=Decimal("100.00"),
+        ending_balance=Decimal("150.00"),
+        starting_redeemable=Decimal("100.00"),
+        ending_redeemable=Decimal("150.00"),
+        notes="Won big on spins",
+    )
+    
+    facade.create_game_session(
+        user_id=user2.id,
+        site_id=site2.id,
+        game_id=game2.id,
+        session_date=date(2024, 1, 16),
+        starting_balance=Decimal("200.00"),
+        ending_balance=Decimal("180.00"),
+        starting_redeemable=Decimal("200.00"),
+        ending_redeemable=Decimal("180.00"),
+        notes="Lost a bit",
+    )
+    
+    return facade
+
+
+def test_search_by_user_name(app, populated_facade, qtbot):
+    """Search by user name should filter sessions correctly."""
+    tab = GameSessionsTab(populated_facade)
+    qtbot.addWidget(tab)
+    
+    # Set date filter to "All Time" so test sessions from 2024 are visible
+    tab.date_filter.set_all_time()
+    tab.apply_filters()
+    
+    # Verify we have sessions
+    assert len(tab.sessions) == 2
+    
+    # Search for "Alice" (user name)
+    tab.search_edit.setText("Alice")
+    tab.apply_filters()
+    
+    # Check filtered results
+    filtered = tab.filtered_sessions
+    assert len(filtered) == 1
+    assert filtered[0].user_id == populated_facade.get_all_users()[0].id
+
+
+def test_search_by_site_name(app, populated_facade, qtbot):
+    """Search by site name should filter sessions correctly."""
+    tab = GameSessionsTab(populated_facade)
+    qtbot.addWidget(tab)
+    
+    # Set date filter to "All Time"
+    tab.date_filter.set_all_time()
+    tab.apply_filters()
+    
+    # Search for "LuckyY" (site name)
+    tab.search_edit.setText("LuckyY")
+    tab.apply_filters()
+    
+    # Check filtered results
+    filtered = tab.filtered_sessions
+    assert len(filtered) == 1
+    sites = {s.id: s for s in populated_facade.get_all_sites()}
+    assert sites[filtered[0].site_id].name == "LuckyY"
+
+
+def test_search_by_game_name(app, populated_facade, qtbot):
+    """Search by game name should filter sessions correctly."""
+    tab = GameSessionsTab(populated_facade)
+    qtbot.addWidget(tab)
+    
+    # Set date filter to "All Time"
+    tab.date_filter.set_all_time()
+    tab.apply_filters()
+    
+    # Search for "Fortune" (partial game name)
+    tab.search_edit.setText("Fortune")
+    tab.apply_filters()
+    
+    # Check filtered results
+    filtered = tab.filtered_sessions
+    assert len(filtered) == 1
+    games = {g.id: g for g in populated_facade.list_all_games()}
+    assert "Fortune" in games[filtered[0].game_id].name
+
+
+def test_search_by_numeric_value(app, populated_facade, qtbot):
+    """Search by numeric balance should still work."""
+    tab = GameSessionsTab(populated_facade)
+    qtbot.addWidget(tab)
+    
+    # Set date filter to "All Time"
+    tab.date_filter.set_all_time()
+    tab.apply_filters()
+    
+    # Search for "200" (starting balance of second session)
+    tab.search_edit.setText("200")
+    tab.apply_filters()
+    
+    # Check filtered results
+    filtered = tab.filtered_sessions
+    assert len(filtered) == 1
+    assert filtered[0].starting_balance == Decimal("200.00")
+
+
+def test_search_no_results(app, populated_facade, qtbot):
+    """Search with no matches should return empty list."""
+    tab = GameSessionsTab(populated_facade)
+    qtbot.addWidget(tab)
+    
+    # Set date filter to "All Time"
+    tab.date_filter.set_all_time()
+    tab.apply_filters()
+    
+    # Search for something that doesn't exist
+    tab.search_edit.setText("NonexistentTerm")
+    tab.apply_filters()
+    
+    # Check filtered results
+    filtered = tab.filtered_sessions
+    assert len(filtered) == 0
+
+
+def test_search_case_insensitive(app, populated_facade, qtbot):
+    """Search should be case-insensitive."""
+    tab = GameSessionsTab(populated_facade)
+    qtbot.addWidget(tab)
+    
+    # Set date filter to "All Time"
+    tab.date_filter.set_all_time()
+    tab.apply_filters()
+    
+    # Search for lowercase version of site name
+    tab.search_edit.setText("casinox")
+    tab.apply_filters()
+    
+    # Check filtered results
+    filtered = tab.filtered_sessions
+    assert len(filtered) == 1
+    sites = {s.id: s for s in populated_facade.get_all_sites()}
+    assert sites[filtered[0].site_id].name == "CasinoX"
+
+
+def test_clear_search_shows_all(app, populated_facade, qtbot):
+    """Clearing search should show all sessions."""
+    tab = GameSessionsTab(populated_facade)
+    qtbot.addWidget(tab)
+    
+    # Set date filter to "All Time"
+    tab.date_filter.set_all_time()
+    tab.apply_filters()
+    
+    # Search for something
+    tab.search_edit.setText("Alice")
+    tab.apply_filters()
+    assert len(tab.filtered_sessions) == 1
+    
+    # Clear search
+    tab.search_edit.setText("")
+    tab.apply_filters()
+    
+    # All sessions should be visible again
+    assert len(tab.filtered_sessions) == 2

--- a/ui/tabs/game_sessions_tab.py
+++ b/ui/tabs/game_sessions_tab.py
@@ -230,22 +230,32 @@ class GameSessionsTab(QWidget):
 
         search_text = self.search_edit.text().lower().strip()
         if search_text:
+            # Resolve names the same way _populate_table does (so search matches what's displayed)
+            users = {u.id: u.name for u in self.facade.get_all_users()}
+            sites = {s.id: s.name for s in self.facade.get_all_sites()}
+            games = {g.id: g for g in self.facade.list_all_games()}
+            
             filtered = []
             for s in rows:
+                user_name = users.get(s.user_id, '')
+                site_name = sites.get(s.site_id, '')
+                game = games.get(s.game_id)
+                game_name = game.name if game else ''
+                
                 parts = [
                     str(s.session_date),
-                    getattr(s, 'user_name', '') or '',
-                    getattr(s, 'site_name', '') or '',
-                    getattr(s, 'game_name', '') or '',
-                    getattr(s, 'status', '') or '',
+                    user_name,
+                    site_name,
+                    game_name,
+                    s.status or '',
                     str(s.starting_balance),
                     str(s.ending_balance),
                     str(s.starting_redeemable),
                     str(s.ending_redeemable),
-                    str(s.delta_total),
-                    str(s.delta_redeem),
-                    str(s.basis_consumed),
-                    str(s.net_taxable_pl),
+                    str(s.delta_total) if s.delta_total is not None else '',
+                    str(s.delta_redeem) if s.delta_redeem is not None else '',
+                    str(s.basis_consumed) if s.basis_consumed is not None else '',
+                    str(s.net_taxable_pl) if s.net_taxable_pl is not None else '',
                     s.notes or '',
                 ]
                 haystack = " ".join(parts).lower()


### PR DESCRIPTION
## Summary
Fixes Game Sessions tab search to correctly filter by user names, site names, and game names.

## Problem
- Game Sessions search was broken - searching for user/site/game names returned no results
- Root cause: `_get_filtered_sessions()` tried to search model attributes (`user_name`, `site_name`, `game_name`) that don't exist on `GameSession` models
- Models only contain IDs (`user_id`, `site_id`, `game_id`)
- Table display separately resolves names via lookup dictionaries, but search didn't

## Solution
- Fixed `_get_filtered_sessions()` to resolve names using same lookup pattern as `_populate_table()`
- Search now builds haystack with actual user/site/game names from lookup dictionaries
- Added None-checks for optional derived fields to avoid stringifying None

## Testing
- Added comprehensive integration test suite (`tests/integration/test_game_sessions_search.py`) with 7 test cases:
  - Search by user name
  - Search by site name
  - Search by game name  
  - Search by numeric value (balance)
  - Search with no results
  - Case-insensitive search
  - Clear search shows all sessions
- All 694 tests pass

## Notes
- Tests set date filter to "All Time" because default filter (Jan 1 current year → today) excluded test data from 2024

Closes #71
