### PR TITLE
Consolidate updater/release channel to Sezzions repo

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -14,7 +14,7 @@ on:
         default: true
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   build-macos:
@@ -91,7 +91,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-macos, build-windows]
     permissions:
-      contents: read
+      contents: write
 
     steps:
       - name: Checkout
@@ -122,13 +122,8 @@ jobs:
 
       - name: Publish update assets
         env:
-          GH_TOKEN: ${{ secrets.SEZZIONS_UPDATES_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: |
-          if [ -z "${GH_TOKEN}" ]; then
-            echo "SEZZIONS_UPDATES_TOKEN secret is required" >&2
-            exit 1
-          fi
-
           VERSION_INPUT="${{ github.event.inputs.version }}"
           NEXT_PATCH_INPUT="${{ github.event.inputs.next_patch }}"
 

--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@ python3 sezzions.py
 
 ## Download (Latest Executables)
 
-Direct binary downloads (public updates repo):
+Direct binary downloads:
 
-- macOS (Apple Silicon): https://github.com/foo-yay/sezzions-updates/releases/latest/download/sezzions-macos-arm64.zip
-- Windows (x64): https://github.com/foo-yay/sezzions-updates/releases/latest/download/sezzions-windows-x64.zip
+- macOS (Apple Silicon): https://github.com/foo-yay/Sezzions/releases/latest/download/sezzions-macos-arm64.zip
+- Windows (x64): https://github.com/foo-yay/Sezzions/releases/latest/download/sezzions-windows-x64.zip
 
 Manifest used by in-app updater:
 
-- https://github.com/foo-yay/sezzions-updates/releases/latest/download/latest.json
+- https://github.com/foo-yay/Sezzions/releases/latest/download/latest.json
 
 ## Database Location
 

--- a/docs/PROJECT_SPEC.md
+++ b/docs/PROJECT_SPEC.md
@@ -105,10 +105,9 @@ This spec defines the canonical workflow expectations and documentation policy (
 Sezzions update discovery/download is implemented as a service-layer workflow sourced from GitHub Releases artifacts (not Git operations).
 
 Default manifest host:
-- Production default points to a dedicated **public updates repository** release asset:
-  - `https://github.com/foo-yay/sezzions-updates/releases/latest/download/latest.json`
-- This allows update checks/downloads for end users while the primary `Sezzions` source
-  repository remains private.
+- Production default points to Sezzions release assets:
+  - `https://github.com/foo-yay/Sezzions/releases/latest/download/latest.json`
+- This keeps source and update channels in one repository.
 
 Release automation command (Issue #174):
 - Sezzions includes `tools/release_update.py` for one-command updater publishing.
@@ -118,7 +117,7 @@ Release automation command (Issue #174):
   - Build macOS arm64 app bundle via PyInstaller,
   - zip artifact as `sezzions-macos-arm64.zip`,
   - generate `latest.json` with SHA-256 and release URLs,
-  - create/update release `vX.Y.Z` in `foo-yay/sezzions-updates`,
+  - create/update release `vX.Y.Z` in `foo-yay/Sezzions`,
   - upload binary asset(s) + manifest with `--clobber` semantics.
 - Optional flags:
   - `--next-patch` (uses highest of local `__version__` and latest published

--- a/docs/status/CHANGELOG.md
+++ b/docs/status/CHANGELOG.md
@@ -12,6 +12,38 @@ Rules:
 ## 2026-03-12
 
 ```yaml
+id: 2026-03-12-22
+type: fix
+areas: [updater, release, docs, ci, tests]
+issue: null
+summary: "Consolidate updater and release automation defaults to Sezzions repository"
+details: >
+  Moved update manifest/release defaults from `foo-yay/sezzions-updates` to
+  `foo-yay/Sezzions` to simplify release operations and avoid cross-repo publish
+  confusion.
+
+  Implemented:
+  - `services/update_service.py` default manifest URL now points to Sezzions releases.
+  - `tools/release_update.py` default updates repo now points to `foo-yay/Sezzions`.
+  - Release workflow now uses repository `GITHUB_TOKEN` with `contents: write`
+    (no separate `SEZZIONS_UPDATES_TOKEN` requirement).
+  - Updated README/tools/spec docs and added regression tests for new defaults.
+
+  Validation:
+  - pytest -q tests/unit/test_update_service.py tests/unit/test_release_update_tool.py
+files_changed:
+  - services/update_service.py
+  - tools/release_update.py
+  - .github/workflows/release-binaries.yml
+  - README.md
+  - tools/README.md
+  - docs/PROJECT_SPEC.md
+  - tests/unit/test_update_service.py
+  - tests/unit/test_release_update_tool.py
+  - docs/status/CHANGELOG.md
+```
+
+```yaml
 id: 2026-03-12-21
 type: release
 areas: [release, versioning]

--- a/services/update_service.py
+++ b/services/update_service.py
@@ -12,7 +12,7 @@ from urllib.error import HTTPError, URLError
 from urllib.request import urlopen
 
 
-DEFAULT_UPDATE_MANIFEST_URL = "https://github.com/foo-yay/sezzions-updates/releases/latest/download/latest.json"
+DEFAULT_UPDATE_MANIFEST_URL = "https://github.com/foo-yay/Sezzions/releases/latest/download/latest.json"
 
 
 @dataclass(frozen=True)

--- a/tests/unit/test_release_update_tool.py
+++ b/tests/unit/test_release_update_tool.py
@@ -23,6 +23,10 @@ def test_release_tag_uses_normalized_version():
     assert release_tag("v1.0.0") == "v1.0.0"
 
 
+def test_default_updates_repo_points_to_sezzions_repo():
+    assert release_update.DEFAULT_UPDATES_REPO == "foo-yay/Sezzions"
+
+
 def test_build_manifest_uses_updates_repo_asset_url():
     manifest = build_manifest(
         version="1.0.1",

--- a/tests/unit/test_update_service.py
+++ b/tests/unit/test_update_service.py
@@ -2,7 +2,11 @@ from pathlib import Path
 import ssl
 from urllib.error import HTTPError, URLError
 
-from services.update_service import UpdateAsset, UpdateService
+from services.update_service import DEFAULT_UPDATE_MANIFEST_URL, UpdateAsset, UpdateService
+
+
+def test_default_manifest_url_points_to_sezzions_repo():
+    assert DEFAULT_UPDATE_MANIFEST_URL == "https://github.com/foo-yay/Sezzions/releases/latest/download/latest.json"
 
 
 def _make_fetcher(payloads: dict[str, bytes]):

--- a/tools/README.md
+++ b/tools/README.md
@@ -15,7 +15,7 @@ Builds and publishes updater assets with a single command:
 - builds macOS arm64 app artifact via PyInstaller,
 - zips the app bundle,
 - generates `latest.json` with SHA-256,
-- uploads assets + manifest to `foo-yay/sezzions-updates` release `v<version>`.
+- uploads assets + manifest to `foo-yay/Sezzions` release `v<version>`.
 
 Binary-only distribution note:
 - GitHub auto-generates source archives for every release and they cannot be removed.
@@ -68,7 +68,8 @@ What it does:
 - supports explicit version input or automatic patch bump.
 
 Prerequisite:
-- Configure repository secret `SEZZIONS_UPDATES_TOKEN` with a PAT that can create/update releases in `foo-yay/sezzions-updates`.
+- No separate cross-repo PAT is required when publishing to the same repository.
+- Workflow uses GitHub Actions `GITHUB_TOKEN` with `contents: write` permission.
 
 ### Schema Validation
 ```bash

--- a/tools/release_update.py
+++ b/tools/release_update.py
@@ -13,7 +13,7 @@ from typing import Any
 
 
 DEFAULT_SOURCE_REPO = "foo-yay/Sezzions"
-DEFAULT_UPDATES_REPO = "foo-yay/sezzions-updates"
+DEFAULT_UPDATES_REPO = "foo-yay/Sezzions"
 DEFAULT_PLATFORM_KEY = "macos-arm64"
 DEFAULT_BINARY_BASENAME = "sezzions-macos-arm64"
 DEFAULT_VERSION_FILE = "__init__.py"


### PR DESCRIPTION
Switch updater manifest and release automation defaults from foo-yay/sezzions-updates to foo-yay/Sezzions, update release workflow to use repository GITHUB_TOKEN, and refresh docs/tests accordingly.\n\nValidation:\n- pytest -q tests/unit/test_update_service.py tests/unit/test_release_update_tool.py\n- pytest -q (full suite): 1047 passed, 1 skipped\n