### PR TITLE
Reinstate split updater repo + enforce release guardrails

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -14,7 +14,7 @@ on:
         default: true
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   build-macos:
@@ -91,7 +91,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-macos, build-windows]
     permissions:
-      contents: write
+      contents: read
 
     steps:
       - name: Checkout
@@ -122,8 +122,13 @@ jobs:
 
       - name: Publish update assets
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.SEZZIONS_UPDATES_TOKEN }}
         run: |
+          if [ -z "${GH_TOKEN}" ]; then
+            echo "SEZZIONS_UPDATES_TOKEN secret is required" >&2
+            exit 1
+          fi
+
           VERSION_INPUT="${{ github.event.inputs.version }}"
           NEXT_PATCH_INPUT="${{ github.event.inputs.next_patch }}"
 

--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@ python3 sezzions.py
 
 ## Download (Latest Executables)
 
-Direct binary downloads:
+Direct binary downloads (public updates repo):
 
-- macOS (Apple Silicon): https://github.com/foo-yay/Sezzions/releases/latest/download/sezzions-macos-arm64.zip
-- Windows (x64): https://github.com/foo-yay/Sezzions/releases/latest/download/sezzions-windows-x64.zip
+- macOS (Apple Silicon): https://github.com/foo-yay/sezzions-updates/releases/latest/download/sezzions-macos-arm64.zip
+- Windows (x64): https://github.com/foo-yay/sezzions-updates/releases/latest/download/sezzions-windows-x64.zip
 
 Manifest used by in-app updater:
 
-- https://github.com/foo-yay/Sezzions/releases/latest/download/latest.json
+- https://github.com/foo-yay/sezzions-updates/releases/latest/download/latest.json
 
 ## Database Location
 

--- a/docs/PROJECT_SPEC.md
+++ b/docs/PROJECT_SPEC.md
@@ -105,9 +105,10 @@ This spec defines the canonical workflow expectations and documentation policy (
 Sezzions update discovery/download is implemented as a service-layer workflow sourced from GitHub Releases artifacts (not Git operations).
 
 Default manifest host:
-- Production default points to Sezzions release assets:
-  - `https://github.com/foo-yay/Sezzions/releases/latest/download/latest.json`
-- This keeps source and update channels in one repository.
+- Production default points to a dedicated **public updates repository** release asset:
+  - `https://github.com/foo-yay/sezzions-updates/releases/latest/download/latest.json`
+- This allows update checks/downloads for end users while the primary `Sezzions` source
+  repository remains private.
 
 Release automation command (Issue #174):
 - Sezzions includes `tools/release_update.py` for one-command updater publishing.
@@ -117,7 +118,7 @@ Release automation command (Issue #174):
   - Build macOS arm64 app bundle via PyInstaller,
   - zip artifact as `sezzions-macos-arm64.zip`,
   - generate `latest.json` with SHA-256 and release URLs,
-  - create/update release `vX.Y.Z` in `foo-yay/Sezzions`,
+  - create/update release `vX.Y.Z` in `foo-yay/sezzions-updates`,
   - upload binary asset(s) + manifest with `--clobber` semantics.
 - Optional flags:
   - `--next-patch` (uses highest of local `__version__` and latest published
@@ -137,6 +138,11 @@ Cross-platform binary publish workflow:
   both `macos-arm64` and `windows-x64` assets in one run.
 - Workflow supports explicit version input or automatic patch bump behavior.
 - Windows builds are generated on GitHub-hosted Windows runners (no local Windows machine required).
+
+Canonical release channel policy (guardrail):
+- `foo-yay/Sezzions` is development/source-of-truth and may publish source tags.
+- `foo-yay/sezzions-updates` is the only public updater channel for `latest.json` + binaries.
+- Update publishing to source repo is disallowed by tooling (`tools/release_update.py`).
 
 Release page/source archive policy:
 - GitHub release source archives (`zip`/`tar.gz`) are auto-generated and cannot be removed.

--- a/docs/status/CHANGELOG.md
+++ b/docs/status/CHANGELOG.md
@@ -12,6 +12,40 @@ Rules:
 ## 2026-03-12
 
 ```yaml
+id: 2026-03-12-24
+type: fix
+areas: [updater, release, docs, ci, tests]
+issue: null
+summary: "Reinstate split-repo updater channel and enforce release guardrails"
+details: >
+  Reverted updater/release defaults back to the dedicated public updates repo
+  (`foo-yay/sezzions-updates`) so source development remains in private
+  `foo-yay/Sezzions` while binaries/manifests publish to the public updates channel.
+
+  Implemented:
+  - Restored default manifest URL to `sezzions-updates`.
+  - Restored release automation default updates repo to `sezzions-updates`.
+  - Added tooling guardrail: `tools/release_update.py` now fails when updates
+    repo equals source repo.
+  - Restored workflow publishing via `SEZZIONS_UPDATES_TOKEN` for cross-repo release writes.
+  - Updated README/tools/spec docs with canonical split-repo policy.
+  - Updated/added unit tests for defaults and repo-separation guard.
+
+  Validation:
+  - pytest -q tests/unit/test_update_service.py tests/unit/test_release_update_tool.py
+files_changed:
+  - services/update_service.py
+  - tools/release_update.py
+  - .github/workflows/release-binaries.yml
+  - README.md
+  - tools/README.md
+  - docs/PROJECT_SPEC.md
+  - tests/unit/test_update_service.py
+  - tests/unit/test_release_update_tool.py
+  - docs/status/CHANGELOG.md
+```
+
+```yaml
 id: 2026-03-12-23
 type: release
 areas: [release, versioning, updater]

--- a/services/update_service.py
+++ b/services/update_service.py
@@ -12,7 +12,7 @@ from urllib.error import HTTPError, URLError
 from urllib.request import urlopen
 
 
-DEFAULT_UPDATE_MANIFEST_URL = "https://github.com/foo-yay/Sezzions/releases/latest/download/latest.json"
+DEFAULT_UPDATE_MANIFEST_URL = "https://github.com/foo-yay/sezzions-updates/releases/latest/download/latest.json"
 
 
 @dataclass(frozen=True)

--- a/tests/unit/test_release_update_tool.py
+++ b/tests/unit/test_release_update_tool.py
@@ -24,7 +24,16 @@ def test_release_tag_uses_normalized_version():
 
 
 def test_default_updates_repo_points_to_sezzions_repo():
-    assert release_update.DEFAULT_UPDATES_REPO == "foo-yay/Sezzions"
+    assert release_update.DEFAULT_UPDATES_REPO == "foo-yay/sezzions-updates"
+
+
+def test_ensure_updates_repo_is_separate_allows_split_repos():
+    release_update.ensure_updates_repo_is_separate("foo-yay/Sezzions", "foo-yay/sezzions-updates")
+
+
+def test_ensure_updates_repo_is_separate_rejects_same_repo():
+    with pytest.raises(RuntimeError, match="must be separate"):
+        release_update.ensure_updates_repo_is_separate("foo-yay/Sezzions", "foo-yay/Sezzions")
 
 
 def test_build_manifest_uses_updates_repo_asset_url():

--- a/tests/unit/test_update_service.py
+++ b/tests/unit/test_update_service.py
@@ -6,7 +6,7 @@ from services.update_service import DEFAULT_UPDATE_MANIFEST_URL, UpdateAsset, Up
 
 
 def test_default_manifest_url_points_to_sezzions_repo():
-    assert DEFAULT_UPDATE_MANIFEST_URL == "https://github.com/foo-yay/Sezzions/releases/latest/download/latest.json"
+    assert DEFAULT_UPDATE_MANIFEST_URL == "https://github.com/foo-yay/sezzions-updates/releases/latest/download/latest.json"
 
 
 def _make_fetcher(payloads: dict[str, bytes]):

--- a/tools/README.md
+++ b/tools/README.md
@@ -15,7 +15,7 @@ Builds and publishes updater assets with a single command:
 - builds macOS arm64 app artifact via PyInstaller,
 - zips the app bundle,
 - generates `latest.json` with SHA-256,
-- uploads assets + manifest to `foo-yay/Sezzions` release `v<version>`.
+- uploads assets + manifest to `foo-yay/sezzions-updates` release `v<version>`.
 
 Binary-only distribution note:
 - GitHub auto-generates source archives for every release and they cannot be removed.
@@ -68,8 +68,12 @@ What it does:
 - supports explicit version input or automatic patch bump.
 
 Prerequisite:
-- No separate cross-repo PAT is required when publishing to the same repository.
-- Workflow uses GitHub Actions `GITHUB_TOKEN` with `contents: write` permission.
+- Configure repository secret `SEZZIONS_UPDATES_TOKEN` with a PAT that can create/update releases in `foo-yay/sezzions-updates`.
+
+Canonical release guardrail:
+- Development/source tags remain in `foo-yay/Sezzions`.
+- Updater manifest + binary assets are published only to `foo-yay/sezzions-updates`.
+- `tools/release_update.py` enforces repo separation and fails if `--updates-repo` equals source repo.
 
 ### Schema Validation
 ```bash

--- a/tools/release_update.py
+++ b/tools/release_update.py
@@ -13,10 +13,22 @@ from typing import Any
 
 
 DEFAULT_SOURCE_REPO = "foo-yay/Sezzions"
-DEFAULT_UPDATES_REPO = "foo-yay/Sezzions"
+DEFAULT_UPDATES_REPO = "foo-yay/sezzions-updates"
 DEFAULT_PLATFORM_KEY = "macos-arm64"
 DEFAULT_BINARY_BASENAME = "sezzions-macos-arm64"
 DEFAULT_VERSION_FILE = "__init__.py"
+
+
+def _normalize_repo_name(repo: str) -> str:
+    return (repo or "").strip().lower()
+
+
+def ensure_updates_repo_is_separate(source_repo: str, updates_repo: str) -> None:
+    if _normalize_repo_name(source_repo) == _normalize_repo_name(updates_repo):
+        raise RuntimeError(
+            "Updates repo must be separate from source repo. "
+            "Publish updater binaries/manifest to foo-yay/sezzions-updates."
+        )
 
 
 def normalize_version(version: str) -> str:
@@ -344,6 +356,7 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> int:
     args = parse_args()
+    ensure_updates_repo_is_separate(args.source_repo, args.updates_repo)
     version_file = Path(args.version_file)
     latest_published_version = read_latest_release_version(args.updates_repo)
 


### PR DESCRIPTION
Restores updater/download channel to foo-yay/sezzions-updates while keeping Sezzions as source/dev repo. Adds tooling guardrails to prevent publishing updater assets to source repo again.\n\nWhat changed:\n- Default manifest URL back to sezzions-updates\n- release_update default updates repo back to sezzions-updates\n- Hard guard: release_update fails if updates repo == source repo\n- release-binaries workflow restored to SEZZIONS_UPDATES_TOKEN cross-repo publish\n- README/tools/spec updated with canonical split-repo policy\n- unit tests updated + new guardrail tests\n\nValidation:\n- pytest -q tests/unit/test_update_service.py tests/unit/test_release_update_tool.py\n- pytest -q (full suite): 1049 passed, 1 skipped\n