### PR TITLE
Standardize UTC storage with timezone setting

### DIFF
--- a/app_facade.py
+++ b/app_facade.py
@@ -322,8 +322,11 @@ class AppFacade:
         session_date: date,
         session_time: Optional[str],
     ) -> Optional[Tuple[date, str]]:
+        from tools.timezone_utils import get_configured_timezone_name, local_date_time_to_utc, utc_date_time_to_local
+
         ts_time = self._normalize_time(session_time)
-        date_str = session_date.isoformat() if hasattr(session_date, "isoformat") else str(session_date)
+        tz_name = get_configured_timezone_name()
+        date_str, ts_time = local_date_time_to_utc(session_date, ts_time, tz_name)
 
         row = self.db.fetch_one(
             """
@@ -344,7 +347,8 @@ class AppFacade:
         start_date = row["session_date"]
         if isinstance(start_date, str):
             start_date = datetime.strptime(start_date, "%Y-%m-%d").date()
-        return start_date, row["start_time"]
+        start_date, start_time = utc_date_time_to_local(start_date, row["start_time"], tz_name)
+        return start_date, start_time
 
     def _containing_boundary(
         self,
@@ -2079,10 +2083,18 @@ class AppFacade:
             WHERE site_id = ? AND user_id = ?
               AND deleted_at IS NULL
               AND (status IS NULL OR status = 'active')
-              AND (? IS NULL OR purchase_date >= ?)
+              AND (? IS NULL OR (purchase_date > ? OR (purchase_date = ? AND COALESCE(purchase_time, '00:00:00') >= ?)))
             ORDER BY purchase_date ASC, COALESCE(purchase_time,'00:00:00') ASC, id ASC
         """
-        return self.db.fetch_all(query, (site_id, user_id, start_date, start_date))
+        if start_date:
+            from tools.timezone_utils import get_configured_timezone_name, local_date_time_to_utc
+            tz_name = get_configured_timezone_name()
+            start_date_utc, start_time_utc = local_date_time_to_utc(start_date, "00:00:00", tz_name)
+            return self.db.fetch_all(
+                query,
+                (site_id, user_id, start_date_utc, start_date_utc, start_date_utc, start_time_utc),
+            )
+        return self.db.fetch_all(query, (site_id, user_id, None, None, None, None))
 
     def get_unrealized_related_purchases(
         self,
@@ -2113,12 +2125,21 @@ class AppFacade:
               AND CAST(ra.allocated_amount AS REAL) > 0
               AND p.deleted_at IS NULL
               AND (p.status IS NULL OR p.status = 'active')
-              AND (? IS NULL OR r.redemption_date >= ?)
+              AND (? IS NULL OR (r.redemption_date > ? OR (r.redemption_date = ? AND COALESCE(r.redemption_time, '00:00:00') >= ?)))
             ORDER BY p.purchase_date ASC, COALESCE(p.purchase_time,'00:00:00') ASC, p.id ASC
         """
-        purchases = self.db.fetch_all(
-            allocations_since_query, (site_id, user_id, start_date, start_date)
-        )
+        if start_date:
+            from tools.timezone_utils import get_configured_timezone_name, local_date_time_to_utc
+            tz_name = get_configured_timezone_name()
+            start_date_utc, start_time_utc = local_date_time_to_utc(start_date, "00:00:00", tz_name)
+            purchases = self.db.fetch_all(
+                allocations_since_query,
+                (site_id, user_id, start_date_utc, start_date_utc, start_date_utc, start_time_utc),
+            )
+        else:
+            purchases = self.db.fetch_all(
+                allocations_since_query, (site_id, user_id, None, None, None, None)
+            )
         if purchases:
             return purchases
 
@@ -2191,12 +2212,20 @@ class AppFacade:
             LEFT JOIN games g ON gs.game_id = g.id
             WHERE gs.site_id = ? AND gs.user_id = ?
               AND gs.deleted_at IS NULL
-                            AND (? IS NULL OR COALESCE(gs.end_date, gs.session_date) >= ?)
+                            AND (? IS NULL OR (COALESCE(gs.end_date, gs.session_date) > ? OR (COALESCE(gs.end_date, gs.session_date) = ? AND COALESCE(gs.end_time, gs.session_time, '00:00:00') >= ?)))
                         ORDER BY COALESCE(gs.end_date, gs.session_date) DESC,
                                          COALESCE(gs.end_time, gs.session_time, '00:00:00') DESC,
                                          gs.id DESC
         """
-        return self.db.fetch_all(query, (site_id, user_id, start_date, start_date))
+        if start_date:
+            from tools.timezone_utils import get_configured_timezone_name, local_date_time_to_utc
+            tz_name = get_configured_timezone_name()
+            start_date_utc, start_time_utc = local_date_time_to_utc(start_date, "00:00:00", tz_name)
+            return self.db.fetch_all(
+                query,
+                (site_id, user_id, start_date_utc, start_date_utc, start_date_utc, start_time_utc),
+            )
+        return self.db.fetch_all(query, (site_id, user_id, None, None, None, None))
 
     def close_unrealized_position(
         self,

--- a/docs/PROJECT_SPEC.md
+++ b/docs/PROJECT_SPEC.md
@@ -762,6 +762,13 @@ When derived data (FIFO allocations, cost basis, P/L) becomes corrupted, automat
   - Example: `ToolsTab._load_automatic_backup_settings()` blocks spinbox/checkbox signals during load to prevent premature saves
 - **Disk Sync**: Settings.save() uses `flush()` and `fsync()` to force OS buffer writes, preventing data loss on crash
 
+**Time Zone & UTC Storage (Issue #107):**
+- `settings.json` stores `time_zone` (IANA name) and `timezone_storage_migrated` flag.
+- All user-entered timestamps are stored in UTC in the database (purchases, redemptions, sessions, adjustments, expenses, audit log).
+- Repository/services convert UTC → local for display and business logic using the selected `time_zone`.
+- Audit log date filters convert local date ranges to UTC bounds before querying.
+- One-time migration converts existing local timestamps to UTC using the currently selected time zone.
+
 **UI Integration:**
 - Tools tab provides unified interface for all database operations
 - Manual backup: directory picker, "Backup Now" button, status display with file size, last backup timestamp

--- a/docs/archive/2026-02-13-timezone-utc-issue.md
+++ b/docs/archive/2026-02-13-timezone-utc-issue.md
@@ -1,0 +1,34 @@
+# Feature: Standardize Time Handling with User Time Zone
+
+## Problem
+Timestamps are currently mixed between local time (user-entered dates/times) and UTC (e.g., audit_log timestamp via CURRENT_TIMESTAMP). This causes confusing date filtering and inconsistent display.
+
+## Proposal
+Add a user-configurable time zone setting and standardize storage/display:
+- Store all timestamps in UTC at write-time.
+- Display dates/times in the user’s selected time zone.
+- Changing the time zone affects display only; it does not rewrite existing stored UTC values.
+
+## Scope
+- Add Settings option for time zone (IANA TZ, e.g., America/Los_Angeles).
+- Update time parsing/formatting helpers to convert local time ↔ UTC.
+- Apply conversion for all user-entered timestamps (purchases, redemptions, sessions, adjustments, checkpoints, audit logs).
+- Update audit log viewer date filtering to use local display while querying UTC range.
+- Migration: backfill existing stored times to UTC using the *current* user time zone at migration time.
+
+## Acceptance Criteria
+- User can select time zone in Settings and it persists.
+- Creating any record stores UTC timestamps.
+- UI displays local times based on the selected time zone.
+- Changing time zone changes display for all records without mutating stored values.
+- Audit log timestamps and filters align with local display.
+- Migration script converts existing rows once, preserving perceived local times.
+
+## Test Plan
+- Unit tests for conversion helpers (local ↔ UTC).
+- Integration tests: create a record in one TZ, switch TZ, display reflects new TZ without data rewrite.
+- Audit log filter test for date ranges in local time.
+
+## Out of Scope
+- Multi-user or per-record time zones.
+- Historical per-entry time zones beyond the global setting.

--- a/docs/status/CHANGELOG.md
+++ b/docs/status/CHANGELOG.md
@@ -12,6 +12,41 @@ Rules:
 ## 2026-02-13
 
 ```yaml
+id: 2026-02-13-05
+type: feature
+areas: [settings, time, repositories, services, ui]
+summary: "Add time zone setting with UTC storage + local display"
+files_changed:
+  - tools/timezone_utils.py
+  - ui/settings.py
+  - ui/settings_dialog.py
+  - ui/main_window.py
+  - app_facade.py
+  - services/timezone_migration_service.py
+  - services/audit_service.py
+  - services/daily_sessions_service.py
+  - services/notification_rules_service.py
+  - repositories/purchase_repository.py
+  - repositories/redemption_repository.py
+  - repositories/game_session_repository.py
+  - repositories/adjustment_repository.py
+  - repositories/expense_repository.py
+  - ui/audit_log_viewer_dialog.py
+  - tests/unit/test_timezone_utils.py
+  - tests/integration/test_timezone_storage.py
+  - docs/PROJECT_SPEC.md
+```
+
+**Feature: Time Zone + UTC Storage**
+
+- Added a Settings time zone selector and persisted `time_zone`/`timezone_storage_migrated`.
+- User-entered timestamps now store in UTC with local display conversion across UI/views.
+- Audit log filtering/CSV export use local date ranges mapped to UTC bounds.
+- One-time migration converts existing local timestamps to UTC using the current time zone.
+
+---
+
+```yaml
 id: 2026-02-13-01
 type: bugfix
 areas: [repositories, accounting]

--- a/repositories/adjustment_repository.py
+++ b/repositories/adjustment_repository.py
@@ -5,6 +5,12 @@ from typing import Optional, List
 from decimal import Decimal
 from datetime import date, datetime
 from models.adjustment import Adjustment, AdjustmentType
+from tools.timezone_utils import (
+    get_configured_timezone_name,
+    local_date_time_to_utc,
+    local_date_range_to_utc_bounds,
+    utc_date_time_to_local,
+)
 
 
 class AdjustmentRepository:
@@ -39,6 +45,7 @@ class AdjustmentRepository:
             WHERE 1=1
         """
         params = []
+        tz_name = get_configured_timezone_name()
         
         if not include_deleted:
             query += " AND a.deleted_at IS NULL"
@@ -56,12 +63,14 @@ class AdjustmentRepository:
             params.append(adjustment_type.value)
         
         if start_date:
-            query += " AND a.effective_date >= ?"
-            params.append(start_date.isoformat() if hasattr(start_date, 'isoformat') else start_date)
+            start_utc, _ = local_date_range_to_utc_bounds(start_date, start_date, tz_name)
+            query += " AND (a.effective_date > ? OR (a.effective_date = ? AND COALESCE(a.effective_time, '00:00:00') >= ?))"
+            params.extend([start_utc[0], start_utc[0], start_utc[1]])
         
         if end_date:
-            query += " AND a.effective_date <= ?"
-            params.append(end_date.isoformat() if hasattr(end_date, 'isoformat') else end_date)
+            _, end_utc = local_date_range_to_utc_bounds(end_date, end_date, tz_name)
+            query += " AND (a.effective_date < ? OR (a.effective_date = ? AND COALESCE(a.effective_time, '00:00:00') <= ?))"
+            params.extend([end_utc[0], end_utc[0], end_utc[1]])
         
         query += " ORDER BY a.effective_date DESC, a.effective_time DESC"
         
@@ -115,6 +124,12 @@ class AdjustmentRepository:
         cutoff_time: str = "23:59:59"
     ) -> List[Adjustment]:
         """Get active balance checkpoint adjustments before a cutoff datetime"""
+        tz_name = get_configured_timezone_name()
+        cutoff_date_str, cutoff_time_str = local_date_time_to_utc(
+            cutoff_date,
+            cutoff_time,
+            tz_name,
+        )
         query = """
             SELECT * FROM account_adjustments 
             WHERE user_id = ? 
@@ -133,9 +148,9 @@ class AdjustmentRepository:
                 user_id,
                 site_id,
                 AdjustmentType.BALANCE_CHECKPOINT_CORRECTION.value,
-                cutoff_date.isoformat() if hasattr(cutoff_date, 'isoformat') else cutoff_date,
-                cutoff_date.isoformat() if hasattr(cutoff_date, 'isoformat') else cutoff_date,
-                cutoff_time
+                cutoff_date_str,
+                cutoff_date_str,
+                cutoff_time_str,
             )
         )
         return [self._row_to_model(row) for row in rows]
@@ -163,7 +178,12 @@ class AdjustmentRepository:
               )
             ORDER BY effective_date ASC, effective_time ASC
         """
-        cutoff_date_str = cutoff_date.isoformat() if hasattr(cutoff_date, "isoformat") else cutoff_date
+        tz_name = get_configured_timezone_name()
+        cutoff_date_str, cutoff_time_str = local_date_time_to_utc(
+            cutoff_date,
+            cutoff_time,
+            tz_name,
+        )
         rows = self.db.fetch_all(
             query,
             (
@@ -172,7 +192,7 @@ class AdjustmentRepository:
                 AdjustmentType.BALANCE_CHECKPOINT_CORRECTION.value,
                 cutoff_date_str,
                 cutoff_date_str,
-                cutoff_time,
+                cutoff_time_str,
             ),
         )
         return [self._row_to_model(row) for row in rows]
@@ -201,16 +221,25 @@ class AdjustmentRepository:
               AND deleted_at IS NULL
         """
         params: list = [user_id, site_id]
+        tz_name = get_configured_timezone_name()
 
         if start_date is not None:
-            start_date_str = start_date.isoformat() if hasattr(start_date, "isoformat") else start_date
+            start_date_str, start_time_str = local_date_time_to_utc(
+                start_date,
+                start_time or "00:00:00",
+                tz_name,
+            )
             query += " AND (effective_date > ? OR (effective_date = ? AND effective_time >= ?))"
-            params.extend([start_date_str, start_date_str, start_time or "00:00:00"])
+            params.extend([start_date_str, start_date_str, start_time_str])
 
         if end_date is not None:
-            end_date_str = end_date.isoformat() if hasattr(end_date, "isoformat") else end_date
+            end_date_str, end_time_str = local_date_time_to_utc(
+                end_date,
+                end_time or "23:59:59",
+                tz_name,
+            )
             query += " AND (effective_date < ? OR (effective_date = ? AND effective_time <= ?))"
-            params.extend([end_date_str, end_date_str, end_time or "23:59:59"])
+            params.extend([end_date_str, end_date_str, end_time_str])
 
         query += " ORDER BY effective_date ASC, effective_time ASC"
 
@@ -239,6 +268,12 @@ class AdjustmentRepository:
     
     def create(self, adjustment: Adjustment, *, auto_commit: bool = True) -> Adjustment:
         """Create a new adjustment"""
+        tz_name = get_configured_timezone_name()
+        utc_date, utc_time = local_date_time_to_utc(
+            adjustment.effective_date,
+            adjustment.effective_time or "00:00:00",
+            tz_name,
+        )
         query = """
             INSERT INTO account_adjustments (
                 user_id, site_id, effective_date, effective_time, type,
@@ -249,8 +284,8 @@ class AdjustmentRepository:
         params = (
             adjustment.user_id,
             adjustment.site_id,
-            adjustment.effective_date.isoformat() if hasattr(adjustment.effective_date, 'isoformat') else adjustment.effective_date,
-            adjustment.effective_time or "00:00:00",
+            utc_date,
+            utc_time,
             adjustment.type.value if isinstance(adjustment.type, AdjustmentType) else adjustment.type,
             str(adjustment.delta_basis_usd),
             str(adjustment.checkpoint_total_sc),
@@ -318,9 +353,12 @@ class AdjustmentRepository:
         - Only counts non-deleted rows.
         - Uses each table's primary timestamp fields.
         """
-
-        date_str = effective_date.isoformat() if hasattr(effective_date, "isoformat") else str(effective_date)
-        time_str = effective_time or "00:00:00"
+        tz_name = get_configured_timezone_name()
+        date_str, time_str = local_date_time_to_utc(
+            effective_date,
+            effective_time or "00:00:00",
+            tz_name,
+        )
 
         def _count(query: str, params: tuple) -> int:
             row = self.db.fetch_one(query, params)
@@ -453,13 +491,20 @@ class AdjustmentRepository:
         effective_date = row['effective_date']
         if isinstance(effective_date, str):
             effective_date = date.fromisoformat(effective_date)
+
+        tz_name = get_configured_timezone_name()
+        effective_date, effective_time = utc_date_time_to_local(
+            effective_date,
+            row['effective_time'] or "00:00:00",
+            tz_name,
+        )
         
         return Adjustment(
             id=row['id'],
             user_id=row['user_id'],
             site_id=row['site_id'],
             effective_date=effective_date,
-            effective_time=row['effective_time'] or "00:00:00",
+            effective_time=effective_time or "00:00:00",
             type=AdjustmentType(row['type']),
             delta_basis_usd=Decimal(row['delta_basis_usd']),
             checkpoint_total_sc=Decimal(row['checkpoint_total_sc']),

--- a/repositories/expense_repository.py
+++ b/repositories/expense_repository.py
@@ -5,6 +5,12 @@ from typing import List, Optional
 from datetime import date, datetime
 from decimal import Decimal
 from models.expense import Expense
+from tools.timezone_utils import (
+    get_configured_timezone_name,
+    local_date_time_to_utc,
+    local_date_range_to_utc_bounds,
+    utc_date_time_to_local,
+)
 
 
 class ExpenseRepository:
@@ -31,25 +37,34 @@ class ExpenseRepository:
             WHERE 1=1
         """
         params = []
+        tz_name = get_configured_timezone_name()
         if start_date:
-            query += " AND e.expense_date >= ?"
-            params.append(start_date.isoformat() if hasattr(start_date, "isoformat") else start_date)
+            start_utc, _ = local_date_range_to_utc_bounds(start_date, start_date, tz_name)
+            query += " AND (e.expense_date > ? OR (e.expense_date = ? AND COALESCE(e.expense_time, '00:00:00') >= ?))"
+            params.extend([start_utc[0], start_utc[0], start_utc[1]])
         if end_date:
-            query += " AND e.expense_date <= ?"
-            params.append(end_date.isoformat() if hasattr(end_date, "isoformat") else end_date)
+            _, end_utc = local_date_range_to_utc_bounds(end_date, end_date, tz_name)
+            query += " AND (e.expense_date < ? OR (e.expense_date = ? AND COALESCE(e.expense_time, '00:00:00') <= ?))"
+            params.extend([end_utc[0], end_utc[0], end_utc[1]])
         query += " ORDER BY e.expense_date DESC, e.id DESC"
         rows = self.db.fetch_all(query, tuple(params))
         return [self._row_to_model(row) for row in rows]
 
     def create(self, expense: Expense) -> Expense:
+        tz_name = get_configured_timezone_name()
+        utc_date, utc_time = local_date_time_to_utc(
+            expense.expense_date,
+            expense.expense_time,
+            tz_name,
+        )
         expense_id = self.db.execute(
             """
             INSERT INTO expenses (expense_date, expense_time, amount, vendor, description, category, user_id)
             VALUES (?, ?, ?, ?, ?, ?, ?)
             """,
             (
-                expense.expense_date.isoformat(),
-                expense.expense_time,
+                utc_date,
+                utc_time,
                 str(expense.amount),
                 expense.vendor,
                 expense.description,
@@ -63,6 +78,12 @@ class ExpenseRepository:
     def update(self, expense: Expense) -> Expense:
         if not expense.id:
             raise ValueError("Cannot update expense without ID")
+        tz_name = get_configured_timezone_name()
+        utc_date, utc_time = local_date_time_to_utc(
+            expense.expense_date,
+            expense.expense_time,
+            tz_name,
+        )
         self.db.execute(
             """
             UPDATE expenses
@@ -71,8 +92,8 @@ class ExpenseRepository:
             WHERE id = ?
             """,
             (
-                expense.expense_date.isoformat(),
-                expense.expense_time,
+                utc_date,
+                utc_time,
                 str(expense.amount),
                 expense.vendor,
                 expense.description,
@@ -90,6 +111,12 @@ class ExpenseRepository:
         expense_date = row["expense_date"]
         if isinstance(expense_date, str):
             expense_date = datetime.strptime(expense_date, "%Y-%m-%d").date()
+        tz_name = get_configured_timezone_name()
+        expense_date, expense_time = utc_date_time_to_local(
+            expense_date,
+            row["expense_time"] if "expense_time" in row.keys() else None,
+            tz_name,
+        )
         expense = Expense(
             id=row["id"],
             expense_date=expense_date,
@@ -98,7 +125,7 @@ class ExpenseRepository:
             description=row["description"] if "description" in row.keys() else None,
             category=row["category"] if "category" in row.keys() else None,
             user_id=row["user_id"] if "user_id" in row.keys() else None,
-            expense_time=row["expense_time"] if "expense_time" in row.keys() else None,
+            expense_time=expense_time,
             created_at=row["created_at"] if "created_at" in row.keys() else None,
             updated_at=row["updated_at"] if "updated_at" in row.keys() else None,
         )

--- a/repositories/game_session_repository.py
+++ b/repositories/game_session_repository.py
@@ -5,6 +5,11 @@ from typing import List, Optional
 from datetime import datetime
 from decimal import Decimal
 from models.game_session import GameSession
+from tools.timezone_utils import (
+    get_configured_timezone_name,
+    local_date_time_to_utc,
+    utc_date_time_to_local,
+)
 
 
 class GameSessionRepository:
@@ -25,16 +30,39 @@ class GameSessionRepository:
             # If value exists but is None, use default
             return val if val is not None else default
         
+        session_date = row["session_date"]
+        if isinstance(session_date, str):
+            session_date = datetime.strptime(session_date, "%Y-%m-%d").date()
+        end_date = row_value("end_date")
+        if isinstance(end_date, str):
+            end_date = datetime.strptime(end_date, "%Y-%m-%d").date()
+
+        tz_name = get_configured_timezone_name()
+        session_date, session_time = utc_date_time_to_local(
+            session_date,
+            row["session_time"] or "00:00:00",
+            tz_name,
+        )
+        end_time_value = row_value("end_time")
+        end_date_local = None
+        end_time_local = None
+        if end_date:
+            end_date_local, end_time_local = utc_date_time_to_local(
+                end_date,
+                end_time_value or "00:00:00",
+                tz_name,
+            )
+
         return GameSession(
             id=row["id"],
             user_id=row["user_id"],
             site_id=row["site_id"],
             game_id=row["game_id"],
             game_type_id=row_value("game_type_id"),
-            session_date=row["session_date"],
-            end_date=row_value("end_date"),
-            end_time=row_value("end_time"),
-            session_time=row["session_time"] or "00:00:00",
+            session_date=session_date,
+            end_date=end_date_local,
+            end_time=end_time_local,
+            session_time=session_time or "00:00:00",
             starting_balance=Decimal(row["starting_balance"]),
             ending_balance=safe_decimal(row_value("ending_balance"), "0.00"),
             starting_redeemable=safe_decimal(row_value("starting_redeemable"), "0.00"),
@@ -132,6 +160,20 @@ class GameSessionRepository:
     
     def create(self, session: GameSession) -> GameSession:
         """Create a new session"""
+        tz_name = get_configured_timezone_name()
+        utc_session_date, utc_session_time = local_date_time_to_utc(
+            session.session_date,
+            session.session_time,
+            tz_name,
+        )
+        utc_end_date = None
+        utc_end_time = None
+        if session.end_date:
+            utc_end_date, utc_end_time = local_date_time_to_utc(
+                session.end_date,
+                session.end_time,
+                tz_name,
+            )
         query = """
             INSERT INTO game_sessions (
                 user_id, site_id, game_id, game_type_id, session_date, session_time, end_date, end_time,
@@ -150,9 +192,9 @@ class GameSessionRepository:
             query,
             (
                 session.user_id, session.site_id, session.game_id, session.game_type_id,
-                session.session_date.isoformat(), session.session_time,
-                session.end_date.isoformat() if session.end_date else None,
-                session.end_time,
+                utc_session_date, utc_session_time,
+                utc_end_date,
+                utc_end_time,
                 str(session.starting_balance), str(session.ending_balance),
                 str(session.starting_redeemable), str(session.ending_redeemable),
                 str(session.purchases_during), str(session.redemptions_during),
@@ -173,6 +215,20 @@ class GameSessionRepository:
     
     def update(self, session: GameSession) -> GameSession:
         """Update an existing session"""
+        tz_name = get_configured_timezone_name()
+        utc_session_date, utc_session_time = local_date_time_to_utc(
+            session.session_date,
+            session.session_time,
+            tz_name,
+        )
+        utc_end_date = None
+        utc_end_time = None
+        if session.end_date:
+            utc_end_date, utc_end_time = local_date_time_to_utc(
+                session.end_date,
+                session.end_time,
+                tz_name,
+            )
         query = """
             UPDATE game_sessions SET
                 user_id = ?, site_id = ?, game_id = ?, game_type_id = ?, session_date = ?, session_time = ?, end_date = ?, end_time = ?,
@@ -191,9 +247,9 @@ class GameSessionRepository:
             query,
             (
                 session.user_id, session.site_id, session.game_id, session.game_type_id,
-                session.session_date.isoformat(), session.session_time,
-                session.end_date.isoformat() if session.end_date else None,
-                session.end_time,
+                utc_session_date, utc_session_time,
+                utc_end_date,
+                utc_end_time,
                 str(session.starting_balance), str(session.ending_balance),
                 str(session.starting_redeemable), str(session.ending_redeemable),
                 str(session.purchases_during), str(session.redemptions_during),

--- a/repositories/purchase_repository.py
+++ b/repositories/purchase_repository.py
@@ -4,6 +4,12 @@ Purchase repository - Data access for Purchase entity
 from typing import Optional, List
 from decimal import Decimal
 from datetime import date, datetime
+from tools.timezone_utils import (
+    get_configured_timezone_name,
+    local_date_time_to_utc,
+    local_date_range_to_utc_bounds,
+    utc_date_time_to_local,
+)
 from models.purchase import Purchase
 
 
@@ -33,14 +39,17 @@ class PurchaseRepository:
             WHERE p.deleted_at IS NULL
         """
         params = []
+        tz_name = get_configured_timezone_name()
         
         if start_date:
-            query += " AND p.purchase_date >= ?"
-            params.append(start_date.isoformat() if hasattr(start_date, 'isoformat') else start_date)
+            start_utc, end_utc = local_date_range_to_utc_bounds(start_date, start_date, tz_name)
+            query += " AND (p.purchase_date > ? OR (p.purchase_date = ? AND COALESCE(p.purchase_time, '00:00:00') >= ?))"
+            params.extend([start_utc[0], start_utc[0], start_utc[1]])
         
         if end_date:
-            query += " AND p.purchase_date <= ?"
-            params.append(end_date.isoformat() if hasattr(end_date, 'isoformat') else end_date)
+            start_utc, end_utc = local_date_range_to_utc_bounds(end_date, end_date, tz_name)
+            query += " AND (p.purchase_date < ? OR (p.purchase_date = ? AND COALESCE(p.purchase_time, '00:00:00') <= ?))"
+            params.extend([end_utc[0], end_utc[0], end_utc[1]])
         
         query += " ORDER BY p.purchase_date DESC, p.purchase_time DESC"
         
@@ -100,6 +109,9 @@ class PurchaseRepository:
         if not redemption_time:
             redemption_time = "23:59:59"
 
+        tz_name = get_configured_timezone_name()
+        redemption_date, redemption_time = local_date_time_to_utc(redemption_date, redemption_time, tz_name)
+
         query = """
             SELECT * FROM purchases
             WHERE user_id = ? AND site_id = ? 
@@ -119,6 +131,12 @@ class PurchaseRepository:
     
     def create(self, purchase: Purchase) -> Purchase:
         """Create new purchase"""
+        tz_name = get_configured_timezone_name()
+        utc_date, utc_time = local_date_time_to_utc(
+            purchase.purchase_date,
+            purchase.purchase_time,
+            tz_name,
+        )
         query = """
             INSERT INTO purchases 
             (user_id, site_id, amount, sc_received, starting_sc_balance, cashback_earned,
@@ -133,8 +151,8 @@ class PurchaseRepository:
             str(purchase.starting_sc_balance),
             str(purchase.cashback_earned),
             1 if purchase.cashback_is_manual else 0,
-            purchase.purchase_date.isoformat(),
-            purchase.purchase_time,
+            utc_date,
+            utc_time,
             purchase.card_id,
             str(purchase.remaining_amount),
             purchase.notes
@@ -146,6 +164,13 @@ class PurchaseRepository:
         """Update existing purchase"""
         if not purchase.id:
             raise ValueError("Cannot update purchase without ID")
+
+        tz_name = get_configured_timezone_name()
+        utc_date, utc_time = local_date_time_to_utc(
+            purchase.purchase_date,
+            purchase.purchase_time,
+            tz_name,
+        )
         
         query = """
             UPDATE purchases
@@ -162,8 +187,8 @@ class PurchaseRepository:
             str(purchase.starting_sc_balance),
             str(purchase.cashback_earned),
             1 if purchase.cashback_is_manual else 0,
-            purchase.purchase_date.isoformat(),
-            purchase.purchase_time,
+            utc_date,
+            utc_time,
             purchase.card_id,
             str(purchase.remaining_amount),
             purchase.notes,
@@ -187,6 +212,13 @@ class PurchaseRepository:
         purchase_date = row['purchase_date']
         if isinstance(purchase_date, str):
             purchase_date = datetime.strptime(purchase_date, "%Y-%m-%d").date()
+
+        tz_name = get_configured_timezone_name()
+        purchase_date, purchase_time = utc_date_time_to_local(
+            purchase_date,
+            row.get('purchase_time'),
+            tz_name,
+        )
         
         purchase = Purchase(
             id=row['id'],
@@ -198,7 +230,7 @@ class PurchaseRepository:
             cashback_earned=Decimal(str(row.get('cashback_earned', '0.00'))),
             cashback_is_manual=bool(row.get('cashback_is_manual', 0)),
             purchase_date=purchase_date,
-            purchase_time=row.get('purchase_time'),
+            purchase_time=purchase_time,
             card_id=row.get('card_id'),
             remaining_amount=Decimal(str(row['remaining_amount'])),
             status=row.get('status'),  # 'active', 'dormant', or NULL

--- a/repositories/redemption_repository.py
+++ b/repositories/redemption_repository.py
@@ -4,6 +4,12 @@ Redemption repository - Data access for Redemption entity
 from typing import Optional, List
 from decimal import Decimal
 from datetime import date, datetime
+from tools.timezone_utils import (
+    get_configured_timezone_name,
+    local_date_time_to_utc,
+    local_date_range_to_utc_bounds,
+    utc_date_time_to_local,
+)
 from models.redemption import Redemption
 
 
@@ -52,14 +58,17 @@ class RedemptionRepository:
             WHERE r.deleted_at IS NULL
         """
         params = []
+        tz_name = get_configured_timezone_name()
         
         if start_date:
-            query += " AND r.redemption_date >= ?"
-            params.append(start_date)
+            start_utc, _ = local_date_range_to_utc_bounds(start_date, start_date, tz_name)
+            query += " AND (r.redemption_date > ? OR (r.redemption_date = ? AND COALESCE(r.redemption_time, '00:00:00') >= ?))"
+            params.extend([start_utc[0], start_utc[0], start_utc[1]])
         
         if end_date:
-            query += " AND r.redemption_date <= ?"
-            params.append(end_date)
+            _, end_utc = local_date_range_to_utc_bounds(end_date, end_date, tz_name)
+            query += " AND (r.redemption_date < ? OR (r.redemption_date = ? AND COALESCE(r.redemption_time, '00:00:00') <= ?))"
+            params.extend([end_utc[0], end_utc[0], end_utc[1]])
         
         query += " ORDER BY r.redemption_date DESC, r.redemption_time DESC"
         
@@ -113,6 +122,12 @@ class RedemptionRepository:
     
     def create(self, redemption: Redemption) -> Redemption:
         """Create new redemption"""
+        tz_name = get_configured_timezone_name()
+        utc_date, utc_time = local_date_time_to_utc(
+            redemption.redemption_date,
+            redemption.redemption_time,
+            tz_name,
+        )
         query = """
             INSERT INTO redemptions 
             (user_id, site_id, amount, fees, redemption_date, redemption_time, 
@@ -124,8 +139,8 @@ class RedemptionRepository:
             redemption.site_id,
             str(redemption.amount),
             str(redemption.fees),
-            redemption.redemption_date.isoformat(),
-            redemption.redemption_time,
+            utc_date,
+            utc_time,
             redemption.redemption_method_id,
             1 if redemption.is_free_sc else 0,
             redemption.receipt_date.isoformat() if redemption.receipt_date else None,
@@ -140,6 +155,13 @@ class RedemptionRepository:
         """Update existing redemption"""
         if not redemption.id:
             raise ValueError("Cannot update redemption without ID")
+
+        tz_name = get_configured_timezone_name()
+        utc_date, utc_time = local_date_time_to_utc(
+            redemption.redemption_date,
+            redemption.redemption_time,
+            tz_name,
+        )
         
         query = """
             UPDATE redemptions
@@ -154,8 +176,8 @@ class RedemptionRepository:
             redemption.site_id,
             str(redemption.amount),
             str(redemption.fees),
-            redemption.redemption_date.isoformat(),
-            redemption.redemption_time,
+            utc_date,
+            utc_time,
             redemption.redemption_method_id,
             1 if redemption.is_free_sc else 0,
             redemption.receipt_date.isoformat() if redemption.receipt_date else None,
@@ -182,6 +204,13 @@ class RedemptionRepository:
         redemption_date = row['redemption_date']
         if isinstance(redemption_date, str):
             redemption_date = datetime.strptime(redemption_date, "%Y-%m-%d").date()
+
+        tz_name = get_configured_timezone_name()
+        redemption_date, redemption_time = utc_date_time_to_local(
+            redemption_date,
+            row['redemption_time'] if 'redemption_time' in row.keys() else None,
+            tz_name,
+        )
         
         redemption = Redemption(
             id=row['id'],
@@ -192,7 +221,7 @@ class RedemptionRepository:
             redemption_date=redemption_date,
             cost_basis=Decimal(str(row['cost_basis'])) if 'cost_basis' in row.keys() and row['cost_basis'] is not None else None,
             taxable_profit=Decimal(str(row['taxable_profit'])) if 'taxable_profit' in row.keys() and row['taxable_profit'] is not None else None,
-            redemption_time=row['redemption_time'] if 'redemption_time' in row.keys() else None,
+            redemption_time=redemption_time,
             redemption_method_id=row['redemption_method_id'] if 'redemption_method_id' in row.keys() else None,
             receipt_date=row['receipt_date'] if 'receipt_date' in row.keys() else None,
             processed=bool(row['processed']) if 'processed' in row.keys() else False,

--- a/services/audit_service.py
+++ b/services/audit_service.py
@@ -364,13 +364,19 @@ class AuditService:
         
         if start_date:
             if isinstance(start_date, date):
-                query += " AND DATE(timestamp) >= ?"
-                params.append(start_date.isoformat())
+                from tools.timezone_utils import get_configured_timezone_name, local_date_range_to_utc_bounds
+                tz_name = get_configured_timezone_name()
+                start_utc, _ = local_date_range_to_utc_bounds(start_date, start_date, tz_name)
+                query += " AND timestamp >= ?"
+                params.append(f"{start_utc[0]} {start_utc[1]}")
         
         if end_date:
             if isinstance(end_date, date):
-                query += " AND DATE(timestamp) <= ?"
-                params.append(end_date.isoformat())
+                from tools.timezone_utils import get_configured_timezone_name, local_date_range_to_utc_bounds
+                tz_name = get_configured_timezone_name()
+                _, end_utc = local_date_range_to_utc_bounds(end_date, end_date, tz_name)
+                query += " AND timestamp <= ?"
+                params.append(f"{end_utc[0]} {end_utc[1]}")
         
         query += " ORDER BY timestamp DESC LIMIT ?"
         params.append(limit)
@@ -516,13 +522,19 @@ class AuditService:
         if start_date:
             # Filter by timestamp (audit_log.timestamp is a TEXT field in ISO format)
             if isinstance(start_date, date):
-                query += " AND DATE(timestamp) >= ?"
-                params.append(start_date.isoformat())
+                from tools.timezone_utils import get_configured_timezone_name, local_date_range_to_utc_bounds
+                tz_name = get_configured_timezone_name()
+                start_utc, _ = local_date_range_to_utc_bounds(start_date, start_date, tz_name)
+                query += " AND timestamp >= ?"
+                params.append(f"{start_utc[0]} {start_utc[1]}")
         
         if end_date:
             if isinstance(end_date, date):
-                query += " AND DATE(timestamp) <= ?"
-                params.append(end_date.isoformat())
+                from tools.timezone_utils import get_configured_timezone_name, local_date_range_to_utc_bounds
+                tz_name = get_configured_timezone_name()
+                _, end_utc = local_date_range_to_utc_bounds(end_date, end_date, tz_name)
+                query += " AND timestamp <= ?"
+                params.append(f"{end_utc[0]} {end_utc[1]}")
         
         query += " ORDER BY id ASC"
         
@@ -538,9 +550,18 @@ class AuditService:
             writer = csv.DictWriter(f, fieldnames=fieldnames)
             writer.writeheader()
             
+            from tools.timezone_utils import get_configured_timezone_name, utc_timestamp_to_local
+            tz_name = get_configured_timezone_name()
             for row in rows:
                 # Convert dict to plain dict (in case it's a sqlite3.Row)
                 row_dict = dict(row)
+                timestamp = row_dict.get("timestamp")
+                if timestamp:
+                    try:
+                        local_dt = utc_timestamp_to_local(str(timestamp), tz_name)
+                        row_dict["timestamp"] = local_dt.strftime("%Y-%m-%d %H:%M:%S")
+                    except Exception:
+                        pass
                 writer.writerow(row_dict)
         
         return len(rows)

--- a/services/daily_sessions_service.py
+++ b/services/daily_sessions_service.py
@@ -70,29 +70,37 @@ class DailySessionsService:
                 params.extend(sites)
 
         start_date, end_date = active_date_filter
-        if start_date and end_date:
-            query += " AND COALESCE(gs.end_date, gs.session_date) BETWEEN ? AND ?"
-            params.extend([
-                start_date.strftime("%Y-%m-%d"),
-                end_date.strftime("%Y-%m-%d"),
-            ])
-        elif start_date:
-            query += " AND COALESCE(gs.end_date, gs.session_date) >= ?"
-            params.append(start_date.strftime("%Y-%m-%d"))
-        elif end_date:
-            query += " AND COALESCE(gs.end_date, gs.session_date) <= ?"
-            params.append(end_date.strftime("%Y-%m-%d"))
-        else:
-            current_year_start = f"{date_type.today().year}-01-01"
-            current_year_end = date_type.today().strftime("%Y-%m-%d")
-            query += " AND COALESCE(gs.end_date, gs.session_date) BETWEEN ? AND ?"
-            params.extend([current_year_start, current_year_end])
+        from tools.timezone_utils import get_configured_timezone_name, local_date_range_to_utc_bounds
+        tz_name = get_configured_timezone_name()
+
+        if not start_date and not end_date:
+            start_date = date_type(date_type.today().year, 1, 1)
+            end_date = date_type.today()
+
+        if start_date:
+            start_utc, _ = local_date_range_to_utc_bounds(start_date, start_date, tz_name)
+            query += " AND (COALESCE(gs.end_date, gs.session_date) > ? OR (COALESCE(gs.end_date, gs.session_date) = ? AND COALESCE(gs.end_time, gs.session_time, '00:00:00') >= ?))"
+            params.extend([start_utc[0], start_utc[0], start_utc[1]])
+
+        if end_date:
+            _, end_utc = local_date_range_to_utc_bounds(end_date, end_date, tz_name)
+            query += " AND (COALESCE(gs.end_date, gs.session_date) < ? OR (COALESCE(gs.end_date, gs.session_date) = ? AND COALESCE(gs.end_time, gs.session_time, '00:00:00') <= ?))"
+            params.extend([end_utc[0], end_utc[0], end_utc[1]])
 
         query += " ORDER BY gs.session_date DESC, u.name, s.name, gs.session_time"
         rows = self.db.fetch_all(query, tuple(params))
 
         sessions: List[Dict] = []
+        from tools.timezone_utils import utc_date_time_to_local
         for row in rows:
+            session_date = row["session_date"]
+            start_time = row["start_time"] or "00:00:00"
+            session_date, start_time = utc_date_time_to_local(session_date, start_time, tz_name)
+
+            end_date = row["end_date"]
+            end_time = row["end_time"] or ""
+            if end_date:
+                end_date, end_time = utc_date_time_to_local(end_date, end_time or "00:00:00", tz_name)
             delta_total = float(row["delta_total"] or 0.0)
             delta_redeem = row["delta_redeem"]
             if delta_redeem is None:
@@ -120,7 +128,7 @@ class DailySessionsService:
             search_blob = " ".join(
                 str(value).lower()
                 for value in (
-                    row["session_date"],
+                    session_date,
                     row["user_name"],
                     row["site_name"],
                     game_type,
@@ -141,7 +149,7 @@ class DailySessionsService:
             sessions.append(
                 {
                     "id": row["id"],
-                    "session_date": row["session_date"],
+                    "session_date": session_date,
                     "user_id": row["user_id"],
                     "user_name": row["user_name"],
                     "site_id": row["site_id"],
@@ -153,9 +161,9 @@ class DailySessionsService:
                     "end_total": end_total,
                     "start_redeem": start_redeem,
                     "end_redeem": end_redeem,
-                    "start_time": row["start_time"] or "",
-                    "end_date": row["end_date"],
-                    "end_time": row["end_time"] or "",
+                    "start_time": start_time or "",
+                    "end_date": end_date,
+                    "end_time": end_time or "",
                     "delta_total": delta_total,
                     "delta_redeem": delta_redeem,
                     "basis_consumed": basis_consumed,

--- a/services/notification_rules_service.py
+++ b/services/notification_rules_service.py
@@ -128,20 +128,26 @@ class NotificationRulesService:
         
         # Query redemptions where receipt_date is NULL and redemption_date is > threshold days ago
         threshold_date = (datetime.now() - timedelta(days=threshold_days)).date()
+        from tools.timezone_utils import get_configured_timezone_name, local_date_time_to_utc, utc_date_time_to_local
+        tz_name = get_configured_timezone_name()
+        cutoff_date, cutoff_time = local_date_time_to_utc(threshold_date, "23:59:59", tz_name)
         
         query = """
-            SELECT r.id, r.redemption_date, r.amount, r.receipt_date,
+            SELECT r.id, r.redemption_date, r.redemption_time, r.amount, r.receipt_date,
                    u.name as user_name, s.name as site_name
             FROM redemptions r
             JOIN users u ON r.user_id = u.id
             JOIN sites s ON r.site_id = s.id
             WHERE r.receipt_date IS NULL
-              AND r.redemption_date <= ?
+                            AND (
+                                        r.redemption_date < ?
+                                        OR (r.redemption_date = ? AND COALESCE(r.redemption_time, '00:00:00') <= ?)
+                                    )
             ORDER BY r.redemption_date ASC
         """
         
         try:
-            pending_redemptions = self.db.fetch_all(query, (threshold_date.isoformat(),))
+            pending_redemptions = self.db.fetch_all(query, (cutoff_date, cutoff_date, cutoff_time))
             
             # Track which redemption notifications should exist
             active_redemption_ids = set()
@@ -149,6 +155,7 @@ class NotificationRulesService:
             for row in pending_redemptions:
                 redemption_id = row['id']
                 redemption_date_str = row['redemption_date']
+                redemption_time_str = row['redemption_time'] if 'redemption_time' in row.keys() else None
                 amount = float(row['amount'])
                 user_name = row['user_name']
                 site_name = row['site_name']
@@ -159,6 +166,12 @@ class NotificationRulesService:
                         redemption_date = datetime.strptime(redemption_date_str, "%Y-%m-%d").date()
                     else:
                         redemption_date = redemption_date_str
+
+                    redemption_date, _ = utc_date_time_to_local(
+                        redemption_date,
+                        redemption_time_str or "00:00:00",
+                        tz_name,
+                    )
                     
                     days_pending = (date.today() - redemption_date).days
                     

--- a/services/timezone_migration_service.py
+++ b/services/timezone_migration_service.py
@@ -1,0 +1,139 @@
+"""Timezone migration service for UTC storage."""
+from __future__ import annotations
+
+from typing import Dict
+
+from repositories.database import DatabaseManager
+from tools.timezone_utils import get_configured_timezone_name, local_date_time_to_utc
+
+
+class TimezoneMigrationService:
+    """Migrate existing local timestamps to UTC storage once."""
+
+    def __init__(self, db: DatabaseManager, settings):
+        self.db = db
+        self.settings = settings
+
+    def migrate_local_timestamps_to_utc(self) -> Dict[str, int]:
+        """Convert existing local date/time fields to UTC in-place.
+
+        Returns a dict with row counts per table.
+        """
+        if self.settings.get("timezone_storage_migrated", False):
+            return {}
+
+        tz_name = get_configured_timezone_name(self.settings)
+        counts = {
+            "purchases": 0,
+            "redemptions": 0,
+            "expenses": 0,
+            "game_sessions": 0,
+            "account_adjustments": 0,
+        }
+
+        with self.db.transaction():
+            counts["purchases"] = self._migrate_table(
+                table="purchases",
+                id_column="id",
+                date_column="purchase_date",
+                time_column="purchase_time",
+                tz_name=tz_name,
+            )
+            counts["redemptions"] = self._migrate_table(
+                table="redemptions",
+                id_column="id",
+                date_column="redemption_date",
+                time_column="redemption_time",
+                tz_name=tz_name,
+            )
+            counts["expenses"] = self._migrate_table(
+                table="expenses",
+                id_column="id",
+                date_column="expense_date",
+                time_column="expense_time",
+                tz_name=tz_name,
+            )
+            counts["account_adjustments"] = self._migrate_table(
+                table="account_adjustments",
+                id_column="id",
+                date_column="effective_date",
+                time_column="effective_time",
+                tz_name=tz_name,
+            )
+            counts["game_sessions"] = self._migrate_game_sessions(tz_name)
+
+        self.settings.set("timezone_storage_migrated", True)
+        return counts
+
+    def _migrate_table(
+        self,
+        *,
+        table: str,
+        id_column: str,
+        date_column: str,
+        time_column: str,
+        tz_name: str,
+    ) -> int:
+        rows = self.db.fetch_all(
+            f"SELECT {id_column}, {date_column}, {time_column} FROM {table}",
+            (),
+        )
+        updated = 0
+        for row in rows:
+            row_id = row[id_column]
+            date_value = row[date_column]
+            time_value = row[time_column]
+            if not date_value:
+                continue
+            utc_date, utc_time = local_date_time_to_utc(date_value, time_value, tz_name)
+            if str(date_value) != utc_date or (time_value or "00:00:00") != utc_time:
+                self.db.execute_no_commit(
+                    f"UPDATE {table} SET {date_column} = ?, {time_column} = ? WHERE {id_column} = ?",
+                    (utc_date, utc_time, row_id),
+                )
+                updated += 1
+        return updated
+
+    def _migrate_game_sessions(self, tz_name: str) -> int:
+        rows = self.db.fetch_all(
+            """
+            SELECT id, session_date, session_time, end_date, end_time
+            FROM game_sessions
+            """,
+            (),
+        )
+        updated = 0
+        for row in rows:
+            session_date = row["session_date"]
+            session_time = row["session_time"]
+            if not session_date:
+                continue
+            session_date_utc, session_time_utc = local_date_time_to_utc(
+                session_date,
+                session_time,
+                tz_name,
+            )
+            end_date_utc = None
+            end_time_utc = None
+            if row["end_date"]:
+                end_date_utc, end_time_utc = local_date_time_to_utc(
+                    row["end_date"],
+                    row["end_time"],
+                    tz_name,
+                )
+            self.db.execute_no_commit(
+                """
+                UPDATE game_sessions
+                SET session_date = ?, session_time = ?, end_date = ?, end_time = ?
+                WHERE id = ?
+                """,
+                (
+                    session_date_utc,
+                    session_time_utc,
+                    end_date_utc,
+                    end_time_utc,
+                    row["id"],
+                ),
+            )
+            updated += 1
+        return updated

--- a/tests/integration/test_timezone_storage.py
+++ b/tests/integration/test_timezone_storage.py
@@ -1,0 +1,66 @@
+"""Integration tests for UTC storage with local display (Issue #107)."""
+from datetime import date
+from decimal import Decimal
+
+from repositories.purchase_repository import PurchaseRepository
+from services.purchase_service import PurchaseService
+from services.audit_service import AuditService
+
+
+def test_purchase_stores_utc_and_displays_local(test_db, sample_user, sample_site, monkeypatch):
+    monkeypatch.setattr(
+        "repositories.purchase_repository.get_configured_timezone_name",
+        lambda *args, **kwargs: "America/Los_Angeles",
+    )
+
+    repo = PurchaseRepository(test_db)
+    service = PurchaseService(repo)
+
+    purchase = service.create_purchase(
+        user_id=sample_user.id,
+        site_id=sample_site.id,
+        amount=Decimal("100.00"),
+        purchase_date=date(2026, 2, 13),
+        purchase_time="20:30:00",
+    )
+
+    row = test_db.fetch_one(
+        "SELECT purchase_date, purchase_time FROM purchases WHERE id = ?",
+        (purchase.id,),
+    )
+    assert row["purchase_date"] == "2026-02-14"
+    assert row["purchase_time"] == "04:30:00"
+
+    fetched_local = repo.get_by_id(purchase.id)
+    assert fetched_local.purchase_date == date(2026, 2, 13)
+    assert fetched_local.purchase_time == "20:30:00"
+
+    monkeypatch.setattr(
+        "repositories.purchase_repository.get_configured_timezone_name",
+        lambda *args, **kwargs: "UTC",
+    )
+    fetched_utc = repo.get_by_id(purchase.id)
+    assert fetched_utc.purchase_date == date(2026, 2, 14)
+    assert fetched_utc.purchase_time == "04:30:00"
+
+
+def test_audit_log_date_filter_uses_local_time(test_db, monkeypatch):
+    monkeypatch.setattr(
+        "tools.timezone_utils.get_configured_timezone_name",
+        lambda *args, **kwargs: "America/Los_Angeles",
+    )
+    audit = AuditService(test_db)
+    audit.log_create("purchases", 1, {"id": 1})
+
+    test_db.execute(
+        "UPDATE audit_log SET timestamp = ? WHERE table_name = ?",
+        ("2026-02-14 01:00:00", "purchases"),
+    )
+
+    entries = audit.get_audit_log(
+        table_name="purchases",
+        start_date=date(2026, 2, 13),
+        end_date=date(2026, 2, 13),
+        limit=10,
+    )
+    assert len(entries) == 1

--- a/tests/unit/test_timezone_utils.py
+++ b/tests/unit/test_timezone_utils.py
@@ -1,0 +1,41 @@
+"""Tests for timezone_utils conversions (Issue #107)."""
+from datetime import date
+
+from tools.timezone_utils import (
+    local_date_time_to_utc,
+    local_date_range_to_utc_bounds,
+    utc_date_time_to_local,
+)
+
+
+def test_local_to_utc_conversion():
+    utc_date, utc_time = local_date_time_to_utc(
+        date(2026, 2, 13),
+        "20:30:00",
+        "America/Los_Angeles",
+    )
+    assert utc_date == "2026-02-14"
+    assert utc_time == "04:30:00"
+
+
+def test_round_trip_local_to_utc_to_local():
+    local_date = date(2026, 2, 13)
+    local_time = "20:30:00"
+    utc_date, utc_time = local_date_time_to_utc(local_date, local_time, "America/Los_Angeles")
+    round_trip_date, round_trip_time = utc_date_time_to_local(
+        utc_date,
+        utc_time,
+        "America/Los_Angeles",
+    )
+    assert round_trip_date == local_date
+    assert round_trip_time == local_time
+
+
+def test_local_date_range_to_utc_bounds():
+    start_utc, end_utc = local_date_range_to_utc_bounds(
+        date(2026, 2, 13),
+        date(2026, 2, 13),
+        "America/Los_Angeles",
+    )
+    assert start_utc == ("2026-02-13", "08:00:00")
+    assert end_utc == ("2026-02-14", "07:59:59")

--- a/tools/timezone_utils.py
+++ b/tools/timezone_utils.py
@@ -1,0 +1,131 @@
+"""
+Timezone utilities for UTC storage + local display.
+"""
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from typing import Optional, Tuple
+from zoneinfo import ZoneInfo, available_timezones
+
+
+def get_system_timezone_name() -> str:
+    """Best-effort system timezone name (IANA)."""
+    try:
+        tzinfo = datetime.now().astimezone().tzinfo
+        if tzinfo is not None and hasattr(tzinfo, "key"):
+            return tzinfo.key
+    except Exception:
+        pass
+    return "UTC"
+
+
+def get_configured_timezone_name(settings: Optional[object] = None) -> str:
+    """Return user-configured timezone name or system default."""
+    if settings is not None:
+        tz_name = getattr(settings, "get", None)
+        if callable(tz_name):
+            value = settings.get("time_zone", None)
+            if value:
+                return str(value)
+    try:
+        from ui.settings import Settings
+
+        stored = Settings().get("time_zone", None)
+        if stored:
+            return str(stored)
+    except Exception:
+        pass
+    return get_system_timezone_name()
+
+
+def get_timezone(tz_name: Optional[str] = None) -> ZoneInfo:
+    """Return ZoneInfo for a timezone name with UTC fallback."""
+    tz_key = tz_name or get_system_timezone_name()
+    try:
+        return ZoneInfo(tz_key)
+    except Exception:
+        return ZoneInfo("UTC")
+
+
+def list_timezones() -> list[str]:
+    """Return sorted IANA timezone names."""
+    return sorted(available_timezones())
+
+
+def _parse_date(value: date | str) -> date:
+    if isinstance(value, date):
+        return value
+    return datetime.strptime(str(value), "%Y-%m-%d").date()
+
+
+def _normalize_time_value(value: Optional[str]) -> str:
+    if not value:
+        return "00:00:00"
+    value = value.strip()
+    if len(value) == 5:
+        return f"{value}:00"
+    return value
+
+
+def local_date_time_to_utc(
+    local_date: date | str,
+    local_time: Optional[str],
+    tz_name: Optional[str] = None,
+) -> Tuple[str, str]:
+    """Convert local date/time to UTC date/time strings (YYYY-MM-DD, HH:MM:SS)."""
+    tz = get_timezone(tz_name)
+    date_value = _parse_date(local_date)
+    time_str = _normalize_time_value(local_time)
+    naive = datetime.combine(date_value, datetime.strptime(time_str, "%H:%M:%S").time())
+    aware = naive.replace(tzinfo=tz)
+    utc_dt = aware.astimezone(timezone.utc)
+    return utc_dt.date().isoformat(), utc_dt.strftime("%H:%M:%S")
+
+
+def utc_date_time_to_local(
+    utc_date: date | str,
+    utc_time: Optional[str],
+    tz_name: Optional[str] = None,
+) -> Tuple[date, str]:
+    """Convert UTC date/time strings to local date/time."""
+    tz = get_timezone(tz_name)
+    date_value = _parse_date(utc_date)
+    time_str = _normalize_time_value(utc_time)
+    naive = datetime.combine(date_value, datetime.strptime(time_str, "%H:%M:%S").time())
+    aware = naive.replace(tzinfo=timezone.utc)
+    local_dt = aware.astimezone(tz)
+    return local_dt.date(), local_dt.strftime("%H:%M:%S")
+
+
+def local_date_range_to_utc_bounds(
+    start_date: date,
+    end_date: date,
+    tz_name: Optional[str] = None,
+) -> Tuple[Tuple[str, str], Tuple[str, str]]:
+    """Convert a local date range to UTC date/time bounds (start/end inclusive)."""
+    start_dt = local_date_time_to_utc(start_date, "00:00:00", tz_name)
+    end_dt = local_date_time_to_utc(end_date, "23:59:59", tz_name)
+    return start_dt, end_dt
+
+
+def utc_timestamp_to_local(timestamp: str, tz_name: Optional[str] = None) -> datetime:
+    """Convert a UTC timestamp string to local datetime."""
+    tz = get_timezone(tz_name)
+    ts = timestamp.strip()
+    try:
+        parsed = datetime.fromisoformat(ts)
+    except ValueError:
+        parsed = datetime.strptime(ts, "%Y-%m-%d %H:%M:%S")
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(tz)
+
+
+def local_datetime_to_utc_timestamp(
+    local_date: date | str,
+    local_time: Optional[str],
+    tz_name: Optional[str] = None,
+) -> str:
+    """Convert local date/time to UTC timestamp string (YYYY-MM-DD HH:MM:SS)."""
+    utc_date_str, utc_time_str = local_date_time_to_utc(local_date, local_time, tz_name)
+    return f"{utc_date_str} {utc_time_str}"

--- a/ui/audit_log_viewer_dialog.py
+++ b/ui/audit_log_viewer_dialog.py
@@ -237,7 +237,9 @@ class AuditLogViewerDialog(QtWidgets.QDialog):
             timestamp = entry.get('timestamp', '')
             if timestamp:
                 try:
-                    dt = datetime.fromisoformat(timestamp)
+                    from tools.timezone_utils import get_configured_timezone_name, utc_timestamp_to_local
+                    tz_name = get_configured_timezone_name()
+                    dt = utc_timestamp_to_local(timestamp, tz_name)
                     timestamp = dt.strftime("%Y-%m-%d %H:%M:%S")
                 except:
                     pass
@@ -292,7 +294,16 @@ class AuditLogViewerDialog(QtWidgets.QDialog):
         # Format entry details
         details = []
         details.append(f"=== Audit Entry #{entry.get('id')} ===\n")
-        details.append(f"Timestamp: {entry.get('timestamp', 'N/A')}")
+        timestamp = entry.get('timestamp', 'N/A')
+        if timestamp not in (None, 'N/A', ''):
+            try:
+                from tools.timezone_utils import get_configured_timezone_name, utc_timestamp_to_local
+                tz_name = get_configured_timezone_name()
+                dt = utc_timestamp_to_local(str(timestamp), tz_name)
+                timestamp = dt.strftime("%Y-%m-%d %H:%M:%S")
+            except Exception:
+                pass
+        details.append(f"Timestamp: {timestamp}")
         details.append(f"Action:    {entry.get('action', 'N/A')}")
         details.append(f"Table:     {entry.get('table_name', 'N/A')}")
         details.append(f"Record ID: {entry.get('record_id', 'N/A')}")

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -42,6 +42,13 @@ class MainWindow(QtWidgets.QMainWindow):
         # Check data integrity before proceeding
         self.maintenance_mode = False
         self._check_data_integrity()
+
+        # One-time migration to store timestamps in UTC
+        try:
+            from services.timezone_migration_service import TimezoneMigrationService
+            TimezoneMigrationService(self.facade.db, self.settings).migrate_local_timestamps_to_utc()
+        except Exception as e:
+            print(f"Warning: Could not migrate timestamps to UTC: {e}")
         
         # Restore window size
         width = self.settings.get('window_width', 1400)

--- a/ui/settings.py
+++ b/ui/settings.py
@@ -28,11 +28,14 @@ class Settings:
     
     def _default_settings(self) -> Dict[str, Any]:
         """Get default settings"""
+        from tools.timezone_utils import get_system_timezone_name
         return {
             'theme': 'Light',
             'window_width': 1400,
             'window_height': 900,
             'last_tab': 0,
+            'time_zone': get_system_timezone_name(),
+            'timezone_storage_migrated': False,
             'automatic_backup': {
                 'enabled': False,
                 'directory': '',

--- a/ui/settings_dialog.py
+++ b/ui/settings_dialog.py
@@ -178,6 +178,21 @@ class SettingsDialog(QtWidgets.QDialog):
         layout.addRow(theme_label, self.theme_combo)
         layout.setAlignment(theme_label, QtCore.Qt.AlignmentFlag.AlignRight | QtCore.Qt.AlignmentFlag.AlignVCenter)
         layout.setAlignment(self.theme_combo, QtCore.Qt.AlignmentFlag.AlignLeft | QtCore.Qt.AlignmentFlag.AlignVCenter)
+
+        # Time zone selector
+        tz_label = QtWidgets.QLabel("Time Zone:")
+        tz_label.setToolTip("Select the time zone used for date/time display")
+        tz_label.setObjectName("FieldLabel")
+        tz_label.setAlignment(QtCore.Qt.AlignmentFlag.AlignRight | QtCore.Qt.AlignmentFlag.AlignVCenter)
+        self.timezone_combo = QtWidgets.QComboBox()
+        self.timezone_combo.setEditable(True)
+        from tools.timezone_utils import list_timezones
+        tz_list = list_timezones()
+        self.timezone_combo.addItems(tz_list)
+        tz_label.setMinimumHeight(self.timezone_combo.sizeHint().height())
+        layout.addRow(tz_label, self.timezone_combo)
+        layout.setAlignment(tz_label, QtCore.Qt.AlignmentFlag.AlignRight | QtCore.Qt.AlignmentFlag.AlignVCenter)
+        layout.setAlignment(self.timezone_combo, QtCore.Qt.AlignmentFlag.AlignLeft | QtCore.Qt.AlignmentFlag.AlignVCenter)
         
         # Info label
         info_label = QtWidgets.QLabel(
@@ -362,6 +377,15 @@ class SettingsDialog(QtWidgets.QDialog):
         theme_index = self.theme_combo.findText(current_theme)
         if theme_index >= 0:
             self.theme_combo.setCurrentIndex(theme_index)
+
+        # Time zone selection
+        current_tz = self.settings.settings.get("time_zone")
+        if current_tz:
+            tz_index = self.timezone_combo.findText(current_tz)
+            if tz_index >= 0:
+                self.timezone_combo.setCurrentIndex(tz_index)
+            else:
+                self.timezone_combo.setCurrentText(current_tz)
         
         # Tax withholding settings
         tax_enabled = self.settings.settings.get("tax_withholding_enabled", False)
@@ -408,6 +432,12 @@ class SettingsDialog(QtWidgets.QDialog):
         # Write display settings
         selected_theme = self.theme_combo.currentText()
         self.settings.settings["theme"] = selected_theme
+
+        # Write time zone settings
+        previous_tz = self.settings.settings.get("time_zone")
+        selected_tz = self.timezone_combo.currentText().strip()
+        if selected_tz:
+            self.settings.settings["time_zone"] = selected_tz
         
         # Write tax withholding settings
         self.settings.settings["tax_withholding_enabled"] = self.tax_withholding_enabled_checkbox.isChecked()
@@ -484,6 +514,11 @@ class SettingsDialog(QtWidgets.QDialog):
         # Apply theme immediately (notify parent window)
         if self.parent() and hasattr(self.parent(), 'apply_theme'):
             self.parent().apply_theme(selected_theme)
+
+        # Refresh data if time zone changed
+        if previous_tz != self.settings.settings.get("time_zone"):
+            if self.parent() and hasattr(self.parent(), 'refresh_all_tabs'):
+                self.parent().refresh_all_tabs()
         
         # Accept dialog
         self.accept()


### PR DESCRIPTION
## Summary
- store timestamps in UTC with timezone-aware conversions on read/write
- add configurable time zone setting + display refresh
- add one-time migration for existing timestamps and tests

## Testing
- pytest -q

## Manual verification
- Launched app, changed time zone, verified displayed times update after refresh

## Pitfalls / Follow-ups
- Consider adding an explicit UI button to re-run timezone migration if a user chose the wrong zone initially
