### PR TITLE
Fix scoped close-marker rebuild parity (Issue #158)

### DIFF
--- a/docs/PROJECT_SPEC.md
+++ b/docs/PROJECT_SPEC.md
@@ -215,6 +215,10 @@ When editing a purchase or creating/editing a game session, the system computes 
     - Allocations are written to `redemption_allocations`, and `purchases.remaining_amount` is reduced accordingly.
     - Realized row remains synchronized to consumed basis (`cost_basis = consumed_basis`, `payout = 0`, `net_pl = -consumed_basis`) to prevent realized/unrealized double-counting.
     - Future purchases (after close timestamp) are never eligible for that close-marker allocation.
+    - **Parity rule (Issue #158, 2026-03-10):** The same close-marker basis-consumption logic must apply in both rebuild paths:
+      - full pair rebuild (`_rebuild_fifo_for_pair`), and
+      - scoped suffix rebuild (`rebuild_fifo_for_pair_from`) used by `AppFacade._rebuild_or_mark_stale`.
+      This prevents path-dependent drift where realized rows are regenerated but basis allocations are omitted.
   - **Position visibility:** Positions removed when: (a) estimated SC < threshold (0.01), (b) closure event datetime >= last activity, or (c) no checkpoint available.
 
 ### 4.4 Taxable P/L (Game Sessions)

--- a/docs/archive/2026-03-10-issue-scoped-close-marker-rebuild-miss.md
+++ b/docs/archive/2026-03-10-issue-scoped-close-marker-rebuild-miss.md
@@ -1,0 +1,64 @@
+## Summary
+Scoped FIFO rebuild (`rebuild_fifo_for_pair_from`) still uses legacy handling for `Balance Closed` close-marker redemptions (`amount=0`, parsable `Net Loss` note): it writes realized loss but does not consume basis or write `redemption_allocations`.
+
+## Impact / scope
+Impact:
+- Unrealized basis can be overstated after close markers when updates go through scoped rebuild flows.
+- Unrealized P/L can be materially incorrect (double-hit effect: realized loss booked while basis remains open).
+- Inconsistency between full rebuild and scoped rebuild semantics.
+
+Scope:
+- `services/recalculation_service.py` scoped rebuild path (`rebuild_fifo_for_pair_from`).
+- Regression coverage for scoped path close-marker handling.
+- Documentation updates clarifying invariant parity between full and scoped rebuild.
+
+## Steps to reproduce
+1. Use a user/site pair with purchases and close-marker redemptions.
+2. Trigger operations that call scoped rebuild (`AppFacade._rebuild_or_mark_stale` normal mode path).
+3. Ensure close marker redemptions exist with:
+   - `amount=0`
+   - parsable notes: `Balance Closed - Net Loss: $X.XX`
+4. Inspect DB:
+   - `realized_transactions` includes close-marker net loss rows
+   - `redemption_allocations` has no corresponding rows for those close markers
+   - pre-close purchases still retain positive `remaining_amount`.
+
+## Expected behavior
+Scoped rebuild should match full rebuild semantics:
+- consume FIFO basis for close markers (timestamp-bounded, capped by available basis),
+- write `redemption_allocations`,
+- update `purchases.remaining_amount`,
+- keep realized row synchronized to consumed basis.
+
+## Actual behavior
+Scoped rebuild writes realized close-loss rows only and skips basis consumption/allocation for close markers.
+
+## Logs / traceback
+Observed on Sheesh (site_id=37, user_id=1):
+- close markers: redemptions 238 and 243
+- realized rows exist for both close markers
+- no allocation rows for 238/243
+- purchases 794/844/886/954 each retained 74.99 remaining basis (sum 299.96), causing Unrealized to display -209.77 from checkpoint 90.19.
+
+## Severity
+High (data incorrect / accounting display materially wrong)
+
+## Environment
+- macOS
+- SQLite local DB (`sezzions.db`)
+
+## Acceptance
+- [x] I’ve checked `docs/PROJECT_SPEC.md` and this is unexpected.
+- [x] This bug involves data correctness (should add/adjust a scenario-based test).
+
+---
+
+## Proposed fix scope
+1. Add regression tests for scoped rebuild close-marker semantics:
+   - Happy path: close marker consumes basis + writes allocations in scoped mode.
+   - Edge case: close-loss note exceeds available basis (cap allocation).
+   - Edge case: no parsable Net Loss note keeps existing non-close-loss behavior.
+   - Invariant: full and scoped rebuild paths produce equivalent close-marker basis outcomes.
+2. Patch `rebuild_fifo_for_pair_from` close-marker branch to mirror full rebuild logic.
+3. Re-run targeted recalculation tests and full `pytest`.
+4. Update `docs/PROJECT_SPEC.md` and `docs/status/CHANGELOG.md` with reproducible details.

--- a/docs/status/CHANGELOG.md
+++ b/docs/status/CHANGELOG.md
@@ -9,6 +9,56 @@ Rules:
 
 ---
 
+## 2026-03-10
+
+```yaml
+id: 2026-03-10-01
+type: fix
+areas: [services, tests, docs]
+issue: 158
+summary: "Fix scoped FIFO rebuild to consume close-marker basis (parity with full rebuild)"
+details: >
+  Fixed a path-dependent accounting bug in RecalculationService where scoped
+  FIFO rebuild (`rebuild_fifo_for_pair_from`) handled close-marker redemptions
+  (`amount=0` + parsable `Net Loss`) differently from full rebuild.
+
+  Root cause:
+  - Full rebuild path had Issue #156 close-marker allocation logic.
+  - Scoped rebuild path still used legacy realized-only handling for close
+    markers, writing realized loss rows without consuming basis or writing
+    redemption_allocations.
+
+  User-visible symptom:
+  - Remaining basis was overstated after close markers when scoped rebuild was
+    triggered by normal edit flows, causing Unrealized P/L to be materially wrong.
+
+  Fix behavior:
+  - Scoped rebuild now mirrors full rebuild for close markers:
+    - consume FIFO basis up to parsed close-loss amount,
+    - cap at available basis at/before close timestamp,
+    - write `redemption_allocations`,
+    - update `purchases.remaining_amount`,
+    - keep realized synchronized (`net_pl = payout - consumed_basis`).
+
+  Regression coverage:
+  - Added scoped-path tests in tests/unit/test_recalculation_service.py:
+    - close-marker basis consumption + allocation writes
+    - timestamp boundary guard (no future purchase allocation)
+
+  Validation:
+  - pytest -q tests/unit/test_recalculation_service.py -k scoped_rebuild_close_marker
+  - pytest -q tests/unit/test_recalculation_service.py
+  - pytest -q tests/integration/test_recalculation_integration.py
+  - pytest -q  (1 unrelated pre-existing failure in tests/ui/test_expenses_autocomplete.py)
+files_changed:
+  - services/recalculation_service.py
+  - tests/unit/test_recalculation_service.py
+  - docs/PROJECT_SPEC.md
+  - docs/status/CHANGELOG.md
+```
+
+---
+
 ## 2026-03-09
 
 ```yaml

--- a/services/recalculation_service.py
+++ b/services/recalculation_service.py
@@ -502,8 +502,31 @@ class RecalculationService:
 
             close_balance_loss = _parse_close_balance_loss(notes)
             if payout == 0 and close_balance_loss is not None:
-                cost_basis = close_balance_loss
-                net_pl = -close_balance_loss
+                remaining_to_allocate = close_balance_loss
+                cost_basis = Decimal("0.00")
+
+                for purchase_id, purchase_dt, _purchase_amt in purchases:
+                    if remaining_to_allocate <= 0:
+                        break
+                    if purchase_dt > red_dt:
+                        break
+
+                    avail = remaining.get(purchase_id, Decimal("0.00"))
+                    if avail <= 0:
+                        continue
+
+                    alloc = min(avail, remaining_to_allocate)
+                    if alloc <= 0:
+                        continue
+
+                    remaining[purchase_id] = avail - alloc
+                    remaining_to_allocate -= alloc
+                    cost_basis += alloc
+
+                    if purchase_id > 0:
+                        allocations_to_write.append((redemption_id, purchase_id, str(alloc)))
+
+                net_pl = payout - cost_basis
                 realized_to_write.append(
                     (
                         red_row["redemption_date"],

--- a/tests/unit/test_recalculation_service.py
+++ b/tests/unit/test_recalculation_service.py
@@ -394,3 +394,98 @@ class TestProgressTracking:
         messages = [msg for _, _, msg in progress_calls]
         assert any("[1/2]" in msg for msg in messages)
         assert any("[2/2]" in msg for msg in messages)
+
+
+class TestScopedRebuildFromBoundary:
+    """Test scoped FIFO rebuild behavior from a boundary timestamp."""
+
+    def test_scoped_rebuild_close_marker_consumes_basis_and_writes_allocations(self, test_db, service):
+        """Scoped rebuild should treat close-marker Net Loss as basis-consuming closeout."""
+        cursor = test_db._connection.cursor()
+
+        cursor.execute(
+            """
+            INSERT INTO purchases (user_id, site_id, amount, purchase_date, purchase_time, remaining_amount)
+            VALUES (1, 1, 100.0, '2024-01-01', '10:00:00', 100.0)
+            """
+        )
+        first_purchase_id = cursor.lastrowid
+        cursor.execute(
+            """
+            INSERT INTO purchases (user_id, site_id, amount, purchase_date, purchase_time, remaining_amount)
+            VALUES (1, 1, 100.0, '2024-01-02', '10:00:00', 100.0)
+            """
+        )
+        second_purchase_id = cursor.lastrowid
+
+        cursor.execute(
+            """
+            INSERT INTO redemptions (user_id, site_id, amount, redemption_date, redemption_time, more_remaining, notes)
+            VALUES (1, 1, 0.0, '2024-01-03', '10:00:00', 0, 'Balance Closed - Net Loss: $150.00')
+            """
+        )
+        close_redemption_id = cursor.lastrowid
+        test_db._connection.commit()
+
+        result = service.rebuild_fifo_for_pair_from(1, 1, '2024-01-03', '00:00:00')
+        assert result.allocations_written == 2
+
+        cursor.execute(
+            "SELECT purchase_id, allocated_amount FROM redemption_allocations WHERE redemption_id = ? ORDER BY purchase_id",
+            (close_redemption_id,),
+        )
+        allocations = cursor.fetchall()
+        assert len(allocations) == 2
+        assert allocations[0]["purchase_id"] == first_purchase_id
+        assert float(allocations[0]["allocated_amount"]) == 100.0
+        assert allocations[1]["purchase_id"] == second_purchase_id
+        assert float(allocations[1]["allocated_amount"]) == 50.0
+
+        cursor.execute("SELECT remaining_amount FROM purchases WHERE id = ?", (first_purchase_id,))
+        assert float(cursor.fetchone()["remaining_amount"]) == 0.0
+        cursor.execute("SELECT remaining_amount FROM purchases WHERE id = ?", (second_purchase_id,))
+        assert float(cursor.fetchone()["remaining_amount"]) == 50.0
+
+    def test_scoped_rebuild_close_marker_respects_timestamp_boundary(self, test_db, service):
+        """Scoped rebuild close-marker should never allocate from future purchases."""
+        cursor = test_db._connection.cursor()
+
+        cursor.execute(
+            """
+            INSERT INTO purchases (user_id, site_id, amount, purchase_date, purchase_time, remaining_amount)
+            VALUES (1, 1, 100.0, '2024-01-01', '10:00:00', 100.0)
+            """
+        )
+        eligible_purchase_id = cursor.lastrowid
+        cursor.execute(
+            """
+            INSERT INTO purchases (user_id, site_id, amount, purchase_date, purchase_time, remaining_amount)
+            VALUES (1, 1, 100.0, '2024-01-04', '10:00:00', 100.0)
+            """
+        )
+        future_purchase_id = cursor.lastrowid
+
+        cursor.execute(
+            """
+            INSERT INTO redemptions (user_id, site_id, amount, redemption_date, redemption_time, more_remaining, notes)
+            VALUES (1, 1, 0.0, '2024-01-03', '10:00:00', 0, 'Balance Closed - Net Loss: $150.00')
+            """
+        )
+        close_redemption_id = cursor.lastrowid
+        test_db._connection.commit()
+
+        service.rebuild_fifo_for_pair_from(1, 1, '2024-01-03', '00:00:00')
+
+        cursor.execute(
+            "SELECT purchase_id, allocated_amount FROM redemption_allocations WHERE redemption_id = ? ORDER BY purchase_id",
+            (close_redemption_id,),
+        )
+        allocations = cursor.fetchall()
+        assert len(allocations) == 1
+        assert allocations[0]["purchase_id"] == eligible_purchase_id
+        assert float(allocations[0]["allocated_amount"]) == 100.0
+
+        cursor.execute("SELECT remaining_amount FROM purchases WHERE id = ?", (eligible_purchase_id,))
+        assert float(cursor.fetchone()["remaining_amount"]) == 0.0
+        cursor.execute("SELECT remaining_amount FROM purchases WHERE id = ?", (future_purchase_id,))
+        assert float(cursor.fetchone()["remaining_amount"]) == 100.0


### PR DESCRIPTION
## Summary
Fixes #158 by making scoped FIFO rebuild (`rebuild_fifo_for_pair_from`) apply the same close-marker basis-consumption logic as full rebuild.

## Problem
Close-marker redemptions (`amount=0` with parsable `Net Loss: $X.XX`) were handled inconsistently:
- full rebuild: consumed basis + wrote allocations
- scoped rebuild: wrote realized only, skipped basis consumption/allocations

This caused path-dependent drift where Unrealized basis remained inflated after close markers if scoped rebuild was used.

## Root cause
`services/recalculation_service.py` had updated close-marker logic in `_rebuild_fifo_for_pair`, but not in `rebuild_fifo_for_pair_from`.

## What changed
- Updated scoped rebuild close-marker branch to:
  - consume FIFO basis up to parsed close-loss amount,
  - cap at available basis at/before close timestamp,
  - write `redemption_allocations`,
  - update `purchases.remaining_amount`,
  - keep realized synchronized (`net_pl = payout - consumed_basis`).
- Added scoped-path regression tests in `tests/unit/test_recalculation_service.py`:
  - `test_scoped_rebuild_close_marker_consumes_basis_and_writes_allocations`
  - `test_scoped_rebuild_close_marker_respects_timestamp_boundary`
- Updated docs:
  - `docs/PROJECT_SPEC.md` (explicit parity invariant)
  - `docs/status/CHANGELOG.md` (entry `2026-03-10-01`)

## Validation
- `/usr/local/bin/python3 -m pytest -q tests/unit/test_recalculation_service.py -k scoped_rebuild_close_marker`
- `/usr/local/bin/python3 -m pytest -q tests/unit/test_recalculation_service.py`
- `/usr/local/bin/python3 -m pytest -q tests/integration/test_recalculation_integration.py`
- `/usr/local/bin/python3 -m pytest -q`
  - Result: 1 unrelated pre-existing failure in `tests/ui/test_expenses_autocomplete.py`

## Pitfalls / follow-ups
- The scoped/full rebuild parity for special-case redemptions should remain covered by regression tests whenever rebuild logic is refactored.
