### PR TITLE
ui: remove Dismiss button from Notification Center

### DIFF
--- a/docs/PROJECT_SPEC.md
+++ b/docs/PROJECT_SPEC.md
@@ -1153,7 +1153,7 @@ Provide passive, persistent notifications for important app events without inter
 - `services/notification_service.py`: CRUD operations, state transitions, de-duplication by composite key (type + subject_id)
 - `repositories/notification_repository.py`: JSON persistence to settings.json (v1 implementation)
 - `services/notification_rules_service.py`: Rule evaluators for backup and redemption conditions
-- `ui/notification_widgets.py`: Bell widget with badge, notification center dialog, snooze/dismiss/delete UI
+- `ui/notification_widgets.py`: Bell widget with badge, notification center dialog, snooze/delete UI
 - Periodic evaluation: Startup + hourly QTimer
 
 **Notification Model:**
@@ -1169,7 +1169,8 @@ Provide passive, persistent notifications for important app events without inter
   - **Resurfacing**: When cooldown expires + condition still true → clears deleted_at/read_at, resurfaces as new/unread
 - `get_all()`, `get_active()`, `get_by_id()`, `get_unread_count()`
 - State transitions: `mark_read(cooldown_days=0)`, `mark_unread()`, `mark_all_read()`
-- User actions: `dismiss()`, `snooze()`, `snooze_for_hours()`, `snooze_until_tomorrow()`, `delete(cooldown_days=0)`
+- User actions: `snooze()`, `snooze_for_hours()`, `snooze_until_tomorrow()`, `delete(cooldown_days=0)`
+  - **Note**: `dismiss()` and `dismiss_by_type()` remain in the service but are **system-only** — used by notification rules to auto-clear resolved conditions (backup completed, redemption received). No user-facing Dismiss button exists.
   - **Cooldown suppression** (Issue #73): `delete()` and `mark_read()` accept `cooldown_days` parameter
     - Sets `suppressed_until = datetime.now() + timedelta(days=cooldown_days)`
     - Prevents immediate reappearance when rules re-evaluate (fixes "nag loop")
@@ -1212,7 +1213,7 @@ Provide passive, persistent notifications for important app events without inter
   - Click opens NotificationCenterDialog
 - **NotificationItemWidget**: QFrame for a single notification
   - Severity icon (ℹ️/⚠️/❌), title (bold if unread), body, timestamp
-  - Actions: "Open" (if action_key), "Snooze", "Dismiss", "Delete", "Mark Read", "Mark Unread"
+  - Actions: "Open" (if action_key), "Snooze", "Delete", "Mark Read", "Mark Unread"
 - **NotificationCenterDialog**: grouped, scrollable list of notifications
   - Groups: Unread / Read / Snoozed (Read + Snoozed are collapsed by default)
   - "Mark All Read" button (applies to non-dismissed/non-deleted notifications, including snoozed)

--- a/docs/status/CHANGELOG.md
+++ b/docs/status/CHANGELOG.md
@@ -9,6 +9,29 @@ Rules:
 
 ---
 
+## 2026-02-23
+
+```yaml
+id: 2026-02-23-01
+type: cleanup
+areas: [ui, notifications]
+issue: ~
+summary: "Remove user-facing Dismiss button from Notification Center"
+details: >
+  The Dismiss button in NotificationItemWidget was non-functional: calling
+  notification_service.dismiss() sets dismissed_at, but create_or_update()
+  immediately resets dismissed_at to None on the next rule evaluation, so
+  the notification reappeared instantly. The button provided no lasting effect.
+  Removed: Dismiss button, dismissed Signal on NotificationItemWidget,
+  item_widget.dismissed.connect() wiring, _dismiss_notification() handler.
+  System-side dismiss() and dismiss_by_type() remain (used by notification
+  rules to auto-clear resolved conditions such as backup completed or
+  redemption received). Spec updated: §6.6 per-item actions and service
+  user-actions list updated to remove Dismiss; system-only note added.
+```
+
+---
+
 ## 2026-02-21
 
 ```yaml

--- a/ui/notification_widgets.py
+++ b/ui/notification_widgets.py
@@ -134,7 +134,6 @@ class NotificationItemWidget(QFrame):
     """Single notification item in the list"""
     
     action_clicked = Signal(object)  # notification
-    dismissed = Signal(int)  # notification_id
     snoozed = Signal(int, datetime)  # notification_id, until
     deleted = Signal(int)  # notification_id
     marked_read = Signal(int)  # notification_id
@@ -226,11 +225,6 @@ class NotificationItemWidget(QFrame):
         snooze_btn.clicked.connect(self._show_snooze_menu)
         actions_layout.addWidget(snooze_btn)
         
-        # Dismiss button
-        dismiss_btn = QPushButton("✓ Dismiss")
-        dismiss_btn.clicked.connect(lambda: self.dismissed.emit(self.notification.id))
-        actions_layout.addWidget(dismiss_btn)
-
         # Mark as read/unread (moves between groups)
         if self.notification.is_read:
             unread_btn = QPushButton("↩︎ Mark Unread")
@@ -458,7 +452,6 @@ class NotificationCenterDialog(QDialog):
             for notif in items:
                 item_widget = NotificationItemWidget(notif)
                 item_widget.action_clicked.connect(self._handle_action)
-                item_widget.dismissed.connect(self._dismiss_notification)
                 item_widget.snoozed.connect(self._snooze_notification)
                 item_widget.deleted.connect(self._delete_notification)
                 item_widget.marked_unread.connect(self._mark_unread_notification)
@@ -549,12 +542,6 @@ class NotificationCenterDialog(QDialog):
                     200,
                     lambda: self._select_redemption_row(redemptions_tab, redemption_id, _retried_all_time=True),
                 )
-    
-    def _dismiss_notification(self, notification_id):
-        """Dismiss a notification"""
-        self.facade.notification_service.dismiss(notification_id)
-        self.load_notifications()
-        self._refresh_bell_badge()
     
     def _snooze_notification(self, notification_id, until):
         """Snooze a notification"""


### PR DESCRIPTION
## Summary

The **Dismiss** button on notification items had no lasting effect. Clicking it set `dismissed_at` via `notification_service.dismiss()`, but `create_or_update()` immediately resets `dismissed_at = None` on the next rule evaluation — so the notification reappeared as soon as backup/redemption rules re-ran (hourly timer, session close, etc.).

## Changes

- **Removed** Dismiss button from `NotificationItemWidget._init_ui()`
- **Removed** `dismissed` Signal from `NotificationItemWidget`
- **Removed** `item_widget.dismissed.connect(self._dismiss_notification)` wiring
- **Removed** `_dismiss_notification()` handler method

## What stays

`notification_service.dismiss()` and `dismiss_by_type()` remain — they are system-only paths used by `NotificationRulesService` to auto-clear resolved conditions (backup completed, redemption received). `dismissed_at` stays in the model for the same reason.

## Remaining user actions per notification

Open (if applicable) · Snooze · Mark Read / Mark Unread · Delete

## Spec + Changelog

- `docs/PROJECT_SPEC.md` §6.6 updated
- `docs/status/CHANGELOG.md` entry `2026-02-23-01` added

## Tests

940 passed, 1 skipped, 0 failures