### PR TITLE
Issue #179: harden auto-update relaunch diagnostics

### DIFF
--- a/docs/PROJECT_SPEC.md
+++ b/docs/PROJECT_SPEC.md
@@ -236,6 +236,10 @@ Update infrastructure is exposed to users through three desktop entry points:
   - spawns background apply script,
   - quits app,
   - replaces app bundle and relaunches automatically.
+- Auto-install diagnostics/fallback:
+  - apply script writes output to `~/Library/Application Support/Sezzions/update-installer.log`,
+  - if auto-install cannot be started (for example permission denied or invalid archive),
+    manual install fallback dialog includes actionable failure reason + log path.
 - If running from source/dev mode (`python3 sezzions.py`) or asset type is not auto-installable:
   - updater falls back to manual install guidance and opens download folder.
 

--- a/docs/status/CHANGELOG.md
+++ b/docs/status/CHANGELOG.md
@@ -12,6 +12,36 @@ Rules:
 ## 2026-03-12
 
 ```yaml
+id: 2026-03-12-19
+type: fix
+areas: [updater, ui, tests, docs]
+issue: 179
+summary: "Improve packaged auto-update fallback diagnostics and installer logging"
+details: >
+  Hardened packaged auto-update install flow so failures are diagnosable and
+  manual fallback is more actionable.
+
+  Implemented:
+  - `ui/main_window.py` now records auto-install failure reasons for fallback UI.
+  - Added installer log path helper: `~/Library/Application Support/Sezzions/update-installer.log`.
+  - Background apply script now appends output to installer log file.
+  - Manual fallback dialog now includes:
+    - auto-install failure reason,
+    - installer log location,
+    - existing downloaded file/folder guidance.
+  - Added preflight diagnostic checks for common failure causes (e.g., non-zip,
+    missing app bundle, destination write permission).
+
+  Validation:
+  - /usr/local/bin/python3 -m pytest -q tests/ui/test_update_ui.py
+files_changed:
+  - ui/main_window.py
+  - tests/ui/test_update_ui.py
+  - docs/PROJECT_SPEC.md
+  - docs/status/CHANGELOG.md
+```
+
+```yaml
 id: 2026-03-12-18
 type: fix
 areas: [startup, settings, tools, release, tests, docs]

--- a/tests/ui/test_update_ui.py
+++ b/tests/ui/test_update_ui.py
@@ -192,3 +192,67 @@ def test_update_now_disabled_in_development_runtime(tmp_path, monkeypatch):
     window.close()
     facade.db.close()
     app.processEvents()
+
+
+def test_update_now_fallback_includes_failure_reason_and_log_path(tmp_path, monkeypatch):
+    app = QApplication.instance() or QApplication([])
+    facade = AppFacade(str(tmp_path / "ui_updates_fallback.db"))
+    window = MainWindow(facade)
+
+    downloaded_zip = tmp_path / "Downloads" / "Sezzions Updates" / "v1.0.3" / "sezzions-macos-arm64.zip"
+    downloaded_zip.parent.mkdir(parents=True, exist_ok=True)
+    downloaded_zip.write_bytes(b"fake")
+
+    facade.download_app_update = lambda asset, destination_dir: str(downloaded_zip)
+
+    monkeypatch.setattr(window, "_try_auto_install_downloaded_update", lambda path: False)
+    window._last_update_install_error = "No write permission for app destination"
+
+    open_calls = {}
+    monkeypatch.setattr(
+        "ui.main_window.QtGui.QDesktopServices.openUrl",
+        lambda url: open_calls.setdefault("url", str(url.toString())),
+    )
+
+    info_calls = {}
+
+    def _fake_info(parent, title, text):
+        info_calls["title"] = title
+        info_calls["text"] = text
+
+    monkeypatch.setattr("ui.main_window.QtWidgets.QMessageBox.information", _fake_info)
+
+    window._update_now(
+        {
+            "asset": {"platform": "macos-arm64", "url": "https://example.com/app.zip", "sha256": "abc"},
+            "latest_version": "1.0.3",
+        }
+    )
+
+    assert "Update Downloaded" == info_calls["title"]
+    assert "No write permission for app destination" in info_calls["text"]
+    assert "update-installer.log" in info_calls["text"]
+    assert "url" in open_calls
+
+    window.close()
+    facade.db.close()
+    app.processEvents()
+
+
+def test_record_update_install_error_writes_details_to_log(tmp_path, monkeypatch):
+    app = QApplication.instance() or QApplication([])
+    facade = AppFacade(str(tmp_path / "ui_updates_log.db"))
+    window = MainWindow(facade)
+
+    log_file = tmp_path / "update-installer.log"
+    monkeypatch.setattr(window, "_update_install_log_path", lambda: log_file)
+
+    window._record_update_install_error("test failure", details="trace line 1")
+
+    assert window._last_update_install_error == "test failure"
+    assert log_file.exists()
+    assert "trace line 1" in log_file.read_text(encoding="utf-8")
+
+    window.close()
+    facade.db.close()
+    app.processEvents()

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import shutil
 import subprocess
 import sys
+import traceback
 import zipfile
 from app_facade import AppFacade
 from ui.tabs.purchases_tab import PurchasesTab
@@ -1121,21 +1122,48 @@ class MainWindow(QtWidgets.QMainWindow):
             return
 
         QtGui.QDesktopServices.openUrl(QtCore.QUrl.fromLocalFile(str(downloaded_file.parent)))
+        failure_reason = getattr(self, "_last_update_install_error", "Automatic install could not be started.")
+        log_path = self._update_install_log_path()
         QtWidgets.QMessageBox.information(
             self,
             "Update Downloaded",
             "Update downloaded successfully.\n\n"
             f"File: {downloaded_file.name}\n"
             f"Location: {downloaded_file.parent}\n\n"
+            f"Auto-install status: {failure_reason}\n"
+            f"Installer log: {log_path}\n\n"
             "Install manually from this folder.",
         )
+
+    def _update_install_log_path(self) -> Path:
+        return Path.home() / "Library" / "Application Support" / "Sezzions" / "update-installer.log"
+
+    def _record_update_install_error(self, message: str, details: str | None = None) -> None:
+        self._last_update_install_error = message
+        if not details:
+            return
+        self._append_update_install_log(details)
+
+    def _append_update_install_log(self, details: str) -> None:
+        log_path = self._update_install_log_path()
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        with log_path.open("a", encoding="utf-8") as fh:
+            fh.write(details.rstrip() + "\n")
 
     def _try_auto_install_downloaded_update(self, downloaded_file: Path) -> bool:
         running_app_bundle = self._running_app_bundle_path()
         if running_app_bundle is None:
+            self._record_update_install_error("Packaged app bundle was not detected.")
             return False
 
         if downloaded_file.suffix.lower() != ".zip":
+            self._record_update_install_error("Downloaded update is not a zip archive.")
+            return False
+
+        if not os.access(str(running_app_bundle.parent), os.W_OK):
+            self._record_update_install_error(
+                f"No write permission for app destination: {running_app_bundle.parent}"
+            )
             return False
 
         try:
@@ -1149,6 +1177,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
             app_candidates = sorted(extract_dir.rglob("*.app"))
             if not app_candidates:
+                self._record_update_install_error("No .app bundle found in downloaded update archive.")
                 return False
 
             candidate = None
@@ -1160,12 +1189,17 @@ class MainWindow(QtWidgets.QMainWindow):
                 candidate = app_candidates[0]
 
             script_path = extract_dir / "apply_update.sh"
+            log_path = self._update_install_log_path()
             script_path.write_text(
                 "#!/bin/bash\n"
                 "set -e\n"
                 "NEW_APP=\"$1\"\n"
                 "TARGET_APP=\"$2\"\n"
                 "APP_PID=\"$3\"\n"
+                "LOG_FILE=\"$4\"\n"
+                "mkdir -p \"$(dirname \"$LOG_FILE\")\"\n"
+                "exec >> \"$LOG_FILE\" 2>&1\n"
+                "echo \"[Sezzions Updater] Starting apply script\"\n"
                 "while kill -0 \"$APP_PID\" >/dev/null 2>&1; do sleep 1; done\n"
                 "rm -rf \"$TARGET_APP\"\n"
                 "ditto \"$NEW_APP\" \"$TARGET_APP\"\n"
@@ -1181,13 +1215,18 @@ class MainWindow(QtWidgets.QMainWindow):
                     str(candidate),
                     str(running_app_bundle),
                     str(os.getpid()),
+                    str(log_path),
                 ],
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
                 start_new_session=True,
             )
             return True
-        except Exception:
+        except Exception as exc:
+            self._record_update_install_error(
+                f"Automatic install failed to start: {exc}",
+                details=traceback.format_exc(),
+            )
             return False
 
     def _running_app_bundle_path(self) -> Path | None:


### PR DESCRIPTION
## Summary
Harden packaged auto-update relaunch behavior and improve diagnostics when auto-install cannot proceed.

Closes #179.

## What changed
- `ui/main_window.py`
  - Added installer log path helper: `~/Library/Application Support/Sezzions/update-installer.log`
  - Added `_record_update_install_error(...)` and `_append_update_install_log(...)`
  - Added preflight failure reasons for common install blockers:
    - no packaged app bundle detected
    - non-zip downloaded asset
    - destination write permission denied
    - missing `.app` in extracted archive
  - Updated apply script to append output to installer log file
  - Updated manual fallback dialog to include:
    - auto-install status reason
    - installer log path
- `tests/ui/test_update_ui.py`
  - Added fallback test asserting manual dialog includes failure reason + log path
  - Added log-write test for `_record_update_install_error(...)`
- Docs:
  - `docs/PROJECT_SPEC.md` updater semantics updated
  - `docs/status/CHANGELOG.md` entry `2026-03-12-19`

## Red -> Green
- Added new UI tests first, then implemented diagnostics + logging behavior to satisfy them.

## Validation
- `/usr/local/bin/python3 -m pytest -q tests/ui/test_update_ui.py`
- `/usr/local/bin/python3 -m pytest -q`
  - Result: one unrelated intermittent failure in
    `tests/ui/test_expenses_autocomplete.py::test_expense_dialog_vendor_and_notes_inline_prediction_with_tab_accept`
  - Re-run of that exact test immediately passed.

## Pitfalls / Follow-ups
- Full end-to-end auto-relaunch behavior still depends on real-world app location permissions/signing context; manual packaged-app verification remains recommended for `/Applications` installs.
