### PR TITLE
Fix expected-balance redemption unit conversion ($ to SC)

### DIFF
--- a/docs/PROJECT_SPEC.md
+++ b/docs/PROJECT_SPEC.md
@@ -156,6 +156,10 @@ When editing a purchase or creating/editing a game session, the system computes 
 - Sums all purchases/redemptions up to and including that timestamp
 - Uses the last closed session before the cutoff as a checkpoint (if available)
 - Returns (expected_total, expected_redeemable)
+- Unit semantics:
+  - Expected balances are tracked in **SC units**.
+  - Purchase SC inputs (`sc_received`, `starting_sc_balance`) are already SC and are applied directly.
+  - Redemption `amount` is stored in **$ units** and must be converted to SC as `amount_sc = amount_usd / site.sc_rate` before applying debit/credit events in expected-balance timelines.
 
 **Exclusion parameter (Issue #49, 2026-02-04):**
 - When editing a purchase, the system must exclude that purchase from its own expected balance calculation to avoid circular inclusion.

--- a/docs/status/CHANGELOG.md
+++ b/docs/status/CHANGELOG.md
@@ -12,6 +12,62 @@ Rules:
 ## 2026-03-10
 
 ```yaml
+id: 2026-03-10-05
+type: fix
+areas: [services, tests, docs]
+issue: null
+summary: "Convert redemption dollars to SC in expected-balance timeline math"
+details: >
+  Fixed unit mismatch in `GameSessionService.compute_expected_balances` where
+  redemption amounts (stored in dollars) were being applied as SC deltas.
+
+  Updated logic now converts redemption dollars to SC using site `sc_rate`
+  (`amount_sc = amount_usd / sc_rate`) before applying debit/credit events
+  for both pending and canceled redemption timeline events.
+
+  This resolves large false balance-check mismatches on non-unit-rate sites
+  (for example, `sc_rate=0.01` where `$64.97` equals `6497 SC`).
+
+  Validation:
+  - pytest -q tests/integration/test_compute_expected_balances_cancel.py
+files_changed:
+  - services/game_session_service.py
+  - tests/integration/test_compute_expected_balances_cancel.py
+  - docs/PROJECT_SPEC.md
+  - docs/status/CHANGELOG.md
+```
+
+```yaml
+id: 2026-03-10-04
+type: fix
+areas: [ui, tests, docs]
+issue: 162
+summary: "Auto-calc redeemable now returns full end balance when normalized wager covers ending SC"
+details: >
+  Updated End Session and Edit Closed Session auto-calc redeemable logic to
+  handle full-playthrough gain scenarios (e.g., ending balance fully redeemable
+  on site after sufficient wager).
+
+  Logic update:
+  - Added a hard-capped full-unlock branch:
+    if `(wager / playthrough_requirement) >= ending_total_sc`,
+    auto-calc sets `ending_redeemable_sc = ending_total_sc`.
+  - Existing conservative path remains for all other scenarios.
+
+  Tests:
+  - Added End Session regression test for full-unlock scenario.
+  - Added Edit Closed Session regression test for full-unlock scenario.
+
+  Validation:
+  - pytest -q tests/ui/test_end_session_auto_redeemable.py
+files_changed:
+  - ui/tabs/game_sessions_tab.py
+  - tests/ui/test_end_session_auto_redeemable.py
+  - docs/PROJECT_SPEC.md
+  - docs/status/CHANGELOG.md
+```
+
+```yaml
 id: 2026-03-10-03
 type: feature
 areas: [ui, tests, docs]

--- a/services/game_session_service.py
+++ b/services/game_session_service.py
@@ -525,6 +525,22 @@ class GameSessionService:
         expected_total = Decimal("0.00")
         expected_redeemable = Decimal("0.00")
 
+        # Redemptions are stored in dollar units; expected balances are in SC units.
+        # Convert redemption amount ($) -> SC via site.sc_rate ($ per SC).
+        site_sc_rate = Decimal("1.0")
+        if self.site_repo is not None:
+            site = self.site_repo.get_by_id(site_id)
+            if site is not None:
+                try:
+                    parsed_rate = Decimal(str(site.sc_rate))
+                    if parsed_rate > 0:
+                        site_sc_rate = parsed_rate
+                except Exception:
+                    pass
+
+        def redemption_amount_sc(amount: Decimal) -> Decimal:
+            return Decimal(str(amount)) / site_sc_rate
+
         def to_utc_dt(d: date, t: Optional[str], tz_name: Optional[str]) -> datetime:
             time_str = t or "00:00:00"
             if len(time_str) == 5:
@@ -615,7 +631,7 @@ class GameSessionService:
             # Event 1 — debit (all statuses contribute the original debit)
             if anchor_dt is None or r_dt > anchor_dt:
                 if r_dt < cutoff:
-                    amount = Decimal(str(r.amount))
+                    amount = redemption_amount_sc(r.amount)
                     expected_total -= amount
                     expected_redeemable -= amount
 
@@ -631,7 +647,7 @@ class GameSessionService:
                     if cancel_dt is not None:
                         if anchor_dt is None or cancel_dt > anchor_dt:
                             if cancel_dt < cutoff:
-                                amount = Decimal(str(r.amount))
+                                amount = redemption_amount_sc(r.amount)
                                 expected_total += amount
                                 expected_redeemable += amount
 

--- a/tests/integration/test_compute_expected_balances_cancel.py
+++ b/tests/integration/test_compute_expected_balances_cancel.py
@@ -177,3 +177,52 @@ def test_b4_uncancel_reintroduces_debit(facade, ctx):
     # Debit is back: status = PENDING, no credit event
     balance = _balance(facade, ctx, date.today() + timedelta(days=1))
     assert balance == Decimal("150.00"), f"Expected 150 after uncancel, got {balance}"
+
+
+def test_redemption_amount_converts_from_usd_to_sc_for_non_unit_rate(facade):
+    """At sc_rate=0.01, a $64.97 redemption must debit 6497 SC from expected balances."""
+    user = facade.create_user("Rate User")
+    site = facade.create_site("Rate Site", sc_rate=0.01)
+
+    # Anchor expected total at 7000 SC from a closed session.
+    sess = facade.create_game_session(
+        user_id=user.id,
+        site_id=site.id,
+        game_id=None,
+        session_date=date.today() - timedelta(days=3),
+        session_time="10:00:00",
+        starting_balance=Decimal("0.00"),
+        ending_balance=Decimal("7000.00"),
+        starting_redeemable=Decimal("0.00"),
+        ending_redeemable=Decimal("7000.00"),
+        calculate_pl=False,
+    )
+    facade.update_game_session(
+        session_id=sess.id,
+        ending_balance=Decimal("7000.00"),
+        ending_redeemable=Decimal("7000.00"),
+        end_date=date.today() - timedelta(days=3),
+        end_time="22:00:00",
+        status="Closed",
+        recalculate_pl=False,
+    )
+
+    facade.create_redemption(
+        user_id=user.id,
+        site_id=site.id,
+        amount=Decimal("64.97"),
+        redemption_date=date.today() - timedelta(days=2),
+        apply_fifo=True,
+        receipt_date=None,
+    )
+
+    total, redeem = facade.compute_expected_balances(
+        user_id=user.id,
+        site_id=site.id,
+        session_date=date.today(),
+        session_time="00:00:00",
+    )
+
+    # $64.97 / 0.01 = 6497 SC debit.
+    assert total == Decimal("503.00")
+    assert redeem == Decimal("503.00")


### PR DESCRIPTION
## Summary
Fixes expected-balance unit mismatch where redemption amounts (stored in dollars) were applied as SC deltas.

## What changed
- Convert redemption amount from $ to SC in GameSessionService.compute_expected_balances using amount_sc = amount_usd / site.sc_rate.
- Apply conversion to both debit and canceled-credit event paths.
- Add regression test for non-unit-rate site (sc_rate=0.01) proving $64.97 redemption debits 6497 SC.
- Update PROJECT_SPEC and changelog.

## Validation
- pytest -q tests/integration/test_compute_expected_balances_cancel.py (pass)

Closes #167
