### PR TITLE
Fix #130: Purchase checkpoints should store redeemable balance

### DIFF
--- a/app_facade.py
+++ b/app_facade.py
@@ -151,6 +151,9 @@ class AppFacade:
             adjustment_service=self.adjustment_service,
         )
         
+        # Inject game_session_service into purchase_service for redeemable balance computation
+        self.purchase_service.game_session_service = self.game_session_service
+        
         self.report_service = ReportService(self.db)
         self.validation_service = ValidationService(self.db)
         self.report_service = ReportService(self.db)

--- a/docs/PROJECT_SPEC.md
+++ b/docs/PROJECT_SPEC.md
@@ -116,7 +116,7 @@ When editing a purchase or creating/editing a game session, the system computes 
 - Unrealized positions represent sites with remaining SC (position still open).
 - **Issue #44 (2026-02-02):** Unrealized tab estimates current balances by incorporating purchases/redemptions after the most recent checkpoint.
 - **Issue #61 (2026-02-05):** Unrealized now uses **the most recent checkpoint** among:
-  1. **Purchase snapshots** (`starting_sc_balance` when recorded) — captures site SC including dailies/bonuses at purchase time
+  1. **Purchase snapshots** (`starting_sc_balance` + `starting_redeemable_balance` when recorded) — captures site SC including dailies/bonuses at purchase time
   2. **Session starts** (`starting_balance` + `starting_redeemable`) — both Active and Closed sessions
   3. **Session ends** (`ending_balance` + `ending_redeemable`) — Closed sessions only
   4. **Balance checkpoints** (`account_adjustments` of type `BALANCE_CHECKPOINT_CORRECTION`) — explicit known balances captured in Setup → Tools

--- a/docs/archive/2026-02-16-issue-redeemable-checkpoint.md
+++ b/docs/archive/2026-02-16-issue-redeemable-checkpoint.md
@@ -1,0 +1,69 @@
+## Problem
+
+When a user makes a purchase after a session that has established a redeemable balance, the Unrealized tab incorrectly resets the redeemable_sc to 0.
+
+**Example:**
+1. User ends session with total_sc=150, redeemable_sc=100
+2. User makes purchase with starting_sc_balance=150
+3. Unrealized tab shows: total_sc=200 (correct), redeemable_sc=0 (WRONG - should be 100)
+
+**Root Cause:**
+Purchase checkpoints currently only store `starting_sc_balance` (total SC) but not redeemable SC. When the purchase becomes the most recent checkpoint, the unrealized position calculation uses redeemable_sc=0 from the purchase instead of carrying forward the value from the previous session.
+
+## Proposed Solution
+
+Add `starting_redeemable_balance` field to purchases table and auto-populate it at purchase creation time using the existing `compute_expected_balances` logic.
+
+**Benefits:**
+- Simple, clean implementation
+- Follows existing pattern of `starting_sc_balance`
+- Leverages existing `compute_expected_balances` method
+- Automatically handles redemptions between checkpoints
+- No runtime lookups required
+
+## Scope
+
+### Schema Changes
+- Add `starting_redeemable_balance DECIMAL(10,2) DEFAULT 0.00` to `purchases` table
+
+### Code Changes
+1. **Database migration** (`repositories/database.py`):
+   - Add column to purchases table migration
+
+2. **Auto-populate on create** (`services/purchase_service.py`):
+   - Call `compute_expected_balances` to get redeemable at purchase time
+   - Store in `starting_redeemable_balance`
+
+3. **Update expected balances logic** (`services/game_session_service.py`):
+   - When applying purchases, also update `expected_redeemable` from stored snapshot
+
+4. **Update checkpoint query** (`repositories/unrealized_position_repository.py`):
+   - Use `starting_redeemable_balance` instead of hardcoded 0
+
+5. **Data backfill**:
+   - One-time migration to populate existing purchases with redeemable values
+
+### Testing
+- Test: Purchase after session preserves redeemable balance
+- Test: Redemption between purchases correctly reduces redeemable
+- Test: Multiple purchases back-to-back reference correct checkpoints
+- Test: First purchase ever has redeemable=0
+
+## Acceptance Criteria
+
+- [ ] Schema migration adds `starting_redeemable_balance` column
+- [ ] Creating purchase auto-populates redeemable from `compute_expected_balances`
+- [ ] Unrealized positions use stored redeemable instead of 0
+- [ ] Existing purchases backfilled with correct redeemable values
+- [ ] All existing tests pass (892 tests)
+- [ ] New integration tests verify fix
+- [ ] Changelog updated
+- [ ] PROJECT_SPEC.md updated
+
+## Test Plan
+
+1. Start session, end with redeemable balance
+2. Make purchase with starting_sc_balance
+3. Verify Unrealized tab shows correct redeemable (not 0)
+4. Make redemption, then another purchase
+5. Verify second purchase has correct redeemable (minus redemption)

--- a/docs/status/CHANGELOG.md
+++ b/docs/status/CHANGELOG.md
@@ -12,6 +12,35 @@ Rules:
 ## 2026-02-16
 
 ```yaml
+id: 2026-02-16-06
+type: bugfix
+areas: [data-model, accounting, unrealized, purchases]
+summary: "Fix purchase checkpoints to preserve redeemable balance"
+files_changed:
+  - models/purchase.py
+  - repositories/database.py
+  - repositories/purchase_repository.py
+  - services/purchase_service.py
+  - app_facade.py
+  - tools/backfill_purchase_redeemable.py
+  - tests/integration/test_issue_130_purchase_redeemable_checkpoint.py
+issue: 130
+pr: null
+```
+
+**Bugfix: Purchase checkpoints now preserve redeemable balance**
+
+- **Problem**: When making a purchase after playing sessions, the Unrealized tab showed redeemable balance reset to $0.00 instead of preserving the redeemable earned from play.
+- **Root cause**: Purchase checkpoint snapshots (`starting_sc_balance`) tracked total SC but not redeemable SC. The `unrealized_position_repository` hardcoded `redeemable_sc = 0` for purchase checkpoints.
+- **Fix**: Added `starting_redeemable_balance` field to purchases table (with migration), auto-populated at purchase creation time using `compute_expected_balances()` to capture the redeemable balance at that moment. Purchase checkpoints now use this stored value instead of hardcoded 0.
+- **Semantics clarification**: `starting_sc_balance` is the POST-purchase SC balance (the balance after the purchase completes, including dailies/bonuses). Similarly, `starting_redeemable_balance` is the redeemable balance at that same point in time. Purchases don't generate redeemable SC, so this preserves the pre-purchase redeemable value.
+- **Backfill tool**: `tools/backfill_purchase_redeemable.py` migrates existing data (with `--dry-run` support).
+- **Testing**: 5 new integration tests covering purchase-after-session, redemptions between purchases, first purchase (baseline), multiple sequential purchases, and balance checkpoint priority scenarios.
+- **Result**: Unrealized positions now correctly show redeemable balance when purchases occur after play sessions, instead of incorrectly resetting to $0.
+
+---
+
+```yaml
 id: 2026-02-16-05
 type: enhancement
 areas: [ui, timezone, travel-mode, sessions, purchases, redemptions, expenses, adjustments]

--- a/models/purchase.py
+++ b/models/purchase.py
@@ -16,6 +16,7 @@ class Purchase:
     purchase_date: date
     sc_received: Decimal = Decimal("0.00")
     starting_sc_balance: Decimal = Decimal("0.00")
+    starting_redeemable_balance: Decimal = Decimal("0.00")
     cashback_earned: Decimal = Decimal("0.00")
     cashback_is_manual: bool = False
     card_id: Optional[int] = None
@@ -48,7 +49,7 @@ class Purchase:
             raise ValueError("Purchase amount must be positive")
 
         # Convert and validate SC/cashback fields
-        for field_name in ["sc_received", "starting_sc_balance", "cashback_earned"]:
+        for field_name in ["sc_received", "starting_sc_balance", "starting_redeemable_balance", "cashback_earned"]:
             value = getattr(self, field_name)
             if isinstance(value, (int, float)):
                 setattr(self, field_name, Decimal(str(value)))

--- a/repositories/database.py
+++ b/repositories/database.py
@@ -921,6 +921,7 @@ class DatabaseManager:
         migrations = [
             ("sc_received", "TEXT DEFAULT '0.00'"),
             ("starting_sc_balance", "TEXT DEFAULT '0.00'"),
+            ("starting_redeemable_balance", "TEXT DEFAULT '0.00'"),
             ("cashback_earned", "TEXT DEFAULT '0.00'"),
             ("cashback_is_manual", "INTEGER DEFAULT 0"),
             ("deleted_at", "TIMESTAMP NULL"),

--- a/repositories/purchase_repository.py
+++ b/repositories/purchase_repository.py
@@ -142,10 +142,10 @@ class PurchaseRepository:
         )
         query = """
             INSERT INTO purchases 
-            (user_id, site_id, amount, sc_received, starting_sc_balance, cashback_earned,
+            (user_id, site_id, amount, sc_received, starting_sc_balance, starting_redeemable_balance, cashback_earned,
              cashback_is_manual, purchase_date, purchase_time, purchase_entry_time_zone,
              card_id, remaining_amount, notes)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """
         purchase_id = self.db.execute(query, (
             purchase.user_id,
@@ -153,6 +153,7 @@ class PurchaseRepository:
             str(purchase.amount),
             str(purchase.sc_received),
             str(purchase.starting_sc_balance),
+            str(purchase.starting_redeemable_balance),
             str(purchase.cashback_earned),
             1 if purchase.cashback_is_manual else 0,
             utc_date,
@@ -181,7 +182,7 @@ class PurchaseRepository:
         query = """
             UPDATE purchases
             SET user_id = ?, site_id = ?, amount = ?, sc_received = ?, starting_sc_balance = ?,
-                cashback_earned = ?, cashback_is_manual = ?, purchase_date = ?, purchase_time = ?,
+                starting_redeemable_balance = ?, cashback_earned = ?, cashback_is_manual = ?, purchase_date = ?, purchase_time = ?,
                 purchase_entry_time_zone = ?, card_id = ?, remaining_amount = ?, notes = ?,
                 updated_at = CURRENT_TIMESTAMP
             WHERE id = ?
@@ -192,6 +193,7 @@ class PurchaseRepository:
             str(purchase.amount),
             str(purchase.sc_received),
             str(purchase.starting_sc_balance),
+            str(purchase.starting_redeemable_balance),
             str(purchase.cashback_earned),
             1 if purchase.cashback_is_manual else 0,
             utc_date,
@@ -236,6 +238,7 @@ class PurchaseRepository:
             amount=Decimal(str(row['amount'])),
             sc_received=Decimal(str(row.get('sc_received', '0.00'))),
             starting_sc_balance=Decimal(str(row.get('starting_sc_balance', '0.00'))),
+            starting_redeemable_balance=Decimal(str(row.get('starting_redeemable_balance', '0.00'))),
             cashback_earned=Decimal(str(row.get('cashback_earned', '0.00'))),
             cashback_is_manual=bool(row.get('cashback_is_manual', 0)),
             purchase_date=purchase_date,

--- a/repositories/unrealized_position_repository.py
+++ b/repositories/unrealized_position_repository.py
@@ -304,6 +304,8 @@ class UnrealizedPositionRepository:
                 redeemable_redemptions_since = Decimal(str(redeemable_redemptions_after['redeemable_redeemed'] or 0))
                 
                 # Compute estimated SC
+                # baseline_total from purchase checkpoint is starting_sc_balance (POST-purchase balance)
+                # The checkpoint purchase is excluded from purchases_since (id != ?) to avoid double-counting
                 total_sc = baseline_total + purchases_since - redemptions_since
                 
                 # Redeemable: use checkpoint redeemable minus redemptions if checkpoint is within current position
@@ -590,7 +592,7 @@ class UnrealizedPositionRepository:
                 purchase_date, 
                 COALESCE(purchase_time, '00:00:00') as purchase_time,
                 starting_sc_balance,
-                0.0 as redeemable_sc
+                COALESCE(starting_redeemable_balance, 0.0) as starting_redeemable_balance
             FROM purchases
             WHERE site_id = ? AND user_id = ?
                             AND deleted_at IS NULL
@@ -606,7 +608,7 @@ class UnrealizedPositionRepository:
                 checkpoints.append({
                     'checkpoint_dt': dt,
                     'total_sc': Decimal(str(purchase_snap['starting_sc_balance'])),
-                    'redeemable_sc': Decimal("0.00"),  # Purchase snapshots don't track redeemable split
+                    'redeemable_sc': Decimal(str(purchase_snap['starting_redeemable_balance'] or 0)),
                     'checkpoint_purchase_id': purchase_snap['purchase_id'],
                     'priority': 0,
                 })

--- a/services/game_session_service.py
+++ b/services/game_session_service.py
@@ -575,7 +575,10 @@ class GameSessionService:
                 continue
 
             expected_total = Decimal(str(p.starting_sc_balance))
-            # Purchases do not increase expected redeemable; redeemable is earned via play-through
+            # Use stored redeemable snapshot from purchase if available (Issue #130)
+            if hasattr(p, 'starting_redeemable_balance') and p.starting_redeemable_balance is not None:
+                expected_redeemable = Decimal(str(p.starting_redeemable_balance))
+            # Otherwise purchases do not increase expected redeemable; redeemable is earned via play-through
             # captured in sessions/checkpoints.
 
         expected_total = max(Decimal("0.00"), expected_total)

--- a/services/purchase_service.py
+++ b/services/purchase_service.py
@@ -13,16 +13,18 @@ from repositories.card_repository import CardRepository
 if TYPE_CHECKING:
     from services.audit_service import AuditService
     from services.undo_redo_service import UndoRedoService
+    from services.game_session_service import GameSessionService
 
 
 class PurchaseService:
     """Business logic for Purchase operations"""
     
-    def __init__(self, purchase_repo: PurchaseRepository, card_repo: Optional[CardRepository] = None, audit_service: Optional['AuditService'] = None, undo_redo_service: Optional['UndoRedoService'] = None):
+    def __init__(self, purchase_repo: PurchaseRepository, card_repo: Optional[CardRepository] = None, audit_service: Optional['AuditService'] = None, undo_redo_service: Optional['UndoRedoService'] = None, game_session_service: Optional['GameSessionService'] = None):
         self.purchase_repo = purchase_repo
         self.card_repo = card_repo
         self.audit_service = audit_service
         self.undo_redo_service = undo_redo_service
+        self.game_session_service = game_session_service
     
     def _calculate_cashback(self, amount: Decimal, card_id: Optional[int]) -> Decimal:
         """Calculate cashback based on card rate.
@@ -72,6 +74,21 @@ class PurchaseService:
         else:
             cashback_is_manual = True  # User explicitly provided
         
+        # Auto-calculate starting_redeemable_balance from most recent checkpoint
+        starting_redeemable_balance = Decimal("0.00")
+        if self.game_session_service:
+            try:
+                _, expected_redeemable = self.game_session_service.compute_expected_balances(
+                    user_id=user_id,
+                    site_id=site_id,
+                    session_date=purchase_date,
+                    session_time=purchase_time or "00:00:00",
+                )
+                starting_redeemable_balance = expected_redeemable
+            except Exception:
+                # If computation fails, default to 0.00
+                starting_redeemable_balance = Decimal("0.00")
+        
         # Create purchase model (validates in __post_init__)
         purchase = Purchase(
             user_id=user_id,
@@ -79,6 +96,7 @@ class PurchaseService:
             amount=amount,
             sc_received=sc_received,
             starting_sc_balance=starting_sc_balance,
+            starting_redeemable_balance=starting_redeemable_balance,
             cashback_earned=cashback_earned,
             cashback_is_manual=cashback_is_manual,
             purchase_date=purchase_date,

--- a/tests/integration/test_issue_130_purchase_redeemable_checkpoint.py
+++ b/tests/integration/test_issue_130_purchase_redeemable_checkpoint.py
@@ -1,0 +1,325 @@
+"""
+Integration tests for Issue #130: Purchase checkpoints should store redeemable balance.
+
+Tests verify that making a purchase after a session preserves the redeemable balance
+instead of resetting it to 0.
+"""
+
+from decimal import Decimal
+from datetime import date
+
+from app_facade import AppFacade
+
+
+def test_purchase_after_session_preserves_redeemable():
+    """
+    Core bug fix test: Purchase after session should preserve redeemable balance, not reset to 0.
+    """
+    facade = AppFacade(":memory:")
+
+    # Setup
+    site = facade.create_site(name="Test Site")
+    user = facade.create_user(name="Test User")
+    game_type = facade.create_game_type(name="Slots")
+    game = facade.create_game(name="Test Slots", game_type_id=game_type.id)
+
+    # Step 1: Make initial purchase
+    purchase1 = facade.create_purchase(
+        site_id=site.id,
+        user_id=user.id,
+        purchase_date=date(2025, 1, 1),
+        purchase_time="09:00:00",
+        amount=Decimal("100.00"),
+        sc_received=Decimal("100.00"),
+        starting_sc_balance=Decimal("0.00"),
+    )
+
+    # Step 2: Play session that generates redeemable balance
+    session = facade.create_game_session(
+        site_id=site.id,
+        user_id=user.id,
+        game_id=game.id,
+        session_date=date(2025, 1, 1),
+        session_time="10:00:00",
+        starting_balance=Decimal("100.00"),
+        starting_redeemable=Decimal("0.00"),
+        ending_balance=Decimal("150.00"),
+        ending_redeemable=Decimal("100.00"),  # User won 50 total, 100 redeemable
+        calculate_pl=False,
+    )
+
+    facade.update_game_session(
+        session_id=session.id,
+        ending_balance=Decimal("150.00"),
+        ending_redeemable=Decimal("100.00"),
+        end_date=date(2025, 1, 1),
+        end_time="11:00:00",
+        status="Closed",
+        recalculate_pl=False,
+    )
+
+    # Step 3: Make another purchase (the critical test)
+    purchase2 = facade.create_purchase(
+        site_id=site.id,
+        user_id=user.id,
+        purchase_date=date(2025, 1, 2),
+        purchase_time="14:00:00",
+        amount=Decimal("50.00"),
+        sc_received=Decimal("50.00"),
+        starting_sc_balance=Decimal("200.00"),  # POST-purchase: 150 (from session) + 50 (this purchase)
+    )
+
+    # Verify: Purchase should have stored the redeemable balance
+    assert purchase2.starting_redeemable_balance == Decimal("100.00"), \
+        f"Purchase should store redeemable=100 from session, got {purchase2.starting_redeemable_balance}"
+
+    # Step 4: Verify Unrealized position shows correct redeemable
+    positions = facade.get_unrealized_positions()
+    assert len(positions) == 1
+
+    position = positions[0]
+    assert position.total_sc == Decimal("200.00"), \
+        f"Total should be 200 (POST-purchase snapshot), got {position.total_sc}"
+    assert position.redeemable_sc == Decimal("100.00"), \
+        f"Redeemable should stay 100 (from session), got {position.redeemable_sc}"
+
+
+def test_redemption_between_purchases_reduces_redeemable():
+    """
+    Verify redemptions between purchases correctly reduce redeemable balance in next purchase checkpoint.
+    """
+    facade = AppFacade(":memory:")
+
+    site = facade.create_site(name="Test Site")
+    user = facade.create_user(name="Test User")
+    game_type = facade.create_game_type(name="Slots")
+    game = facade.create_game(name="Test Slots", game_type_id=game_type.id)
+
+    # Initial purchase + session
+    facade.create_purchase(
+        site_id=site.id,
+        user_id=user.id,
+        purchase_date=date(2025, 1, 1),
+        purchase_time="09:00:00",
+        amount=Decimal("100.00"),
+        sc_received=Decimal("100.00"),
+        starting_sc_balance=Decimal("0.00"),
+    )
+
+    session = facade.create_game_session(
+        site_id=site.id,
+        user_id=user.id,
+        game_id=game.id,
+        session_date=date(2025, 1, 1),
+        session_time="10:00:00",
+        starting_balance=Decimal("100.00"),
+        starting_redeemable=Decimal("0.00"),
+        ending_balance=Decimal("200.00"),
+        ending_redeemable=Decimal("150.00"),
+        calculate_pl=False,
+    )
+
+    facade.update_game_session(
+        session_id=session.id,
+        ending_balance=Decimal("200.00"),
+        ending_redeemable=Decimal("150.00"),
+        end_date=date(2025, 1, 1),
+        end_time="11:00:00",
+        status="Closed",
+        recalculate_pl=False,
+    )
+
+    # Redemption reduces redeemable (is_free_sc defaults to False)
+    facade.create_redemption(
+        user_id=user.id,
+        site_id=site.id,
+        amount=Decimal("50.00"),
+        redemption_date=date(2025, 1, 1),
+        redemption_time="12:00:00",
+    )
+
+    # Purchase after redemption should reflect reduced redeemable
+    purchase2 = facade.create_purchase(
+        site_id=site.id,
+        user_id=user.id,
+        purchase_date=date(2025, 1, 2),
+        purchase_time="09:00:00",
+        amount=Decimal("50.00"),
+        sc_received=Decimal("50.00"),
+        starting_sc_balance=Decimal("200.00"),  # POST-purchase: 150 (after redemption) + 50 (this purchase)
+    )
+
+    # Redeemable should be 100 (150 from session - 50 redemption)
+    assert purchase2.starting_redeemable_balance == Decimal("100.00"), \
+        f"Redeemable should be 100 (150 - 50 redemption), got {purchase2.starting_redeemable_balance}"
+
+
+def test_first_purchase_has_zero_redeemable():
+    """
+    Verify that first purchase (no prior sessions) correctly has redeemable=0.
+    """
+    facade = AppFacade(":memory:")
+
+    site = facade.create_site(name="Test Site")
+    user = facade.create_user(name="Test User")
+
+    purchase = facade.create_purchase(
+        site_id=site.id,
+        user_id=user.id,
+        purchase_date=date(2025, 1, 1),
+        purchase_time="10:00:00",
+        amount=Decimal("100.00"),
+        sc_received=Decimal("100.00"),
+        starting_sc_balance=Decimal("0.00"),
+    )
+
+    assert purchase.starting_redeemable_balance == Decimal("0.00"), \
+        "First purchase should have redeemable=0 (no prior sessions)"
+
+
+def test_multiple_purchases_back_to_back():
+    """
+    Verify that multiple purchases in sequence properly reference each other's checkpoints.
+    """
+    facade = AppFacade(":memory:")
+
+    site = facade.create_site(name="Test Site")
+    user = facade.create_user(name="Test User")
+    game_type = facade.create_game_type(name="Slots")
+    game = facade.create_game(name="Test Slots", game_type_id=game_type.id)
+
+    # Purchase 1
+    purchase1 = facade.create_purchase(
+        site_id=site.id,
+        user_id=user.id,
+        purchase_date=date(2025, 1, 1),
+        purchase_time="09:00:00",
+        amount=Decimal("100.00"),
+        sc_received=Decimal("100.00"),
+        starting_sc_balance=Decimal("0.00"),
+    )
+
+    # Session establishes redeemable
+    session = facade.create_game_session(
+        site_id=site.id,
+        user_id=user.id,
+        game_id=game.id,
+        session_date=date(2025, 1, 1),
+        session_time="10:00:00",
+        starting_balance=Decimal("100.00"),
+        starting_redeemable=Decimal("0.00"),
+        ending_balance=Decimal("150.00"),
+        ending_redeemable=Decimal("100.00"),
+        calculate_pl=False,
+    )
+
+    facade.update_game_session(
+        session_id=session.id,
+        ending_balance=Decimal("150.00"),
+        ending_redeemable=Decimal("100.00"),
+        end_date=date(2025, 1, 1),
+        end_time="11:00:00",
+        status="Closed",
+        recalculate_pl=False,
+    )
+
+    # Purchase 2 (should reference session)
+    purchase2 = facade.create_purchase(
+        site_id=site.id,
+        user_id=user.id,
+        purchase_date=date(2025, 1, 2),
+        purchase_time="09:00:00",
+        amount=Decimal("50.00"),
+        sc_received=Decimal("50.00"),
+        starting_sc_balance=Decimal("200.00"),  # POST-purchase: 150 + 50
+    )
+
+    assert purchase2.starting_redeemable_balance == Decimal("100.00")
+
+    # Purchase 3 immediately after Purchase 2 (should reference Purchase 2)
+    purchase3 = facade.create_purchase(
+        site_id=site.id,
+        user_id=user.id,
+        purchase_date=date(2025, 1, 2),
+        purchase_time="09:01:00",
+        amount=Decimal("25.00"),
+        sc_received=Decimal("25.00"),
+        starting_sc_balance=Decimal("225.00"),  # POST-purchase: 200 + 25
+    )
+
+    # Purchase 3 should still have redeemable=100 (from Purchase 2's snapshot)
+    assert purchase3.starting_redeemable_balance == Decimal("100.00"), \
+        f"Purchase 3 should reference Purchase 2's redeemable, got {purchase3.starting_redeemable_balance}"
+
+
+def test_balance_checkpoint_takes_priority():
+    """
+    Verify that explicit balance checkpoint takes priority over session for redeemable.
+    """
+    facade = AppFacade(":memory:")
+
+    site = facade.create_site(name="Test Site")
+    user = facade.create_user(name="Test User")
+    game_type = facade.create_game_type(name="Slots")
+    game = facade.create_game(name="Test Slots", game_type_id=game_type.id)
+
+    # Purchase + Session
+    facade.create_purchase(
+        site_id=site.id,
+        user_id=user.id,
+        purchase_date=date(2025, 1, 1),
+        purchase_time="09:00:00",
+        amount=Decimal("100.00"),
+        sc_received=Decimal("100.00"),
+        starting_sc_balance=Decimal("0.00"),
+    )
+
+    session = facade.create_game_session(
+        site_id=site.id,
+        user_id=user.id,
+        game_id=game.id,
+        session_date=date(2025, 1, 1),
+        session_time="10:00:00",
+        starting_balance=Decimal("100.00"),
+        starting_redeemable=Decimal("0.00"),
+        ending_balance=Decimal("150.00"),
+        ending_redeemable=Decimal("100.00"),
+        calculate_pl=False,
+    )
+
+    facade.update_game_session(
+        session_id=session.id,
+        ending_balance=Decimal("150.00"),
+        ending_redeemable=Decimal("100.00"),
+        end_date=date(2025, 1, 1),
+        end_time="11:00:00",
+        status="Closed",
+        recalculate_pl=False,
+    )
+
+    # Manual balance correction (takes priority)
+    facade.db.execute("""
+        INSERT INTO account_adjustments 
+        (site_id, user_id, type, effective_date, effective_time, 
+         checkpoint_total_sc, checkpoint_redeemable_sc, reason)
+        VALUES (?, ?, 'BALANCE_CHECKPOINT_CORRECTION', ?, ?, ?, ?, ?)
+    """, (
+        site.id, user.id,
+        date(2025, 1, 2), '09:00:00',
+        str(Decimal("150.00")), str(Decimal("75.00")),  # Correction: redeemable is actually 75, not 100
+        "Manual redeemable balance correction"
+    ))
+
+    # Purchase after balance correction should use corrected redeemable
+    purchase2 = facade.create_purchase(
+        site_id=site.id,
+        user_id=user.id,
+        purchase_date=date(2025, 1, 3),
+        purchase_time="10:00:00",
+        amount=Decimal("50.00"),
+        sc_received=Decimal("50.00"),
+        starting_sc_balance=Decimal("200.00"),  # POST-purchase: 150 + 50
+    )
+
+    assert purchase2.starting_redeemable_balance == Decimal("75.00"), \
+        f"Purchase should use balance checkpoint (75), not session (100), got {purchase2.starting_redeemable_balance}"

--- a/tests/integration/test_issue_44_unrealized_live_balances.py
+++ b/tests/integration/test_issue_44_unrealized_live_balances.py
@@ -300,7 +300,7 @@ class TestIssue61UnrealizedCheckpoints:
     """Test Issue #61: Unrealized uses purchase/session-start checkpoints for Total SC (Est.)"""
     
     def test_purchase_snapshot_overrides_sc_received_sum(self, db, repo):
-        """When purchase has starting_sc_balance snapshot, use it as baseline (includes dailies)."""
+        """When purchase has starting_sc_balance snapshot, use it as baseline (post-purchase SC)."""
         db.execute("""
             INSERT INTO purchases
             (user_id, site_id, purchase_date, purchase_time, amount, sc_received, starting_sc_balance, remaining_amount)
@@ -312,7 +312,8 @@ class TestIssue61UnrealizedCheckpoints:
         assert len(positions) == 1
         pos = positions[0]
         
-        # Total SC should use the snapshot (105.00), not just sc_received (100.00)
+        # Total SC = starting_sc_balance (105 is POST-purchase, includes dailies/bonuses)
+        # Purchase is excluded from deltas to avoid double-counting
         assert pos.total_sc == Decimal("105.00"), "Should use purchase snapshot as baseline"
         assert pos.purchase_basis == Decimal("100.00")
         assert pos.unrealized_pl == Decimal("5.00")  # 105 - 100

--- a/tools/backfill_purchase_redeemable.py
+++ b/tools/backfill_purchase_redeemable.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""
+One-time migration script to backfill starting_redeemable_balance for existing purchases.
+
+Issue #130: Purchase checkpoints should store redeemable balance to prevent reset.
+
+This script:
+1. Finds all purchases with starting_sc_balance > 0 and starting_redeemable_balance = 0
+2. For each, computes expected redeemable using compute_expected_balances
+3. Updates the purchase with the computed value
+
+Usage:
+    python3 tools/backfill_purchase_redeemable.py [--dry-run]
+"""
+
+import sys
+import os
+
+# Add parent directory to path so we can import from the project
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from decimal import Decimal
+from app_facade import AppFacade
+
+
+def backfill_purchase_redeemable(db_path: str = "sezzions.db", dry_run: bool = False):
+    """
+    Backfill starting_redeemable_balance for existing purchases.
+    
+    Args:
+        db_path: Path to the database file
+        dry_run: If True, print what would be done without making changes
+    """
+    print(f"Backfilling purchase redeemable balances ({db_path})...")
+    if dry_run:
+        print("DRY RUN MODE - No changes will be made")
+    
+    facade = AppFacade(db_path)
+    
+    # Find all purchases with starting_sc_balance > 0
+    query = """
+        SELECT id, user_id, site_id, purchase_date, purchase_time, 
+               starting_sc_balance, COALESCE(starting_redeemable_balance, 0) as starting_redeemable_balance
+        FROM purchases
+        WHERE deleted_at IS NULL
+          AND starting_sc_balance > 0.001
+        ORDER BY purchase_date ASC, purchase_time ASC, id ASC
+    """
+    
+    purchases_to_update = facade.db.fetch_all(query)
+    
+    print(f"Found {len(purchases_to_update)} purchases with starting_sc_balance > 0")
+    
+    updated_count = 0
+    skipped_count = 0
+    error_count = 0
+    
+    for p in purchases_to_update:
+        purchase_id = p['id']
+        user_id = p['user_id']
+        site_id = p['site_id']
+        purchase_date = p['purchase_date']
+        purchase_time = p['purchase_time'] or "00:00:00"
+        current_redeemable = Decimal(str(p['starting_redeemable_balance'] or 0))
+        
+        try:
+            # Compute expected redeemable at this purchase time
+            _, expected_redeemable = facade.compute_expected_balances(
+                user_id=user_id,
+                site_id=site_id,
+                session_date=purchase_date,
+                session_time=purchase_time,
+                exclude_purchase_id=purchase_id,  # Exclude this purchase from the calculation
+            )
+            
+            # Only update if the value would change
+            if expected_redeemable != current_redeemable:
+                if dry_run:
+                    print(f"  [DRY RUN] Would update purchase {purchase_id}: "
+                          f"{current_redeemable} → {expected_redeemable}")
+                    updated_count += 1
+                else:
+                    # Update the purchase
+                    update_query = """
+                        UPDATE purchases
+                        SET starting_redeemable_balance = ?
+                        WHERE id = ?
+                    """
+                    facade.db.execute(update_query, (str(expected_redeemable), purchase_id))
+                    print(f"  Updated purchase {purchase_id}: {current_redeemable} → {expected_redeemable}")
+                    updated_count += 1
+            else:
+                skipped_count += 1
+                
+        except Exception as e:
+            print(f"  ERROR processing purchase {purchase_id}: {e}")
+            error_count += 1
+    
+    if not dry_run:
+        facade.db.commit()
+    
+    print(f"\nBackfill complete:")
+    print(f"  Updated: {updated_count}")
+    print(f"  Skipped (already correct): {skipped_count}")
+    print(f"  Errors: {error_count}")
+    
+    facade.db.close()
+
+
+if __name__ == "__main__":
+    import argparse
+    
+    parser = argparse.ArgumentParser(description="Backfill starting_redeemable_balance for purchases")
+    parser.add_argument("--dry-run", action="store_true", help="Show what would be done without making changes")
+    parser.add_argument("--db", default="sezzions.db", help="Path to database file (default: sezzions.db)")
+    
+    args = parser.parse_args()
+    
+    backfill_purchase_redeemable(db_path=args.db, dry_run=args.dry_run)


### PR DESCRIPTION
Fixes #130

## Problem
When making a purchase, the redeemable balance was resetting to $0.00 in the Unrealized tab. Purchase checkpoints were hardcoding `redeemable_sc = Decimal("0.00")` instead of preserving the actual redeemable balance.

## Root Cause
Purchase records captured `starting_sc_balance` (POST-purchase total SC including dailies/bonuses) but did not capture the corresponding redeemable SC at that same point in time.

## Solution
- Add `starting_redeemable_balance` column to purchases table (stores redeemable SC POST-purchase)
- Auto-populate at purchase creation using `compute_expected_balances()`
- Update unrealized position repository to use stored value instead of hardcoded 0
- Semantics clarification: `starting_sc_balance` is POST-purchase balance (includes purchase + dailies)
- Checkpoint purchase excluded from `purchases_since` to avoid double-counting

## Backfill
- Included migration script: `tools/backfill_purchase_redeemable.py`
- Run with `--dry-run` to preview changes

## Testing
- Added 5 comprehensive integration tests covering:
  - Purchase after session (preserves redeemable)
  - Purchase after purchase (preserves redeemable)
  - Balance checkpoint vs purchase checkpoint priority
  - Redemption between purchases (redeemable decreases correctly)
  - Multiple consecutive purchases (chain preservation)
- All 897 tests passing ✅

## Documentation
- Updated `PROJECT_SPEC.md` checkpoint documentation
- Added comprehensive changelog entry (2026-02-16-06)
