### PR TITLE
Fix expected-balance chronology ordering

### DIFF
--- a/docs/PROJECT_SPEC.md
+++ b/docs/PROJECT_SPEC.md
@@ -153,13 +153,30 @@ When editing a purchase or creating/editing a game session, the system computes 
 
 **Balance computation logic (`GameSessionService.compute_expected_balances`):**
 - Takes a user/site/timestamp cutoff (and optionally an `exclude_purchase_id`)
-- Sums all purchases/redemptions up to and including that timestamp
+- Applies a single chronological event timeline up to the cutoff timestamp (across purchase snapshots and redemption deltas)
 - Uses the last closed session before the cutoff as a checkpoint (if available)
 - Returns (expected_total, expected_redeemable)
 - Unit semantics:
   - Expected balances are tracked in **SC units**.
   - Purchase SC inputs (`sc_received`, `starting_sc_balance`) are already SC and are applied directly.
   - Redemption `amount` is stored in **$ units** and must be converted to SC as `amount_sc = amount_usd / site.sc_rate` before applying debit/credit events in expected-balance timelines.
+
+**Chronological timeline invariant (Issue #169, 2026-03-12):**
+- Expected balances must represent the most recent effective state at the cutoff by applying event effects in timestamp order, regardless of event type.
+- Purchase snapshots are authoritative at their purchase timestamp (`starting_sc_balance` and, when present, `starting_redeemable_balance`).
+- Redemptions that occur **after** a purchase and **before** the cutoff must reduce the expected balances and must not be erased by later non-chronological overwrite behavior.
+- Deterministic same-timestamp ordering is required:
+  - Purchases are ordered by `(timestamp, purchase_id)` for edit/exclusion stability.
+  - Redemption cancel model remains two-event (`debit@redemption_date`, `credit@canceled_at`) and both events are inserted in the chronological timeline.
+
+**Reproducible validation scenario (Issue #169):**
+- Setup: site `sc_rate=0.01`, closed session anchor = `1000 total / 1000 redeemable`.
+- Event 1 (purchase): snapshot `starting_sc_balance=1300`.
+- Event 2 (redemption): `$5.00` after purchase and before cutoff (`500 SC` at `sc_rate=0.01`).
+- Expected at cutoff after both events:
+  - `expected_total = 1300 - 500 = 800`
+  - `expected_redeemable = 1000 - 500 = 500`
+- Regression guard: `tests/integration/test_compute_expected_balances_cancel.py::test_redemption_after_purchase_before_cutoff_is_applied_chronologically`.
 
 **Exclusion parameter (Issue #49, 2026-02-04):**
 - When editing a purchase, the system must exclude that purchase from its own expected balance calculation to avoid circular inclusion.

--- a/docs/archive/2026-03-12-issue-expected-balance-chronology.md
+++ b/docs/archive/2026-03-12-issue-expected-balance-chronology.md
@@ -1,0 +1,42 @@
+## Summary
+Expected starting balances should be derived from a single chronological event timeline as of the cutoff timestamp. Current behavior can produce pre-redemption expectations when a purchase snapshot overwrite runs after redemption application.
+
+## Problem
+`GameSessionService.compute_expected_balances()` currently applies redemptions first and then applies purchases, where purchases overwrite `expected_total` (and potentially `expected_redeemable`) using purchase checkpoint snapshots.
+
+In scenarios where a redemption occurs after a purchase but before the cutoff, this ordering can erase the redemption effect and produce stale pre-redemption expected balances.
+
+## Reproduction
+1. Create a user/site with `sc_rate = 0.01`.
+2. Ensure there is a valid anchor state before event timeline (checkpoint or last closed session).
+3. Add a purchase before cutoff with snapshot balances (e.g., total/redeemable = 1300).
+4. Add a redemption after that purchase but before cutoff (e.g., $5.00 => 500 SC).
+5. Open Start Session / compute expected balances at cutoff after both events.
+
+### Actual
+Expected balances remain at purchase snapshot values (e.g., 1300) as if redemption did not occur.
+
+### Expected
+Expected balances reflect chronological state at cutoff (e.g., 1300 - 500 = 800), with all event types (gameplay/checkpoints, purchases, redemptions) applied by timestamp order.
+
+## Scope
+- Update `compute_expected_balances()` to process event effects in chronological order.
+- Preserve existing semantics for anchors, exclusion behavior, and unit conversion (redemption USD -> SC via site rate).
+- Add regression coverage for post-purchase redemption before cutoff.
+
+## Acceptance Criteria
+- Given purchase before cutoff and redemption after purchase before cutoff, expected balances include redemption effect.
+- Same-timestamp ordering remains deterministic.
+- Excluding purchase during purchase edit still behaves correctly.
+- Existing conversion semantics (`redemption.amount` in USD) remain correct for non-unit site rates.
+
+## Test Plan
+- Add/extend integration tests in expected-balance suite:
+  - Happy path: purchase then redemption before cutoff.
+  - Edge: same timestamp deterministic behavior.
+  - Edge: with `exclude_purchase_id` and same timestamp earlier purchase IDs.
+  - Failure/invariant: verify only events before cutoff are included.
+
+## Risks / Notes
+- Purchase snapshots are still authoritative state checkpoints, but timeline processing must not wipe later events.
+- Keep changes minimal and localized to expected-balance timeline assembly.

--- a/docs/archive/2026-03-12-pr-169-body.md
+++ b/docs/archive/2026-03-12-pr-169-body.md
@@ -1,0 +1,41 @@
+## Summary
+Fix expected-balance chronology so balances at a cutoff reflect the most recent state across purchases and redemptions by timestamp order.
+
+Closes #169
+
+## Root Cause
+`compute_expected_balances()` applied redemption deltas in one pass and then applied purchases in a later pass that overwrote expected balances from purchase snapshots. When a redemption occurred after a purchase (but before cutoff), the redemption effect could be erased.
+
+## What Changed
+- Refactored expected-balance event application into a single merged timeline sorted by `(timestamp, event_priority, id)`.
+- Preserved purchase exclusion semantics (`exclude_purchase_id`) and same-timestamp purchase determinism.
+- Preserved redemption cancel/uncancel two-event model (debit at redemption time, credit at canceled time).
+- Kept redemption unit conversion (`amount_usd / sc_rate`) in place.
+
+## Test Matrix
+### Happy path
+- Purchase before cutoff + redemption after purchase before cutoff now yields post-redemption expected balances.
+
+### Edge cases
+- Same-timestamp purchase ordering remains deterministic and compatible with `exclude_purchase_id` tests.
+- Entry-timezone ordering behavior remains valid.
+
+### Failure/invariant
+- Events at/after cutoff are not applied (existing strict cutoff semantics retained).
+- Purchase edit exclusion behavior remains unchanged in integration tests.
+
+## Tests
+- Red phase (before code fix):
+  - `pytest -q tests/integration/test_compute_expected_balances_cancel.py -k redemption_after_purchase_before_cutoff_is_applied_chronologically` (failed as expected: `1300 != 800`)
+- Post-fix targeted:
+  - `pytest -q tests/integration/test_compute_expected_balances_cancel.py`
+  - `pytest -q tests/integration/test_issue_49_purchase_exclusion.py tests/integration/test_expected_balance_entry_timezone_ordering.py tests/integration/test_expected_redeemable_not_from_purchases.py`
+- Full suite:
+  - `pytest -q` → 1 unrelated pre-existing failure in `tests/ui/test_expenses_autocomplete.py::test_expense_dialog_vendor_and_notes_inline_prediction_with_tab_accept`
+
+## Manual Verification
+- Not performed in this change set (no direct UI interaction done in this PR workflow).
+
+## Pitfalls / Follow-ups
+- Same-timestamp cross-type ordering (purchase vs redemption at exact same timestamp) is deterministic but still based on implementation-defined event priority, not user-confirmed domain policy. Consider a follow-up issue to codify this policy explicitly.
+- If future event types are added to expected-balance computation, they must be inserted into the same merged timeline to avoid reintroducing overwrite drift.

--- a/docs/status/CHANGELOG.md
+++ b/docs/status/CHANGELOG.md
@@ -9,6 +9,49 @@ Rules:
 
 ---
 
+## 2026-03-12
+
+```yaml
+id: 2026-03-12-01
+type: fix
+areas: [services, tests, docs]
+issue: 169
+summary: "Apply expected balances from a single chronological event timeline"
+details: >
+  Fixed expected-balance chronology drift in `GameSessionService.compute_expected_balances`
+  where redemptions were applied in a separate pass and then purchase snapshot assignment
+  could overwrite their effect.
+
+  Root cause:
+  - Historical logic applied all redemption deltas first.
+  - Purchase application then reassigned expected totals from purchase snapshots.
+  - In timelines where a redemption occurred after a purchase but before cutoff,
+    expected balances could incorrectly reflect pre-redemption values.
+
+  Fix behavior:
+  - Build one merged, deterministic timeline of events after anchor and before cutoff.
+  - Apply purchase snapshot events and redemption debit/credit events in chronological order.
+  - Preserve existing semantics:
+    - purchase exclusion during edit (`exclude_purchase_id`)
+    - redemption unit conversion (`$ -> SC` via `sc_rate`)
+    - canceled redemption two-event model (debit + credit)
+
+  Repro scenario now covered:
+  - Anchor: 1000 total / 1000 redeemable
+  - Purchase snapshot: 1300
+  - Redemption after purchase before cutoff: $5.00 at sc_rate=0.01 (=500 SC)
+  - Correct expected balances at cutoff: total=800, redeemable=500
+
+  Validation:
+  - pytest -q tests/integration/test_compute_expected_balances_cancel.py
+  - pytest -q tests/integration/test_issue_49_purchase_exclusion.py tests/integration/test_expected_balance_entry_timezone_ordering.py tests/integration/test_expected_redeemable_not_from_purchases.py
+files_changed:
+  - services/game_session_service.py
+  - tests/integration/test_compute_expected_balances_cancel.py
+  - docs/PROJECT_SPEC.md
+  - docs/status/CHANGELOG.md
+```
+
 ## 2026-03-10
 
 ```yaml

--- a/services/game_session_service.py
+++ b/services/game_session_service.py
@@ -615,41 +615,7 @@ class GameSessionService:
             ),
         )
 
-        # Apply redemptions (delta-based) first by walking time; purchases will overwrite total.
-        # This is safe because purchase.starting_sc_balance is authoritative post-purchase.
-        #
-        # Two-event delta model (Issue #148):
-        #   PENDING / PENDING_CANCEL: one debit event at redemption_date
-        #   CANCELED: debit at redemption_date + credit at canceled_at
-        for r in redemptions_sorted:
-            r_status = getattr(r, 'status', 'PENDING') or 'PENDING'
-            r_dt = to_utc_dt(
-                r.redemption_date,
-                r.redemption_time,
-                r.redemption_entry_time_zone or get_accounting_timezone_name(),
-            )
-            # Event 1 — debit (all statuses contribute the original debit)
-            if anchor_dt is None or r_dt > anchor_dt:
-                if r_dt < cutoff:
-                    amount = redemption_amount_sc(r.amount)
-                    expected_total -= amount
-                    expected_redeemable -= amount
-
-            # Event 2 — credit back at canceled_at (CANCELED only)
-            if r_status == 'CANCELED':
-                canceled_at_str = getattr(r, 'canceled_at', None)
-                if canceled_at_str:
-                    try:
-                        # canceled_at is stored as UTC ISO datetime string
-                        cancel_dt = datetime.strptime(canceled_at_str[:19], "%Y-%m-%d %H:%M:%S")
-                    except (ValueError, TypeError):
-                        cancel_dt = None
-                    if cancel_dt is not None:
-                        if anchor_dt is None or cancel_dt > anchor_dt:
-                            if cancel_dt < cutoff:
-                                amount = redemption_amount_sc(r.amount)
-                                expected_total += amount
-                                expected_redeemable += amount
+        timeline_events = []
 
         for p in purchases_sorted:
             p_dt = to_utc_dt(
@@ -672,12 +638,52 @@ class GameSessionService:
             if exclude_purchase_id is not None and p.id == exclude_purchase_id:
                 continue
 
-            expected_total = Decimal(str(p.starting_sc_balance))
-            # Use stored redeemable snapshot from purchase if available (Issue #130)
-            if hasattr(p, 'starting_redeemable_balance') and p.starting_redeemable_balance is not None:
-                expected_redeemable = Decimal(str(p.starting_redeemable_balance))
-            # Otherwise purchases do not increase expected redeemable; redeemable is earned via play-through
-            # captured in sessions/checkpoints.
+            timeline_events.append((p_dt, 0, int(p.id or 0), "purchase", p))
+
+        # Two-event delta model (Issue #148):
+        #   PENDING / PENDING_CANCEL: one debit event at redemption_date
+        #   CANCELED: debit at redemption_date + credit at canceled_at
+        for r in redemptions_sorted:
+            r_status = getattr(r, 'status', 'PENDING') or 'PENDING'
+            r_dt = to_utc_dt(
+                r.redemption_date,
+                r.redemption_time,
+                r.redemption_entry_time_zone or get_accounting_timezone_name(),
+            )
+            if (anchor_dt is None or r_dt > anchor_dt) and r_dt < cutoff:
+                timeline_events.append((r_dt, 1, int(r.id or 0), "redemption_debit", r))
+
+            if r_status == 'CANCELED':
+                canceled_at_str = getattr(r, 'canceled_at', None)
+                if canceled_at_str:
+                    try:
+                        # canceled_at is stored as UTC ISO datetime string
+                        cancel_dt = datetime.strptime(canceled_at_str[:19], "%Y-%m-%d %H:%M:%S")
+                    except (ValueError, TypeError):
+                        cancel_dt = None
+                    if (cancel_dt is not None
+                            and (anchor_dt is None or cancel_dt > anchor_dt)
+                            and cancel_dt < cutoff):
+                        timeline_events.append((cancel_dt, 2, int(r.id or 0), "redemption_credit", r))
+
+        timeline_events.sort(key=lambda event: (event[0], event[1], event[2]))
+
+        for _, _, _, event_type, record in timeline_events:
+            if event_type == "purchase":
+                expected_total = Decimal(str(record.starting_sc_balance))
+                # Use stored redeemable snapshot from purchase if available (Issue #130)
+                if hasattr(record, 'starting_redeemable_balance') and record.starting_redeemable_balance is not None:
+                    expected_redeemable = Decimal(str(record.starting_redeemable_balance))
+                # Otherwise purchases do not increase expected redeemable; redeemable is earned via play-through
+                # captured in sessions/checkpoints.
+            elif event_type == "redemption_debit":
+                amount = redemption_amount_sc(record.amount)
+                expected_total -= amount
+                expected_redeemable -= amount
+            elif event_type == "redemption_credit":
+                amount = redemption_amount_sc(record.amount)
+                expected_total += amount
+                expected_redeemable += amount
 
         expected_total = max(Decimal("0.00"), expected_total)
         expected_redeemable = max(Decimal("0.00"), expected_redeemable)

--- a/tests/integration/test_compute_expected_balances_cancel.py
+++ b/tests/integration/test_compute_expected_balances_cancel.py
@@ -226,3 +226,64 @@ def test_redemption_amount_converts_from_usd_to_sc_for_non_unit_rate(facade):
     # $64.97 / 0.01 = 6497 SC debit.
     assert total == Decimal("503.00")
     assert redeem == Decimal("503.00")
+
+
+def test_redemption_after_purchase_before_cutoff_is_applied_chronologically(facade):
+    """A redemption after a purchase (both before cutoff) must reduce expected balances."""
+    user = facade.create_user("Chronology User")
+    site = facade.create_site("Chronology Site", sc_rate=0.01)
+
+    # Anchor at 1000/1000 from a closed session.
+    sess = facade.create_game_session(
+        user_id=user.id,
+        site_id=site.id,
+        game_id=None,
+        session_date=date.today() - timedelta(days=3),
+        session_time="10:00:00",
+        starting_balance=Decimal("0.00"),
+        ending_balance=Decimal("1000.00"),
+        starting_redeemable=Decimal("0.00"),
+        ending_redeemable=Decimal("1000.00"),
+        calculate_pl=False,
+    )
+    facade.update_game_session(
+        session_id=sess.id,
+        ending_balance=Decimal("1000.00"),
+        ending_redeemable=Decimal("1000.00"),
+        end_date=date.today() - timedelta(days=3),
+        end_time="22:00:00",
+        status="Closed",
+        recalculate_pl=False,
+    )
+
+    # Purchase snapshot is post-purchase balance.
+    facade.create_purchase(
+        user_id=user.id,
+        site_id=site.id,
+        amount=Decimal("3.00"),
+        sc_received=Decimal("300.00"),
+        starting_sc_balance=Decimal("1300.00"),
+        purchase_date=date.today() - timedelta(days=2),
+        purchase_time="10:00:00",
+    )
+
+    # $5.00 at sc_rate=0.01 => 500 SC redemption, after purchase and before cutoff.
+    facade.create_redemption(
+        user_id=user.id,
+        site_id=site.id,
+        amount=Decimal("5.00"),
+        redemption_date=date.today() - timedelta(days=2),
+        redemption_time="11:00:00",
+        apply_fifo=True,
+        receipt_date=None,
+    )
+
+    total, redeem = facade.compute_expected_balances(
+        user_id=user.id,
+        site_id=site.id,
+        session_date=date.today() - timedelta(days=2),
+        session_time="12:00:00",
+    )
+
+    assert total == Decimal("800.00")
+    assert redeem == Decimal("500.00")


### PR DESCRIPTION
## Summary
Fix expected-balance chronology so balances at a cutoff reflect the most recent state across purchases and redemptions by timestamp order.

Closes #169

## Root Cause
`compute_expected_balances()` applied redemption deltas in one pass and then applied purchases in a later pass that overwrote expected balances from purchase snapshots. When a redemption occurred after a purchase (but before cutoff), the redemption effect could be erased.

## What Changed
- Refactored expected-balance event application into a single merged timeline sorted by `(timestamp, event_priority, id)`.
- Preserved purchase exclusion semantics (`exclude_purchase_id`) and same-timestamp purchase determinism.
- Preserved redemption cancel/uncancel two-event model (debit at redemption time, credit at canceled time).
- Kept redemption unit conversion (`amount_usd / sc_rate`) in place.

## Test Matrix
### Happy path
- Purchase before cutoff + redemption after purchase before cutoff now yields post-redemption expected balances.

### Edge cases
- Same-timestamp purchase ordering remains deterministic and compatible with `exclude_purchase_id` tests.
- Entry-timezone ordering behavior remains valid.

### Failure/invariant
- Events at/after cutoff are not applied (existing strict cutoff semantics retained).
- Purchase edit exclusion behavior remains unchanged in integration tests.

## Tests
- Red phase (before code fix):
  - `pytest -q tests/integration/test_compute_expected_balances_cancel.py -k redemption_after_purchase_before_cutoff_is_applied_chronologically` (failed as expected: `1300 != 800`)
- Post-fix targeted:
  - `pytest -q tests/integration/test_compute_expected_balances_cancel.py`
  - `pytest -q tests/integration/test_issue_49_purchase_exclusion.py tests/integration/test_expected_balance_entry_timezone_ordering.py tests/integration/test_expected_redeemable_not_from_purchases.py`
- Full suite:
  - `pytest -q` → 1 unrelated pre-existing failure in `tests/ui/test_expenses_autocomplete.py::test_expense_dialog_vendor_and_notes_inline_prediction_with_tab_accept`

## Manual Verification
- Not performed in this change set (no direct UI interaction done in this PR workflow).

## Pitfalls / Follow-ups
- Same-timestamp cross-type ordering (purchase vs redemption at exact same timestamp) is deterministic but still based on implementation-defined event priority, not user-confirmed domain policy. Consider a follow-up issue to codify this policy explicitly.
- If future event types are added to expected-balance computation, they must be inserted into the same merged timeline to avoid reintroducing overwrite drift.
