### PR TITLE
fix: improve dark theme dialog label contrast

### DIFF
--- a/docs/PROJECT_SPEC.md
+++ b/docs/PROJECT_SPEC.md
@@ -223,6 +223,7 @@ UI rules:
 - UI calls services; no direct SQL in UI.
 - Prefer View-first dialog flows; edits are deliberate.
 - Bulk actions and destructive actions require confirmation.
+- Dialog secondary labels use theme-managed `MutedLabel` styling for dark-theme readability.
 
 Window Constraints (Issue #76):
 - Tools tab wrapped in QScrollArea to prevent off-screen expansion

--- a/docs/status/CHANGELOG.md
+++ b/docs/status/CHANGELOG.md
@@ -12,6 +12,35 @@ Rules:
 ## 2026-02-06
 
 ```yaml
+id: 2026-02-06-09
+type: bugfix
+areas: [ui]
+summary: "Dark theme dialog labels now use theme-muted styling for readability"
+issue: "#76"
+files_changed:
+  - ui/themes.py
+  - ui/tabs/redemptions_tab.py
+  - ui/tabs/purchases_tab.py
+  - ui/tabs/game_sessions_tab.py
+  - ui/tabs/realized_tab.py
+  - ui/tabs/users_tab.py
+  - ui/tabs/sites_tab.py
+  - ui/tabs/cards_tab.py
+  - ui/tabs/games_tab.py
+  - ui/tabs/game_types_tab.py
+  - ui/tabs/redemption_methods_tab.py
+  - ui/tabs/redemption_method_types_tab.py
+  - ui/tabs/expenses_tab.py
+  - ui/tabs/unrealized_tab.py
+  - ui/tabs/purchases_tab_modern.py
+```
+
+Notes:
+- **Problem:** Dialog field labels were using `palette(mid)` and became unreadable in Dark theme.
+- **Solution:** Introduced `MutedLabel` theme styling and applied it across dialog view layouts.
+- **Impact:** Consistent, readable secondary labels in Dark theme without changing dialog layout.
+
+```yaml
 id: 2026-02-06-08
 type: bugfix
 areas: [ui]

--- a/ui/tabs/cards_tab.py
+++ b/ui/tabs/cards_tab.py
@@ -736,7 +736,7 @@ class CardViewDialog(QtWidgets.QDialog):
         left_grid.setColumnStretch(1, 1)
         
         user_lbl = QtWidgets.QLabel("User:")
-        user_lbl.setStyleSheet("color: palette(mid);")
+        user_lbl.setObjectName("MutedLabel")
         user_name = getattr(card, 'user_name', None)
         user_display = user_name if user_name else "Unknown User" if card.user_id else "—"
         user_val = self._make_selectable_label(user_display)
@@ -744,13 +744,13 @@ class CardViewDialog(QtWidgets.QDialog):
         left_grid.addWidget(user_val, 0, 1)
         
         name_lbl = QtWidgets.QLabel("Card Name:")
-        name_lbl.setStyleSheet("color: palette(mid);")
+        name_lbl.setObjectName("MutedLabel")
         name_val = self._make_selectable_label(card.name)
         left_grid.addWidget(name_lbl, 1, 0, QtCore.Qt.AlignRight)
         left_grid.addWidget(name_val, 1, 1)
         
         last_four_lbl = QtWidgets.QLabel("Last Four:")
-        last_four_lbl.setStyleSheet("color: palette(mid);")
+        last_four_lbl.setObjectName("MutedLabel")
         last_four_val = self._make_selectable_label(card.last_four or "—")
         left_grid.addWidget(last_four_lbl, 2, 0, QtCore.Qt.AlignRight)
         left_grid.addWidget(last_four_val, 2, 1)
@@ -764,13 +764,13 @@ class CardViewDialog(QtWidgets.QDialog):
         right_grid.setColumnStretch(1, 1)
         
         status_lbl = QtWidgets.QLabel("Status:")
-        status_lbl.setStyleSheet("color: palette(mid);")
+        status_lbl.setObjectName("MutedLabel")
         status_val = self._make_selectable_label("Active" if card.is_active else "Inactive")
         right_grid.addWidget(status_lbl, 0, 0, QtCore.Qt.AlignRight)
         right_grid.addWidget(status_val, 0, 1)
         
         cashback_lbl = QtWidgets.QLabel("Cashback %:")
-        cashback_lbl.setStyleSheet("color: palette(mid);")
+        cashback_lbl.setObjectName("MutedLabel")
         cashback_val = self._make_selectable_label(f"{float(card.cashback_rate):.2f}" if card.cashback_rate else "0.00")
         right_grid.addWidget(cashback_lbl, 1, 0, QtCore.Qt.AlignRight)
         right_grid.addWidget(cashback_val, 1, 1)
@@ -801,7 +801,10 @@ class CardViewDialog(QtWidgets.QDialog):
             notes_layout.addWidget(notes_display)
         else:
             notes_empty = QtWidgets.QLabel("—")
-            notes_empty.setStyleSheet("color: palette(mid); font-style: italic;")
+            notes_empty.setObjectName("MutedLabel")
+            notes_font = notes_empty.font()
+            notes_font.setItalic(True)
+            notes_empty.setFont(notes_font)
             notes_layout.addWidget(notes_empty)
         main_layout.addWidget(notes_section)
         

--- a/ui/tabs/expenses_tab.py
+++ b/ui/tabs/expenses_tab.py
@@ -863,7 +863,7 @@ class ExpenseViewDialog(QtWidgets.QDialog):
         
         # Date & Time
         date_label = QtWidgets.QLabel("Date:")
-        date_label.setStyleSheet("color: palette(mid);")
+        date_label.setObjectName("MutedLabel")
         left_grid.addWidget(date_label, 0, 0)
         date_time_str = self._format_date(expense.expense_date)
         if expense.expense_time:
@@ -873,13 +873,13 @@ class ExpenseViewDialog(QtWidgets.QDialog):
         
         # Vendor
         vendor_label = QtWidgets.QLabel("Vendor:")
-        vendor_label.setStyleSheet("color: palette(mid);")
+        vendor_label.setObjectName("MutedLabel")
         left_grid.addWidget(vendor_label, 1, 0)
         left_grid.addWidget(self._make_selectable_label(expense.vendor or "—"), 1, 1)
         
         # Amount
         amount_label = QtWidgets.QLabel("Amount:")
-        amount_label.setStyleSheet("color: palette(mid);")
+        amount_label.setObjectName("MutedLabel")
         left_grid.addWidget(amount_label, 2, 0)
         left_grid.addWidget(self._make_selectable_label(f"${expense.amount:,.2f}"), 2, 1)
         
@@ -892,13 +892,13 @@ class ExpenseViewDialog(QtWidgets.QDialog):
         
         # User
         user_label = QtWidgets.QLabel("User:")
-        user_label.setStyleSheet("color: palette(mid);")
+        user_label.setObjectName("MutedLabel")
         right_grid.addWidget(user_label, 0, 0)
         right_grid.addWidget(self._make_selectable_label(expense.user_name or "—"), 0, 1)
         
         # Category
         category_label = QtWidgets.QLabel("Category:")
-        category_label.setStyleSheet("color: palette(mid);")
+        category_label.setObjectName("MutedLabel")
         right_grid.addWidget(category_label, 1, 0)
         right_grid.addWidget(self._make_selectable_label(expense.category or "—"), 1, 1)
         
@@ -923,7 +923,10 @@ class ExpenseViewDialog(QtWidgets.QDialog):
             notes_layout.addWidget(notes_display)
         else:
             notes_empty = QtWidgets.QLabel("—")
-            notes_empty.setStyleSheet("color: palette(mid); font-style: italic;")
+            notes_empty.setObjectName("MutedLabel")
+            notes_font = notes_empty.font()
+            notes_font.setItalic(True)
+            notes_empty.setFont(notes_font)
             notes_layout.addWidget(notes_empty)
         
         layout.addWidget(notes_section)

--- a/ui/tabs/game_sessions_tab.py
+++ b/ui/tabs/game_sessions_tab.py
@@ -3080,7 +3080,7 @@ class ViewSessionDialog(QDialog):
 
         # Row 0: Start Date/Time (left), End Date/Time (right)
         start_dt_label = QLabel("Start Date / Time:")
-        start_dt_label.setStyleSheet("color: palette(mid);")
+        start_dt_label.setObjectName("MutedLabel")
         details_grid.addWidget(start_dt_label, 0, 0)
 
         start_dt_value = self._format_datetime(self.session.session_date, self.session.session_time)
@@ -3090,7 +3090,7 @@ class ViewSessionDialog(QDialog):
         details_grid.addWidget(start_dt_display, 0, 1)
 
         end_dt_label = QLabel("End Date / Time:")
-        end_dt_label.setStyleSheet("color: palette(mid);")
+        end_dt_label.setObjectName("MutedLabel")
         details_grid.addWidget(end_dt_label, 0, 2)
 
         end_dt_value = self._format_datetime(self.session.end_date, self.session.end_time) if self.session.end_date else "—"
@@ -3101,7 +3101,7 @@ class ViewSessionDialog(QDialog):
 
         # Row 1: User (left), Site (right)
         user_label = QLabel("User:")
-        user_label.setStyleSheet("color: palette(mid);")
+        user_label.setObjectName("MutedLabel")
         details_grid.addWidget(user_label, 1, 0)
 
         user_name = users.get(self.session.user_id, "—")
@@ -3111,7 +3111,7 @@ class ViewSessionDialog(QDialog):
         details_grid.addWidget(user_display, 1, 1)
 
         site_label = QLabel("Site:")
-        site_label.setStyleSheet("color: palette(mid);")
+        site_label.setObjectName("MutedLabel")
         details_grid.addWidget(site_label, 1, 2)
 
         site_name = sites.get(self.session.site_id, "—")
@@ -3149,7 +3149,7 @@ class ViewSessionDialog(QDialog):
 
         row = 0
         game_type_label = QLabel("Game Type:")
-        game_type_label.setStyleSheet("color: palette(mid);")
+        game_type_label.setObjectName("MutedLabel")
         game_stats_grid.addWidget(game_type_label, row, 0)
         game_type_value = QLabel(game_type_name)
         game_type_value.setTextInteractionFlags(Qt.TextSelectableByMouse)
@@ -3158,7 +3158,7 @@ class ViewSessionDialog(QDialog):
 
         row += 1
         game_name_label = QLabel("Game Name:")
-        game_name_label.setStyleSheet("color: palette(mid);")
+        game_name_label.setObjectName("MutedLabel")
         game_stats_grid.addWidget(game_name_label, row, 0)
         game_name_value = QLabel(game_name)
         game_name_value.setTextInteractionFlags(Qt.TextSelectableByMouse)
@@ -3167,7 +3167,7 @@ class ViewSessionDialog(QDialog):
 
         row += 1
         wager_label = QLabel("Wager:")
-        wager_label.setStyleSheet("color: palette(mid);")
+        wager_label.setObjectName("MutedLabel")
         game_stats_grid.addWidget(wager_label, row, 0)
         wager_value = self.session.wager_amount if self.session.wager_amount is not None else None
         wager_display = format_currency(wager_value) if wager_value not in (None, "") else "—"
@@ -3178,7 +3178,7 @@ class ViewSessionDialog(QDialog):
 
         row += 1
         rtp_label = QLabel("RTP:")
-        rtp_label.setStyleSheet("color: palette(mid);")
+        rtp_label.setObjectName("MutedLabel")
         game_stats_grid.addWidget(rtp_label, row, 0)
         rtp_display = self._calculate_rtp_display(game)
         rtp_value_label = QLabel(rtp_display)
@@ -3390,7 +3390,10 @@ class ViewSessionDialog(QDialog):
             notes_layout.addWidget(notes_display)
         else:
             notes_empty = QLabel("—")
-            notes_empty.setStyleSheet("color: palette(mid); font-style: italic;")
+            notes_empty.setObjectName("MutedLabel")
+            notes_font = notes_empty.font()
+            notes_font.setItalic(True)
+            notes_empty.setFont(notes_font)
             notes_layout.addWidget(notes_empty)
 
         layout.addWidget(notes_section)

--- a/ui/tabs/game_types_tab.py
+++ b/ui/tabs/game_types_tab.py
@@ -567,13 +567,13 @@ class GameTypeViewDialog(QtWidgets.QDialog):
         grid.setColumnStretch(1, 1)
         
         name_lbl = QtWidgets.QLabel("Name:")
-        name_lbl.setStyleSheet("color: palette(mid);")
+        name_lbl.setObjectName("MutedLabel")
         name_val = self._make_selectable_label(game_type.name)
         grid.addWidget(name_lbl, 0, 0, QtCore.Qt.AlignRight)
         grid.addWidget(name_val, 0, 1)
         
         status_lbl = QtWidgets.QLabel("Status:")
-        status_lbl.setStyleSheet("color: palette(mid);")
+        status_lbl.setObjectName("MutedLabel")
         status_val = self._make_selectable_label("Active" if game_type.is_active else "Inactive")
         grid.addWidget(status_lbl, 1, 0, QtCore.Qt.AlignRight)
         grid.addWidget(status_val, 1, 1)
@@ -602,7 +602,10 @@ class GameTypeViewDialog(QtWidgets.QDialog):
             notes_layout.addWidget(notes_display)
         else:
             notes_empty = QtWidgets.QLabel("—")
-            notes_empty.setStyleSheet("color: palette(mid); font-style: italic;")
+            notes_empty.setObjectName("MutedLabel")
+            notes_font = notes_empty.font()
+            notes_font.setItalic(True)
+            notes_empty.setFont(notes_font)
             notes_layout.addWidget(notes_empty)
         main_layout.addWidget(notes_section)
         

--- a/ui/tabs/games_tab.py
+++ b/ui/tabs/games_tab.py
@@ -497,7 +497,10 @@ class GameDialog(QtWidgets.QDialog):
         
         actual_rtp_val = f"{float(getattr(game, 'actual_rtp', 0) or 0):.2f}%" if game and getattr(game, "actual_rtp", None) is not None else "—"
         self.actual_rtp_value = QtWidgets.QLabel(actual_rtp_val)
-        self.actual_rtp_value.setStyleSheet("color: palette(mid); font-style: italic;")
+        self.actual_rtp_value.setObjectName("MutedLabel")
+        actual_rtp_font = self.actual_rtp_value.font()
+        actual_rtp_font.setItalic(True)
+        self.actual_rtp_value.setFont(actual_rtp_font)
         rtp_row.addWidget(self.actual_rtp_value)
         rtp_row.addStretch(1)
         
@@ -729,13 +732,13 @@ class GameViewDialog(QtWidgets.QDialog):
         left_grid.setColumnStretch(1, 1)
         
         name_lbl = QtWidgets.QLabel("Name:")
-        name_lbl.setStyleSheet("color: palette(mid);")
+        name_lbl.setObjectName("MutedLabel")
         name_val = self._make_selectable_label(game.name)
         left_grid.addWidget(name_lbl, 0, 0, QtCore.Qt.AlignRight)
         left_grid.addWidget(name_val, 0, 1)
         
         game_type_lbl = QtWidgets.QLabel("Game Type:")
-        game_type_lbl.setStyleSheet("color: palette(mid);")
+        game_type_lbl.setObjectName("MutedLabel")
         game_type_name = getattr(game, 'game_type_name', None)
         game_type_display = game_type_name if game_type_name else "Unknown Type" if game.game_type_id else "—"
         game_type_val = self._make_selectable_label(game_type_display)
@@ -751,20 +754,20 @@ class GameViewDialog(QtWidgets.QDialog):
         right_grid.setColumnStretch(1, 1)
         
         rtp_lbl = QtWidgets.QLabel("RTP (%):")
-        rtp_lbl.setStyleSheet("color: palette(mid);")
+        rtp_lbl.setObjectName("MutedLabel")
         rtp_val = self._make_selectable_label(str(game.rtp) if game.rtp is not None else "—")
         right_grid.addWidget(rtp_lbl, 0, 0, QtCore.Qt.AlignRight)
         right_grid.addWidget(rtp_val, 0, 1)
         
         actual_rtp_lbl = QtWidgets.QLabel("Actual RTP:")
-        actual_rtp_lbl.setStyleSheet("color: palette(mid);")
+        actual_rtp_lbl.setObjectName("MutedLabel")
         actual_rtp_val_text = f"{float(getattr(game, 'actual_rtp', 0) or 0):.2f}%" if getattr(game, "actual_rtp", None) is not None else "—"
         actual_rtp_val = self._make_selectable_label(actual_rtp_val_text)
         right_grid.addWidget(actual_rtp_lbl, 1, 0, QtCore.Qt.AlignRight)
         right_grid.addWidget(actual_rtp_val, 1, 1)
         
         status_lbl = QtWidgets.QLabel("Status:")
-        status_lbl.setStyleSheet("color: palette(mid);")
+        status_lbl.setObjectName("MutedLabel")
         status_val = self._make_selectable_label("Active" if game.is_active else "Inactive")
         right_grid.addWidget(status_lbl, 2, 0, QtCore.Qt.AlignRight)
         right_grid.addWidget(status_val, 2, 1)
@@ -795,7 +798,10 @@ class GameViewDialog(QtWidgets.QDialog):
             notes_layout.addWidget(notes_display)
         else:
             notes_empty = QtWidgets.QLabel("—")
-            notes_empty.setStyleSheet("color: palette(mid); font-style: italic;")
+            notes_empty.setObjectName("MutedLabel")
+            notes_font = notes_empty.font()
+            notes_font.setItalic(True)
+            notes_empty.setFont(notes_font)
             notes_layout.addWidget(notes_empty)
         main_layout.addWidget(notes_section)
         

--- a/ui/tabs/purchases_tab.py
+++ b/ui/tabs/purchases_tab.py
@@ -2036,12 +2036,12 @@ class PurchaseViewDialog(QtWidgets.QDialog):
         when_grid.setVerticalSpacing(6)
         
         date_label = QtWidgets.QLabel("Date:")
-        date_label.setStyleSheet("color: palette(mid);")
+        date_label.setObjectName("MutedLabel")
         when_grid.addWidget(date_label, 0, 0)
         when_grid.addWidget(make_selectable_label(format_date(self.purchase.purchase_date)), 0, 1)
         
         time_label = QtWidgets.QLabel("Time:")
-        time_label.setStyleSheet("color: palette(mid);")
+        time_label.setObjectName("MutedLabel")
         when_grid.addWidget(time_label, 1, 0)
         when_grid.addWidget(make_selectable_label(format_time(self.purchase.purchase_time)), 1, 1)
         
@@ -2057,17 +2057,17 @@ class PurchaseViewDialog(QtWidgets.QDialog):
         details_grid.setVerticalSpacing(6)
         
         user_label = QtWidgets.QLabel("User:")
-        user_label.setStyleSheet("color: palette(mid);")
+        user_label.setObjectName("MutedLabel")
         details_grid.addWidget(user_label, 0, 0)
         details_grid.addWidget(make_selectable_label(user_name or "—"), 0, 1)
         
         site_label = QtWidgets.QLabel("Site:")
-        site_label.setStyleSheet("color: palette(mid);")
+        site_label.setObjectName("MutedLabel")
         details_grid.addWidget(site_label, 1, 0)
         details_grid.addWidget(make_selectable_label(site_name or "—"), 1, 1)
         
         card_label = QtWidgets.QLabel("Card:")
-        card_label.setStyleSheet("color: palette(mid);")
+        card_label.setObjectName("MutedLabel")
         details_grid.addWidget(card_label, 2, 0)
         details_grid.addWidget(make_selectable_label(card_name or "—"), 2, 1)
         
@@ -2096,27 +2096,27 @@ class PurchaseViewDialog(QtWidgets.QDialog):
         basis_val = f"${float(self.purchase.remaining_amount):.2f}"
         
         amount_label = QtWidgets.QLabel("Amount:")
-        amount_label.setStyleSheet("color: palette(mid);")
+        amount_label.setObjectName("MutedLabel")
         balances_grid.addWidget(amount_label, 0, 0)
         balances_grid.addWidget(make_selectable_label(amount_val, align_right=True), 0, 1)
         
         cashback_label = QtWidgets.QLabel("Cashback:")
-        cashback_label.setStyleSheet("color: palette(mid);")
+        cashback_label.setObjectName("MutedLabel")
         balances_grid.addWidget(cashback_label, 1, 0)
         balances_grid.addWidget(make_selectable_label(cashback_val, align_right=True), 1, 1)
         
         start_sc_label = QtWidgets.QLabel("Starting SC:")
-        start_sc_label.setStyleSheet("color: palette(mid);")
+        start_sc_label.setObjectName("MutedLabel")
         balances_grid.addWidget(start_sc_label, 2, 0)
         balances_grid.addWidget(make_selectable_label(start_sc_val, align_right=True), 2, 1)
         
         sc_label = QtWidgets.QLabel("SC Received:")
-        sc_label.setStyleSheet("color: palette(mid);")
+        sc_label.setObjectName("MutedLabel")
         balances_grid.addWidget(sc_label, 3, 0)
         balances_grid.addWidget(make_selectable_label(sc_val, align_right=True), 3, 1)
         
         basis_label = QtWidgets.QLabel("Remaining Basis:")
-        basis_label.setStyleSheet("color: palette(mid);")
+        basis_label.setObjectName("MutedLabel")
         balances_grid.addWidget(basis_label, 4, 0)
         balances_grid.addWidget(make_selectable_label(basis_val, align_right=True), 4, 1)
         
@@ -2142,7 +2142,10 @@ class PurchaseViewDialog(QtWidgets.QDialog):
             notes_layout.addWidget(notes_display)
         else:
             notes_empty = QtWidgets.QLabel("—")
-            notes_empty.setStyleSheet("color: palette(mid); font-style: italic;")
+            notes_empty.setObjectName("MutedLabel")
+            notes_font = notes_empty.font()
+            notes_font.setItalic(True)
+            notes_empty.setFont(notes_font)
             notes_layout.addWidget(notes_empty)
         
         layout.addWidget(notes_section)
@@ -2273,7 +2276,10 @@ class PurchaseViewDialog(QtWidgets.QDialog):
 
         if not self.linked_sessions and not allocations and not basis_purchases:
             placeholder = QtWidgets.QLabel("No related sessions, purchases, or redemptions found.")
-            placeholder.setStyleSheet("color: palette(mid); font-style: italic;")
+            placeholder.setObjectName("MutedLabel")
+            placeholder_font = placeholder.font()
+            placeholder_font.setItalic(True)
+            placeholder.setFont(placeholder_font)
             layout.addWidget(placeholder)
             layout.addStretch()
             return widget

--- a/ui/tabs/purchases_tab_modern.py
+++ b/ui/tabs/purchases_tab_modern.py
@@ -1134,7 +1134,10 @@ class ModernPurchaseViewDialog(QtWidgets.QDialog):
 
         if not self.linked_sessions and not allocations:
             placeholder = QtWidgets.QLabel("No related sessions or redemptions found.")
-            placeholder.setStyleSheet("color: palette(mid); font-style: italic;")
+            placeholder.setObjectName("MutedLabel")
+            placeholder_font = placeholder.font()
+            placeholder_font.setItalic(True)
+            placeholder.setFont(placeholder_font)
             layout.addWidget(placeholder)
             layout.addStretch()
             return widget

--- a/ui/tabs/realized_tab.py
+++ b/ui/tabs/realized_tab.py
@@ -170,23 +170,23 @@ class RealizedPositionDialog(QtWidgets.QDialog):
         
         # Left column
         date_label = QtWidgets.QLabel("Redemption Date:")
-        date_label.setStyleSheet("color: palette(mid);")
+        date_label.setObjectName("MutedLabel")
         position_grid.addWidget(date_label, 0, 0)
         position_grid.addWidget(make_selectable_label(format_date(self.position.get("redemption_date"))), 0, 1)
         
         user_label = QtWidgets.QLabel("User:")
-        user_label.setStyleSheet("color: palette(mid);")
+        user_label.setObjectName("MutedLabel")
         position_grid.addWidget(user_label, 1, 0)
         position_grid.addWidget(make_selectable_label(self.position.get("user_name") or "—"), 1, 1)
         
         # Right column
         time_label = QtWidgets.QLabel("Redemption Time:")
-        time_label.setStyleSheet("color: palette(mid);")
+        time_label.setObjectName("MutedLabel")
         position_grid.addWidget(time_label, 0, 2)
         position_grid.addWidget(make_selectable_label(format_time(self.position.get("redemption_time"))), 0, 3)
         
         site_label = QtWidgets.QLabel("Site:")
-        site_label.setStyleSheet("color: palette(mid);")
+        site_label.setObjectName("MutedLabel")
         position_grid.addWidget(site_label, 1, 2)
         position_grid.addWidget(make_selectable_label(self.position.get("site_name") or "—"), 1, 3)
         
@@ -210,22 +210,22 @@ class RealizedPositionDialog(QtWidgets.QDialog):
         financial_grid.setVerticalSpacing(6)
         
         redemption_label = QtWidgets.QLabel("Redemption Amount:")
-        redemption_label.setStyleSheet("color: palette(mid);")
+        redemption_label.setObjectName("MutedLabel")
         financial_grid.addWidget(redemption_label, 0, 0)
         financial_grid.addWidget(make_selectable_label(format_currency(self.position.get("redemption_amount"))), 0, 1)
         
         basis_label = QtWidgets.QLabel("Cost Basis:")
-        basis_label.setStyleSheet("color: palette(mid);")
+        basis_label.setObjectName("MutedLabel")
         financial_grid.addWidget(basis_label, 1, 0)
         financial_grid.addWidget(make_selectable_label(format_currency(self.position.get("cost_basis"))), 1, 1)
         
         fees_label = QtWidgets.QLabel("Fees:")
-        fees_label.setStyleSheet("color: palette(mid);")
+        fees_label.setObjectName("MutedLabel")
         financial_grid.addWidget(fees_label, 2, 0)
         financial_grid.addWidget(make_selectable_label(format_currency(self.position.get("fees"))), 2, 1)
         
         pl_label = QtWidgets.QLabel("Realized P/L:")
-        pl_label.setStyleSheet("color: palette(mid);")
+        pl_label.setObjectName("MutedLabel")
         financial_grid.addWidget(pl_label, 3, 0)
         
         # Color code P/L
@@ -257,29 +257,29 @@ class RealizedPositionDialog(QtWidgets.QDialog):
         processing_grid.setVerticalSpacing(6)
         
         method_type_label = QtWidgets.QLabel("Redemption Method Type:")
-        method_type_label.setStyleSheet("color: palette(mid);")
+        method_type_label.setObjectName("MutedLabel")
         processing_grid.addWidget(method_type_label, 0, 0)
         processing_grid.addWidget(make_selectable_label(self.position.get("method_type") or "—"), 0, 1)
         
         method_label = QtWidgets.QLabel("Redemption Method:")
-        method_label.setStyleSheet("color: palette(mid);")
+        method_label.setObjectName("MutedLabel")
         processing_grid.addWidget(method_label, 1, 0)
         processing_grid.addWidget(make_selectable_label(self.position.get("method_name") or "—"), 1, 1)
         
         type_label = QtWidgets.QLabel("Redemption Type:")
-        type_label.setStyleSheet("color: palette(mid);")
+        type_label.setObjectName("MutedLabel")
         processing_grid.addWidget(type_label, 2, 0)
         type_text = "Partial" if self.position.get("more_remaining") else "Full"
         processing_grid.addWidget(make_selectable_label(type_text), 2, 1)
         
         receipt_label = QtWidgets.QLabel("Receipt Date:")
-        receipt_label.setStyleSheet("color: palette(mid);")
+        receipt_label.setObjectName("MutedLabel")
         processing_grid.addWidget(receipt_label, 3, 0)
         receipt_text = format_date(self.position.get("receipt_date")) if self.position.get("receipt_date") else "—"
         processing_grid.addWidget(make_selectable_label(receipt_text), 3, 1)
         
         processed_label = QtWidgets.QLabel("Processed:")
-        processed_label.setStyleSheet("color: palette(mid);")
+        processed_label.setObjectName("MutedLabel")
         processing_grid.addWidget(processed_label, 4, 0)
         processed_text = "Yes" if self.position.get("processed") else "No"
         processing_grid.addWidget(make_selectable_label(processed_text), 4, 1)
@@ -304,7 +304,10 @@ class RealizedPositionDialog(QtWidgets.QDialog):
             notes_layout.addWidget(notes_display)
         else:
             notes_empty = QtWidgets.QLabel("—")
-            notes_empty.setStyleSheet("color: palette(mid); font-style: italic;")
+            notes_empty.setObjectName("MutedLabel")
+            notes_font = notes_empty.font()
+            notes_font.setItalic(True)
+            notes_empty.setFont(notes_font)
             notes_layout.addWidget(notes_empty)
         
         layout.addWidget(notes_section)

--- a/ui/tabs/redemption_method_types_tab.py
+++ b/ui/tabs/redemption_method_types_tab.py
@@ -565,13 +565,13 @@ class RedemptionMethodTypeViewDialog(QtWidgets.QDialog):
         grid.setColumnStretch(1, 1)
         
         name_lbl = QtWidgets.QLabel("Name:")
-        name_lbl.setStyleSheet("color: palette(mid);")
+        name_lbl.setObjectName("MutedLabel")
         name_val = self._make_selectable_label(method_type.name)
         grid.addWidget(name_lbl, 0, 0, QtCore.Qt.AlignRight)
         grid.addWidget(name_val, 0, 1)
         
         status_lbl = QtWidgets.QLabel("Status:")
-        status_lbl.setStyleSheet("color: palette(mid);")
+        status_lbl.setObjectName("MutedLabel")
         status_val = self._make_selectable_label("Active" if method_type.is_active else "Inactive")
         grid.addWidget(status_lbl, 1, 0, QtCore.Qt.AlignRight)
         grid.addWidget(status_val, 1, 1)
@@ -600,7 +600,10 @@ class RedemptionMethodTypeViewDialog(QtWidgets.QDialog):
             notes_layout.addWidget(notes_display)
         else:
             notes_empty = QtWidgets.QLabel("—")
-            notes_empty.setStyleSheet("color: palette(mid); font-style: italic;")
+            notes_empty.setObjectName("MutedLabel")
+            notes_font = notes_empty.font()
+            notes_font.setItalic(True)
+            notes_empty.setFont(notes_font)
             notes_layout.addWidget(notes_empty)
         main_layout.addWidget(notes_section)
         

--- a/ui/tabs/redemption_methods_tab.py
+++ b/ui/tabs/redemption_methods_tab.py
@@ -685,13 +685,13 @@ class RedemptionMethodViewDialog(QtWidgets.QDialog):
         left_grid.setColumnStretch(1, 1)
         
         name_lbl = QtWidgets.QLabel("Name:")
-        name_lbl.setStyleSheet("color: palette(mid);")
+        name_lbl.setObjectName("MutedLabel")
         name_val = self._make_selectable_label(method.name)
         left_grid.addWidget(name_lbl, 0, 0, QtCore.Qt.AlignRight)
         left_grid.addWidget(name_val, 0, 1)
         
         method_type_lbl = QtWidgets.QLabel("Method Type:")
-        method_type_lbl.setStyleSheet("color: palette(mid);")
+        method_type_lbl.setObjectName("MutedLabel")
         method_type_val = self._make_selectable_label(method.method_type or "—")
         left_grid.addWidget(method_type_lbl, 1, 0, QtCore.Qt.AlignRight)
         left_grid.addWidget(method_type_val, 1, 1)
@@ -705,7 +705,7 @@ class RedemptionMethodViewDialog(QtWidgets.QDialog):
         right_grid.setColumnStretch(1, 1)
         
         user_lbl = QtWidgets.QLabel("User:")
-        user_lbl.setStyleSheet("color: palette(mid);")
+        user_lbl.setObjectName("MutedLabel")
         user_name = getattr(method, 'user_name', None)
         user_display = user_name if user_name else "Unknown User" if method.user_id else "—"
         user_val = self._make_selectable_label(user_display)
@@ -713,7 +713,7 @@ class RedemptionMethodViewDialog(QtWidgets.QDialog):
         right_grid.addWidget(user_val, 0, 1)
         
         status_lbl = QtWidgets.QLabel("Status:")
-        status_lbl.setStyleSheet("color: palette(mid);")
+        status_lbl.setObjectName("MutedLabel")
         status_val = self._make_selectable_label("Active" if method.is_active else "Inactive")
         right_grid.addWidget(status_lbl, 1, 0, QtCore.Qt.AlignRight)
         right_grid.addWidget(status_val, 1, 1)
@@ -744,7 +744,10 @@ class RedemptionMethodViewDialog(QtWidgets.QDialog):
             notes_layout.addWidget(notes_display)
         else:
             notes_empty = QtWidgets.QLabel("—")
-            notes_empty.setStyleSheet("color: palette(mid); font-style: italic;")
+            notes_empty.setObjectName("MutedLabel")
+            notes_font = notes_empty.font()
+            notes_font.setItalic(True)
+            notes_empty.setFont(notes_font)
             notes_layout.addWidget(notes_empty)
         main_layout.addWidget(notes_section)
         

--- a/ui/tabs/redemptions_tab.py
+++ b/ui/tabs/redemptions_tab.py
@@ -2015,12 +2015,12 @@ class RedemptionViewDialog(QtWidgets.QDialog):
         when_grid.setVerticalSpacing(6)
         
         date_label = QtWidgets.QLabel("Date:")
-        date_label.setStyleSheet("color: palette(mid);")
+        date_label.setObjectName("MutedLabel")
         when_grid.addWidget(date_label, 0, 0)
         when_grid.addWidget(make_selectable_label(format_date(self.redemption.redemption_date)), 0, 1)
         
         time_label = QtWidgets.QLabel("Time:")
-        time_label.setStyleSheet("color: palette(mid);")
+        time_label.setObjectName("MutedLabel")
         when_grid.addWidget(time_label, 1, 0)
         when_grid.addWidget(make_selectable_label(format_time(self.redemption.redemption_time)), 1, 1)
         
@@ -2036,32 +2036,32 @@ class RedemptionViewDialog(QtWidgets.QDialog):
         details_grid.setVerticalSpacing(6)
         
         user_label = QtWidgets.QLabel("User:")
-        user_label.setStyleSheet("color: palette(mid);")
+        user_label.setObjectName("MutedLabel")
         details_grid.addWidget(user_label, 0, 0)
         details_grid.addWidget(make_selectable_label(user_name or "—"), 0, 1)
         
         site_label = QtWidgets.QLabel("Site:")
-        site_label.setStyleSheet("color: palette(mid);")
+        site_label.setObjectName("MutedLabel")
         details_grid.addWidget(site_label, 1, 0)
         details_grid.addWidget(make_selectable_label(site_name or "—"), 1, 1)
         
         method_type_label = QtWidgets.QLabel("Method Type:")
-        method_type_label.setStyleSheet("color: palette(mid);")
+        method_type_label.setObjectName("MutedLabel")
         details_grid.addWidget(method_type_label, 2, 0)
         details_grid.addWidget(make_selectable_label(method_type or "—"), 2, 1)
         
         method_label = QtWidgets.QLabel("Method:")
-        method_label.setStyleSheet("color: palette(mid);")
+        method_label.setObjectName("MutedLabel")
         details_grid.addWidget(method_label, 3, 0)
         details_grid.addWidget(make_selectable_label(method_name or "—"), 3, 1)
         
         amount_label = QtWidgets.QLabel("Amount:")
-        amount_label.setStyleSheet("color: palette(mid);")
+        amount_label.setObjectName("MutedLabel")
         details_grid.addWidget(amount_label, 4, 0)
         details_grid.addWidget(make_selectable_label(f"${float(self.redemption.amount):.2f}"), 4, 1)
         
         fees_label = QtWidgets.QLabel("Fees:")
-        fees_label.setStyleSheet("color: palette(mid);")
+        fees_label.setObjectName("MutedLabel")
         details_grid.addWidget(fees_label, 5, 0)
         details_grid.addWidget(make_selectable_label(f"${float(self.redemption.fees):.2f}"), 5, 1)
         
@@ -2084,19 +2084,19 @@ class RedemptionViewDialog(QtWidgets.QDialog):
         processing_grid.setVerticalSpacing(6)
         
         redemption_type_label = QtWidgets.QLabel("Redemption Type:")
-        redemption_type_label.setStyleSheet("color: palette(mid);")
+        redemption_type_label.setObjectName("MutedLabel")
         processing_grid.addWidget(redemption_type_label, 0, 0)
         type_text = "Partial" if self.redemption.more_remaining else "Full"
         processing_grid.addWidget(make_selectable_label(type_text), 0, 1)
         
         receipt_label = QtWidgets.QLabel("Receipt Date:")
-        receipt_label.setStyleSheet("color: palette(mid);")
+        receipt_label.setObjectName("MutedLabel")
         processing_grid.addWidget(receipt_label, 1, 0)
         receipt_text = format_date(self.redemption.receipt_date) if self.redemption.receipt_date else "—"
         processing_grid.addWidget(make_selectable_label(receipt_text), 1, 1)
         
         processed_label = QtWidgets.QLabel("Processed:")
-        processed_label.setStyleSheet("color: palette(mid);")
+        processed_label.setObjectName("MutedLabel")
         processing_grid.addWidget(processed_label, 2, 0)
         processed_text = "Yes" if self.redemption.processed else "No"
         processing_grid.addWidget(make_selectable_label(processed_text), 2, 1)
@@ -2123,7 +2123,10 @@ class RedemptionViewDialog(QtWidgets.QDialog):
             notes_layout.addWidget(notes_display)
         else:
             notes_empty = QtWidgets.QLabel("—")
-            notes_empty.setStyleSheet("color: palette(mid); font-style: italic;")
+            notes_empty.setObjectName("MutedLabel")
+            notes_font = notes_empty.font()
+            notes_font.setItalic(True)
+            notes_empty.setFont(notes_font)
             notes_layout.addWidget(notes_empty)
         
         layout.addWidget(notes_section)

--- a/ui/tabs/sites_tab.py
+++ b/ui/tabs/sites_tab.py
@@ -635,13 +635,13 @@ class SiteViewDialog(QtWidgets.QDialog):
         left_grid.setColumnStretch(1, 1)
         
         name_lbl = QtWidgets.QLabel("Name:")
-        name_lbl.setStyleSheet("color: palette(mid);")
+        name_lbl.setObjectName("MutedLabel")
         name_val = self._make_selectable_label(site.name)
         left_grid.addWidget(name_lbl, 0, 0, QtCore.Qt.AlignRight)
         left_grid.addWidget(name_val, 0, 1)
         
         url_lbl = QtWidgets.QLabel("URL:")
-        url_lbl.setStyleSheet("color: palette(mid);")
+        url_lbl.setObjectName("MutedLabel")
         url_val = self._make_selectable_label(site.url or "—")
         left_grid.addWidget(url_lbl, 1, 0, QtCore.Qt.AlignRight)
         left_grid.addWidget(url_val, 1, 1)
@@ -655,13 +655,13 @@ class SiteViewDialog(QtWidgets.QDialog):
         right_grid.setColumnStretch(1, 1)
         
         status_lbl = QtWidgets.QLabel("Status:")
-        status_lbl.setStyleSheet("color: palette(mid);")
+        status_lbl.setObjectName("MutedLabel")
         status_val = self._make_selectable_label("Active" if site.is_active else "Inactive")
         right_grid.addWidget(status_lbl, 0, 0, QtCore.Qt.AlignRight)
         right_grid.addWidget(status_val, 0, 1)
         
         rate_lbl = QtWidgets.QLabel("SC Rate:")
-        rate_lbl.setStyleSheet("color: palette(mid);")
+        rate_lbl.setObjectName("MutedLabel")
         rate_val = self._make_selectable_label(str(site.sc_rate))
         right_grid.addWidget(rate_lbl, 1, 0, QtCore.Qt.AlignRight)
         right_grid.addWidget(rate_val, 1, 1)
@@ -692,7 +692,10 @@ class SiteViewDialog(QtWidgets.QDialog):
             notes_layout.addWidget(notes_display)
         else:
             notes_empty = QtWidgets.QLabel("—")
-            notes_empty.setStyleSheet("color: palette(mid); font-style: italic;")
+            notes_empty.setObjectName("MutedLabel")
+            notes_font = notes_empty.font()
+            notes_font.setItalic(True)
+            notes_empty.setFont(notes_font)
             notes_layout.addWidget(notes_empty)
         main_layout.addWidget(notes_section)
         

--- a/ui/tabs/unrealized_tab.py
+++ b/ui/tabs/unrealized_tab.py
@@ -582,23 +582,23 @@ class UnrealizedPositionDialog(QtWidgets.QDialog):
         
         # Left column
         site_label = QtWidgets.QLabel("Site:")
-        site_label.setStyleSheet("color: palette(mid);")
+        site_label.setObjectName("MutedLabel")
         header_grid.addWidget(site_label, 0, 0)
         header_grid.addWidget(make_selectable_label(self.position.site_name), 0, 1)
         
         start_date_label = QtWidgets.QLabel("Start Date:")
-        start_date_label.setStyleSheet("color: palette(mid);")
+        start_date_label.setObjectName("MutedLabel")
         header_grid.addWidget(start_date_label, 1, 0)
         header_grid.addWidget(make_selectable_label(self._format_date(self.position.start_date)), 1, 1)
         
         # Right column
         user_label = QtWidgets.QLabel("User:")
-        user_label.setStyleSheet("color: palette(mid);")
+        user_label.setObjectName("MutedLabel")
         header_grid.addWidget(user_label, 0, 2)
         header_grid.addWidget(make_selectable_label(self.position.user_name), 0, 3)
         
         last_activity_label = QtWidgets.QLabel("Last Activity:")
-        last_activity_label.setStyleSheet("color: palette(mid);")
+        last_activity_label.setObjectName("MutedLabel")
         header_grid.addWidget(last_activity_label, 1, 2)
         header_grid.addWidget(make_selectable_label(self._format_date(self.position.last_activity)), 1, 3)
         
@@ -623,7 +623,7 @@ class UnrealizedPositionDialog(QtWidgets.QDialog):
         metrics_grid.setVerticalSpacing(6)
         
         basis_label = QtWidgets.QLabel("Remaining Basis:")
-        basis_label.setStyleSheet("color: palette(mid);")
+        basis_label.setObjectName("MutedLabel")
         metrics_grid.addWidget(basis_label, 0, 0)
         metrics_grid.addWidget(make_selectable_label(self._format_currency(self.position.purchase_basis), align_right=True), 0, 1)
         
@@ -631,7 +631,7 @@ class UnrealizedPositionDialog(QtWidgets.QDialog):
         unrealized_pl = float(self.position.unrealized_pl or 0)
         pl_color = "green" if unrealized_pl >= 0 else "red"
         unrealized_label = QtWidgets.QLabel("Unrealized P/L:")
-        unrealized_label.setStyleSheet("color: palette(mid);")
+        unrealized_label.setObjectName("MutedLabel")
         metrics_grid.addWidget(unrealized_label, 1, 0)
         metrics_grid.addWidget(make_selectable_label(self._format_signed_currency(self.position.unrealized_pl), align_right=True, color=pl_color), 1, 1)
         
@@ -654,12 +654,12 @@ class UnrealizedPositionDialog(QtWidgets.QDialog):
         values_grid.setVerticalSpacing(6)
         
         current_sc_label = QtWidgets.QLabel("Current SC:")
-        current_sc_label.setStyleSheet("color: palette(mid);")
+        current_sc_label.setObjectName("MutedLabel")
         values_grid.addWidget(current_sc_label, 0, 0)
         values_grid.addWidget(make_selectable_label(f"{float(self.position.current_sc):.2f}", align_right=True), 0, 1)
         
         current_value_label = QtWidgets.QLabel("Current Value:")
-        current_value_label.setStyleSheet("color: palette(mid);")
+        current_value_label.setObjectName("MutedLabel")
         values_grid.addWidget(current_value_label, 1, 0)
         values_grid.addWidget(make_selectable_label(self._format_currency(self.position.current_value), align_right=True), 1, 1)
         
@@ -685,7 +685,10 @@ class UnrealizedPositionDialog(QtWidgets.QDialog):
             notes_layout.addWidget(notes_display)
         else:
             notes_empty = QtWidgets.QLabel("—")
-            notes_empty.setStyleSheet("color: palette(mid); font-style: italic;")
+            notes_empty.setObjectName("MutedLabel")
+            notes_font = notes_empty.font()
+            notes_font.setItalic(True)
+            notes_empty.setFont(notes_font)
             notes_layout.addWidget(notes_empty)
         
         layout.addWidget(notes_section)

--- a/ui/tabs/users_tab.py
+++ b/ui/tabs/users_tab.py
@@ -623,13 +623,13 @@ class UserViewDialog(QtWidgets.QDialog):
         left_grid.setColumnStretch(1, 1)
         
         name_lbl = QtWidgets.QLabel("Name:")
-        name_lbl.setStyleSheet("color: palette(mid);")
+        name_lbl.setObjectName("MutedLabel")
         name_val = self._make_selectable_label(user.name)
         left_grid.addWidget(name_lbl, 0, 0, QtCore.Qt.AlignRight)
         left_grid.addWidget(name_val, 0, 1)
         
         email_lbl = QtWidgets.QLabel("Email:")
-        email_lbl.setStyleSheet("color: palette(mid);")
+        email_lbl.setObjectName("MutedLabel")
         email_val = self._make_selectable_label(user.email or "—")
         left_grid.addWidget(email_lbl, 1, 0, QtCore.Qt.AlignRight)
         left_grid.addWidget(email_val, 1, 1)
@@ -643,7 +643,7 @@ class UserViewDialog(QtWidgets.QDialog):
         right_grid.setColumnStretch(1, 1)
         
         status_lbl = QtWidgets.QLabel("Status:")
-        status_lbl.setStyleSheet("color: palette(mid);")
+        status_lbl.setObjectName("MutedLabel")
         status_val = self._make_selectable_label("Active" if user.is_active else "Inactive")
         right_grid.addWidget(status_lbl, 0, 0, QtCore.Qt.AlignRight)
         right_grid.addWidget(status_val, 0, 1)
@@ -674,7 +674,10 @@ class UserViewDialog(QtWidgets.QDialog):
             notes_layout.addWidget(notes_display)
         else:
             notes_empty = QtWidgets.QLabel("—")
-            notes_empty.setStyleSheet("color: palette(mid); font-style: italic;")
+            notes_empty.setObjectName("MutedLabel")
+            notes_font = notes_empty.font()
+            notes_font.setItalic(True)
+            notes_empty.setFont(notes_font)
             notes_layout.addWidget(notes_empty)
         main_layout.addWidget(notes_section)
         

--- a/ui/themes.py
+++ b/ui/themes.py
@@ -120,6 +120,7 @@ class Theme:
             QLabel#InfoField[status="negative"] {{ color: #c0392b; }}
             QLabel#InfoField[status="neutral"] {{ color: {text_muted}; }}
             QLabel#HelperText {{ color: {text_muted}; font-size: 11px; }}
+            QLabel#MutedLabel {{ color: {text_muted}; }}
             QLabel#HelperText[status="match"] {{ color: #2e7d32; }}
             QLabel#HelperText[status="warning"] {{ color: #f57c00; }}
             QLabel#HelperText[status="error"] {{ color: #c0392b; }}


### PR DESCRIPTION
## Summary
- Use theme-managed MutedLabel styling for dialog secondary labels
- Keep italic placeholders while using theme colors for contrast
- Document the styling rule in PROJECT_SPEC and add changelog entry

## Testing
- Not run (UI-only styling change)
