### PR TITLE
Fix settings.json persistence path consistency

### DIFF
--- a/app_facade.py
+++ b/app_facade.py
@@ -59,6 +59,7 @@ from services.timestamp_service import TimestampService
 from services.audit_service import AuditService
 from services.undo_redo_service import UndoRedoService
 from services.update_service import UpdateService, UpdateAsset, DEFAULT_UPDATE_MANIFEST_URL
+from services.db_location_service import settings_file_path
 from repositories.notification_repository import NotificationRepository
 import __init__ as sezzions_package
 
@@ -187,7 +188,7 @@ class AppFacade:
         self.csv_export_service = CSVExportService(self.db)
         
         # Notification services
-        notification_settings_path = str(Path(self.db_path).parent / "settings.json")
+        notification_settings_path = str(settings_file_path())
         self.notification_repo = NotificationRepository(settings_file=notification_settings_path)
         self.notification_service = NotificationService(self.notification_repo)
         self.notification_rules_service = NotificationRulesService(

--- a/docs/PROJECT_SPEC.md
+++ b/docs/PROJECT_SPEC.md
@@ -1287,8 +1287,10 @@ When derived data (FIFO allocations, cost basis, P/L) becomes corrupted, automat
 
 **Settings Persistence Architecture:**
 - Settings stored in `settings.json` with nested structure (e.g., `automatic_backup` object)
-- Settings default path is local to current working directory: `./settings.json`
-- This keeps DB/settings discoverable and colocated for local-run workflows.
+- Settings default path is runtime-resolved via canonical config location:
+  - source/dev: project-root `settings.json`
+  - packaged runtime: `~/Library/Application Support/Sezzions/settings.json`
+- Components that persist settings must share this same path to avoid split state.
 - Each `Settings()` instantiation loads fresh from disk—no singleton pattern currently
 - **Critical Pattern**: Components that partially update settings.json must reload from disk first
   - Example: `MainWindow.closeEvent()` reloads settings before saving window geometry to avoid overwriting other components' changes (e.g., ToolsTab's automatic_backup config)

--- a/docs/status/CHANGELOG.md
+++ b/docs/status/CHANGELOG.md
@@ -12,6 +12,32 @@ Rules:
 ## 2026-03-12
 
 ```yaml
+id: 2026-03-12-26
+type: fix
+areas: [settings, notifications, ui, startup, tests]
+issue: null
+summary: "Unify settings persistence path to prevent split-state config saves"
+details: >
+  Fixed inconsistent settings persistence where some components wrote to
+  working-directory `settings.json` while others wrote to a different path,
+  causing theme and related preferences to appear non-persistent.
+
+  Implemented:
+  - `ui/settings.py` now resolves defaults via `services.db_location_service.settings_file_path()`.
+  - `app_facade.py` notification repository now uses the same canonical settings path.
+  - Updated unit tests and spec documentation to reflect the canonical path behavior.
+
+  Validation:
+  - pytest -q tests/unit/test_settings_paths.py tests/unit/test_update_service.py tests/unit/test_release_update_tool.py
+files_changed:
+  - ui/settings.py
+  - app_facade.py
+  - tests/unit/test_settings_paths.py
+  - docs/PROJECT_SPEC.md
+  - docs/status/CHANGELOG.md
+```
+
+```yaml
 id: 2026-03-12-25
 type: release
 areas: [release, versioning, updater]

--- a/tests/unit/test_settings_paths.py
+++ b/tests/unit/test_settings_paths.py
@@ -1,12 +1,13 @@
+from services.db_location_service import settings_file_path
 from ui.settings import Settings, default_settings_file
 
 
 def test_default_settings_file_uses_project_relative_path_when_not_frozen(monkeypatch):
-    assert default_settings_file() == "settings.json"
+    assert default_settings_file() == str(settings_file_path())
 
 
 def test_default_settings_file_is_always_project_relative():
-    assert default_settings_file() == "settings.json"
+    assert default_settings_file() == str(settings_file_path())
 
 
 def test_settings_uses_default_resolved_path_when_not_provided(monkeypatch, tmp_path):

--- a/ui/settings.py
+++ b/ui/settings.py
@@ -7,11 +7,12 @@ import json
 import os
 from pathlib import Path
 from typing import Any, Dict
+from services.db_location_service import settings_file_path
 
 
 def default_settings_file() -> str:
-    """Return default settings file path in current working directory."""
-    return "settings.json"
+    """Return canonical settings file path for the current runtime."""
+    return str(settings_file_path())
 
 
 class Settings:


### PR DESCRIPTION
Fixes inconsistent settings persistence paths that caused theme and related preferences to appear non-persistent.\n\nWhat changed:\n- ui/settings now resolves default path via services.db_location_service.settings_file_path()\n- AppFacade notification repository now uses the same canonical settings path\n- unit tests updated for canonical path expectations\n- spec + changelog updated\n\nValidation:\n- pytest -q tests/unit/test_settings_paths.py tests/unit/test_update_service.py tests/unit/test_release_update_tool.py\n- pytest -q (full suite): 1049 passed, 1 skipped\n