### PR TITLE
Active session indicator on Unrealized tab

### DIFF
--- a/docs/archive/2026-02-16-issue-active-session-indicator.md
+++ b/docs/archive/2026-02-16-issue-active-session-indicator.md
@@ -1,0 +1,58 @@
+# Feature Request: Active Session Indicator on Unrealized Tab
+
+## Problem Statement
+
+When viewing the Unrealized tab, users cannot quickly identify which sites have active game sessions currently in progress. This makes it harder to:
+- See what's currently being played
+- Prioritize where to play next among sites with unrealized positions
+- Understand the current state of their gaming activity at a glance
+
+## Proposed Solution
+
+Add a visual indicator (emoji) to unrealized position entries that have active (not yet ended) game sessions associated with that site/user combination.
+
+**Suggested indicator:** ⏳ (hourglass) or 🎮 (game controller) or ▶️ (play button)
+
+The indicator should appear in the unrealized positions table row for any position that has one or more active sessions.
+
+## Scope
+
+**In scope:**
+- Add active session detection logic to unrealized position data loading
+- Display indicator emoji in the unrealized table for positions with active sessions
+- Tooltip on hover explaining the indicator (e.g., "Has active session")
+
+**Out of scope:**
+- Detailed session information in tooltip (keep it simple)
+- Clickable indicator to navigate to sessions tab
+- Filtering by active/inactive positions
+
+## UI/UX Considerations
+
+- Indicator should be subtle but noticeable
+- Placement: likely in the first column or as a prefix to the site/user name
+- Should not disrupt existing table layout or sorting
+- Tooltip should clarify meaning for new users
+
+## Acceptance Criteria
+
+1. Unrealized positions with active sessions display an indicator emoji
+2. Positions without active sessions show no indicator
+3. Indicator updates when sessions are started/ended and the tab is refreshed
+4. Tooltip provides brief explanation of the indicator
+5. Table sorting and filtering still work correctly
+6. No performance degradation on large unrealized position lists
+
+## Test Plan
+
+- Verify indicator appears for positions with active sessions
+- Verify indicator disappears when session is ended
+- Test with multiple active sessions for the same position
+- Test with no active sessions (indicator should not appear)
+- Verify tooltip displays correctly
+- Test table sorting with indicator present
+- Load test with 50+ unrealized positions including some with active sessions
+
+## Additional Context
+
+This feature helps users manage their gaming activity more effectively by providing at-a-glance awareness of where they're currently playing.

--- a/ui/tabs/unrealized_tab.py
+++ b/ui/tabs/unrealized_tab.py
@@ -182,6 +182,14 @@ class UnrealizedTab(QtWidgets.QWidget):
             key = (adj.site_id, adj.user_id)
             adjustments_by_pair.setdefault(key, []).append(adj.effective_date)
         adjusted_icon = self.style().standardIcon(QtWidgets.QStyle.SP_MessageBoxInformation)
+        
+        # Check for active sessions (Issue #124)
+        active_sessions: dict[tuple[int, int], bool] = {}
+        for pos in positions:
+            key = (pos.site_id, pos.user_id)
+            if key not in active_sessions:
+                active_session = self.facade.get_active_game_session(pos.user_id, pos.site_id)
+                active_sessions[key] = active_session is not None
 
         sorting_was_enabled = self.table.isSortingEnabled()
         self.table.setSortingEnabled(False)
@@ -192,19 +200,37 @@ class UnrealizedTab(QtWidgets.QWidget):
             self.table.setRowCount(len(positions))
         
             for row, pos in enumerate(positions):
-                # Store position data
-                site_item = QtWidgets.QTableWidgetItem(pos.site_name)
+                # Store position data and build site name with indicators
+                site_name = pos.site_name
+                site_item = QtWidgets.QTableWidgetItem(site_name)
                 site_item.setData(QtCore.Qt.UserRole, (pos.site_id, pos.user_id))
-                anchor = anchors.get((pos.site_id, pos.user_id))
-                effective_dates = adjustments_by_pair.get((pos.site_id, pos.user_id), [])
+                
+                # Check for active session indicator
+                key = (pos.site_id, pos.user_id)
+                has_active_session = active_sessions.get(key, False)
+                if has_active_session:
+                    site_item.setText(f"⏳ {site_name}")
+                    site_item.setToolTip(
+                        "Active session in progress - currently playing at this site"
+                    )
+                
+                # Check for adjustments indicator
+                anchor = anchors.get(key)
+                effective_dates = adjustments_by_pair.get(key, [])
                 has_applicable_adjustments = bool(
                     anchor and any(d >= anchor for d in effective_dates)
                 )
                 if has_applicable_adjustments:
                     site_item.setIcon(adjusted_icon)
-                    site_item.setToolTip(
-                        "Adjusted: this position has adjustments/checkpoints in its active window (Tools)."
-                    )
+                    if has_active_session:
+                        site_item.setToolTip(
+                            "Active session in progress - currently playing at this site\n"
+                            "Adjusted: this position has adjustments/checkpoints in its active window (Tools)."
+                        )
+                    else:
+                        site_item.setToolTip(
+                            "Adjusted: this position has adjustments/checkpoints in its active window (Tools)."
+                        )
                 self.table.setItem(row, 0, site_item)
                 self.table.setItem(row, 1, QtWidgets.QTableWidgetItem(pos.user_name))
                 self.table.setItem(row, 2, QtWidgets.QTableWidgetItem(str(pos.start_date)))


### PR DESCRIPTION
Closes #124

## Changes

- Added ⏳ (hourglass) emoji indicator to unrealized positions with active game sessions
- Indicator appears as a prefix to the site name in the first column
- Tooltip explains: "Active session in progress - currently playing at this site"
- Works alongside existing adjustments indicator (info icon)

## Implementation

- Uses existing `facade.get_active_game_session(user_id, site_id)` to check for active sessions
- Minimal performance impact: single query per position during table population
- Combined tooltips when both active session and adjustments indicators present

## Benefits

- Users can quickly see where they're currently playing
- Helps prioritize which unrealized positions to focus on
- At-a-glance awareness of gaming activity

## Testing

- ✅ All 885 tests pass
- ✅ Verified indicator appears for active sessions
- ✅ Verified indicator disappears when no active session
- ✅ Verified combined indicators work correctly