### PR TITLE
Fix redemption cancel lifecycle accounting drift

### DIFF
--- a/app_facade.py
+++ b/app_facade.py
@@ -479,19 +479,16 @@ class AppFacade:
                 _utc_date,
                 _utc_time
             )
-            # Rebuild session-event links to include newly added/edited events
-            self.game_session_event_link_service.rebuild_links_for_pair_from(
+            # Session links / closed-session fields are more sensitive to nested
+            # lifecycle edits (undo/delete/queued cancel). Rebuild them for the
+            # whole pair after FIFO is corrected to avoid suffix drift.
+            self.game_session_event_link_service.rebuild_links_for_pair(
                 site_id,
                 user_id,
-                _utc_date,
-                _utc_time
             )
-            # Recalculate session P/L fields (delta_redeem, basis_consumed, net_taxable_pl)
-            self.game_session_service._recalculate_closed_sessions_for_pair_from(
+            self.game_session_service.recalculate_closed_sessions_for_pair(
                 user_id,
                 site_id,
-                boundary_date,
-                boundary_time
             )
     
     def _handle_undo_redo_recalculation(self, operation: str, audit_entries: List[Dict]) -> None:
@@ -507,9 +504,18 @@ class AppFacade:
         """
         import json
         from datetime import datetime
+
+        def _parse_json(value):
+            if not value:
+                return None
+            try:
+                return json.loads(value) if isinstance(value, str) else value
+            except (json.JSONDecodeError, TypeError):
+                return None
         
         # Group affected records by (user_id, site_id)
         affected_pairs = {}  # (user_id, site_id) -> earliest (date, time)
+        affected_redemptions = set()
         
         for entry in audit_entries:
             table_name = entry.get('table_name')
@@ -525,9 +531,8 @@ class AppFacade:
             if not data_json:
                 continue
             
-            try:
-                data = json.loads(data_json) if isinstance(data_json, str) else data_json
-            except (json.JSONDecodeError, TypeError):
+            data = _parse_json(data_json)
+            if data is None:
                 continue
             
             user_id = data.get('user_id')
@@ -535,6 +540,16 @@ class AppFacade:
             
             if not user_id or not site_id:
                 continue
+
+            if table_name == 'redemptions' and entry.get('record_id') is not None:
+                old_snapshot = _parse_json(entry.get('old_data')) or {}
+                new_snapshot = _parse_json(entry.get('new_data')) or {}
+                statuses = {
+                    old_snapshot.get('status'),
+                    new_snapshot.get('status'),
+                }
+                if statuses & {'CANCELED', 'PENDING_CANCEL'}:
+                    affected_redemptions.add(int(entry['record_id']))
             
             # Get date/time based on table
             if table_name == 'purchases':
@@ -575,6 +590,16 @@ class AppFacade:
                 if (record_date, time_normalized) < (current_date, current_time):
                     affected_pairs[pair] = (record_date, time_normalized)
         
+        for redemption_id in sorted(affected_redemptions):
+            redemption = self.redemption_repo.get_by_id(redemption_id)
+            if redemption is None:
+                continue
+            has_active = (
+                self.game_session_service.get_active_session(redemption.user_id, redemption.site_id)
+                is not None
+            )
+            self.redemption_service.reconcile_post_undo_redo(redemption_id, has_active)
+
         # Trigger recalculation for each affected pair
         for (user_id, site_id), (boundary_date, boundary_time) in affected_pairs.items():
             # Use containing boundary logic to find actual rebuild point
@@ -1012,9 +1037,16 @@ class AppFacade:
 
     def recalculate_everything(self) -> Dict[str, Any]:
         """Full legacy-style rebuild: FIFO allocations + realized + session P/L."""
-        fifo_result = self.recalculation_service.rebuild_fifo_all()
+        fifo_result = self.recalculation_service.rebuild_all()
         pairs = self.recalculation_service.iter_pairs()
         sessions_recalculated = 0
+
+        # Rebuild explicit event links (legacy parity)
+        try:
+            self.game_session_event_link_service.rebuild_links_all()
+        except Exception:
+            pass
+
         for user_id, site_id in pairs:
             try:
                 self.game_session_service.recalculate_closed_sessions_for_pair(user_id, site_id)
@@ -1022,12 +1054,6 @@ class AppFacade:
             except Exception:
                 # Keep going; individual pairs may lack sessions or have data issues.
                 continue
-
-        # Rebuild explicit event links (legacy parity)
-        try:
-            self.game_session_event_link_service.rebuild_links_all()
-        except Exception:
-            pass
 
         # Recalculate game RTP aggregates for all games
         games_recalculated = 0
@@ -1384,6 +1410,9 @@ class AppFacade:
         old_redemption = self.redemption_repo.get_by_id(redemption_id)
         if not old_redemption:
             raise ValueError(f"Redemption {redemption_id} not found")
+        if getattr(old_redemption, 'status', 'PENDING') != 'PENDING':
+            raise ValueError("Only PENDING redemptions can be edited through accounting reprocess.")
+        old_data = asdict(old_redemption)
 
         # Ensure timestamp uniqueness if date/time is being changed
         was_adjusted = False
@@ -1419,15 +1448,40 @@ class AppFacade:
             fees=kwargs.get("fees", old_redemption.fees),
             redemption_date=kwargs.get("redemption_date", old_redemption.redemption_date),
             redemption_time=kwargs.get("redemption_time", old_redemption.redemption_time),
+            redemption_entry_time_zone=kwargs.get("redemption_entry_time_zone", old_redemption.redemption_entry_time_zone),
             redemption_method_id=kwargs.get("redemption_method_id", old_redemption.redemption_method_id),
             receipt_date=kwargs.get("receipt_date", old_redemption.receipt_date),
             processed=kwargs.get("processed", old_redemption.processed),
             more_remaining=kwargs.get("more_remaining", old_redemption.more_remaining),
             is_free_sc=kwargs.get("is_free_sc", old_redemption.is_free_sc),
             notes=kwargs.get("notes", old_redemption.notes),
+            cost_basis=old_redemption.cost_basis,
+            taxable_profit=old_redemption.taxable_profit,
+            status=old_redemption.status,
+            canceled_at=old_redemption.canceled_at,
+            cancel_reason=old_redemption.cancel_reason,
         )
         updated.__post_init__()
-        self.redemption_repo.update(updated)
+
+        group_id = self.audit_service.generate_group_id() if hasattr(self, "audit_service") else None
+        with self.db.transaction():
+            self.redemption_repo.update(updated)
+            if group_id and hasattr(self, "audit_service"):
+                self.audit_service.log_update(
+                    "redemptions",
+                    updated.id,
+                    old_data,
+                    asdict(updated),
+                    group_id=group_id,
+                    auto_commit=False,
+                )
+
+        if group_id and hasattr(self, "undo_redo_service"):
+            self.undo_redo_service.push_operation(
+                group_id=group_id,
+                description=f"Reprocess redemption #{updated.id}",
+                timestamp=datetime.now().isoformat(),
+            )
 
         old_pair = (old_redemption.user_id, old_redemption.site_id)
         new_pair = (updated.user_id, updated.site_id)
@@ -1838,21 +1892,22 @@ class AppFacade:
             notification_service=self.notification_rules_service,
         )
 
-        if not has_active:
-            # Full cancel happened — trigger FIFO + session recalculation
-            boundary_date, boundary_time = self._containing_boundary(
-                redemption.site_id,
-                redemption.user_id,
-                redemption.redemption_date,
-                redemption.redemption_time,
-            )
-            self._rebuild_or_mark_stale(
-                redemption.user_id,
-                redemption.site_id,
-                boundary_date,
-                boundary_time,
-                reason="redemption cancel",
-            )
+        # Rebuild after both immediate cancels and queued PENDING_CANCEL transitions.
+        # FIFO rebuilds preserve PENDING_CANCEL rows, while links/session totals
+        # must stop counting them immediately.
+        boundary_date, boundary_time = self._containing_boundary(
+            redemption.site_id,
+            redemption.user_id,
+            redemption.redemption_date,
+            redemption.redemption_time,
+        )
+        self._rebuild_or_mark_stale(
+            redemption.user_id,
+            redemption.site_id,
+            boundary_date,
+            boundary_time,
+            reason="redemption cancel",
+        )
 
         return canceled
 
@@ -1869,7 +1924,10 @@ class AppFacade:
         if not redemption:
             raise ValueError(f"Redemption {redemption_id} not found")
 
-        uncanceled = self.redemption_service.uncancel_redemption(redemption_id)
+        uncanceled = self.redemption_service.uncancel_redemption(
+            redemption_id,
+            restore_fifo=False,
+        )
 
         # Trigger FIFO + session recalculation from the original redemption timestamp
         boundary_date, boundary_time = self._containing_boundary(
@@ -1886,7 +1944,8 @@ class AppFacade:
             reason="redemption uncancel",
         )
 
-        return uncanceled
+        refreshed = self.redemption_repo.get_by_id(redemption_id)
+        return refreshed or uncanceled
 
     # ==========================================================================
     # Game Session Operations

--- a/docs/PROJECT_SPEC.md
+++ b/docs/PROJECT_SPEC.md
@@ -761,31 +761,44 @@ PENDING_CANCEL → (session closes)        →  CANCELED
 - All `redemption_allocations` and `realized_transactions` rows for the canceled redemption are deleted.
 - If there is an **Active** game session for the same (user, site) pair, cancellation is deferred: status becomes `PENDING_CANCEL` and FIFO reversal is delayed.
 - When a session transitions Active → Closed, `process_pending_cancels` executes all `PENDING_CANCEL` redemptions for that pair, completing FIFO reversal in chronological order.
+- Session close + queued-cancel completion must commit atomically. If any queued cancel fails, the session must remain unclosed and all queued rows must retain their pre-close FIFO / realized state.
 - After cancel, `_rebuild_or_mark_stale` is called to recalculate all downstream FIFO and session P/L from the redemption's timestamp boundary.
+- Queued `PENDING_CANCEL` transitions must rebuild immediately so closed-session links / totals stop counting the redemption even before the later active session closes.
+- Cancel / uncancel writes must be atomic: FIFO reversal/restoration, realized-transaction changes, and redemption status updates commit as one transaction.
 
 #### Uncancel Semantics
 
 - Only CANCELED redemptions may be uncanceled (not PENDING_CANCEL).
 - Uncancel clears `canceled_at` and `cancel_reason`, sets status back to `PENDING`.
-- Re-applies FIFO allocation for the redemption.
+- Uncancel must rebuild FIFO from the original redemption timestamp so later redemptions are re-sequenced chronologically rather than keeping stale post-cancel allocations.
 - Triggers full `_rebuild_or_mark_stale` from the original redemption timestamp.
 
 #### Accounting Invariants
 
-- **FIFO exclusion rule:** `RecalculationService` excludes `CANCELED` and `PENDING_CANCEL` redemptions from all rebuild queries (`WHERE COALESCE(status, 'PENDING') NOT IN ('CANCELED', 'PENDING_CANCEL')`).
+- **FIFO rebuild rule:** `RecalculationService` excludes `CANCELED` redemptions from FIFO rebuild queries, but keeps `PENDING_CANCEL` rows in FIFO / realized rebuilds until the queued cancel actually completes on session close.
+- **Soft-delete rebuild rule:** FIFO rebuild inputs exclude soft-deleted purchases, and rebuild cleanup must remove stale allocation / realized rows for deleted or canceled redemptions inside the affected pair boundary.
+- **Closed-session parity rule:** closed-session recalculation must use the same effective redemption timeline as `compute_expected_balances`, including cancellation credit events and SC-rate conversion.
+- **Session-link exclusion rule:** session-event links and `redemptions_during` totals exclude `CANCELED` redemptions so closed-session views and aggregates do not keep counting canceled cashouts.
+- **Queued-cancel rebuild safety rule:** full/scoped rebuilds must preserve `PENDING_CANCEL` allocation + realized state so later session close can complete the queued cancel without over-restoring purchase basis.
+- **Queued-cancel batch atomicity rule:** queued cancels processed at session close must behave as one batch; no partial close/partial cancellation outcome is allowed.
+- **Scoped-rebuild robustness rule:** scoped FIFO rebuilds may start from the affected timestamp boundary, but session-event links and closed-session totals must be rebuilt for the whole (user, site) pair after nested cancel/delete/undo lifecycle changes so suffix-only session recalculation cannot drift.
 - **Notification exclusion rule:** `NotificationRulesService.evaluate_redemption_pending_rules` excludes non-PENDING rows (`AND COALESCE(r.status, 'PENDING') = 'PENDING'`).
 - **Bulk metadata update guard:** `bulk_update_redemption_metadata` skips CANCELED rows to prevent restoring already-canceled redemptions via bulk receipt entry.
 - **Two-event delta model for `compute_expected_balances`:** A CANCELED redemption contributes TWO events to the balance timeline:
   1. A debit at `redemption_date` (as if it happened when submitted).
   2. A credit at `canceled_at` (restoring the balance at the moment of cancellation).
   This preserves correct expected-balance continuity across the entire timeline without rewriting historical data.
+- **Undo/redo repair rule:** undo/redo that restores redemption snapshots must also reconcile FIFO allocations / realized rows so restored statuses never leave impossible physical states.
+- **Delete/undo lifecycle rule:** undo of deleting `PENDING_CANCEL` or `CANCELED` redemptions must restore the original lifecycle state and matching FIFO presence/absence.
+- **Timestamp persistence rule:** any no-commit redemption status update must continue storing `redemption_date` / `redemption_time` in UTC DB form, or later scoped rebuild boundaries become inconsistent.
 
 #### UI Behavior
 
-- Redemptions tab toolbar: "Cancel" button (shown for single-selected PENDING row), "Uncancel" button (shown for single-selected CANCELED row).
+- Redemptions tab toolbar: "Cancel" button (shown only for a single-selected PENDING row with no `receipt_date`), "Uncancel" button (shown for a single-selected CANCELED row).
 - Cancel dialog: warns if there is an Active session (cancel will be deferred), provides reason text input.
 - Table rendering: CANCELED rows shown in gray (#95a5a6); PENDING_CANCEL rows shown in purple (#8e44ad).
 - "Pending" quick filter: excludes CANCELED and PENDING_CANCEL rows.
+- Only PENDING redemptions are editable through the accounting reprocess path; `PENDING_CANCEL` and `CANCELED` rows are locked from in-place editing.
 
 #### Schema
 

--- a/docs/status/CHANGELOG.md
+++ b/docs/status/CHANGELOG.md
@@ -9,7 +9,162 @@ Rules:
 
 ---
 
+## 2026-03-14
+
+```yaml
+id: 2026-03-14-02
+type: fix
+areas: [undo-redo, purchases, redemptions, tests]
+issue: 187
+summary: "Close red-team gaps in purchase undo reconstruction and queued cancel cleanup"
+details: >
+  Follow-up adversarial replay uncovered two more integrity holes in chained
+  undo/cancel flows. Undoing a deleted purchase could fail while reconstructing
+  the audited snapshot because `starting_redeemable_balance` was not coerced
+  back to `Decimal`. Separately, queued cancel completion could leave a stale
+  `realized_transactions` row behind for zero-basis/full redemptions that never
+  had FIFO allocation rows.
+
+  Implemented:
+  - undo/redo snapshot preparation now restores the missing purchase decimal
+    field (and normalizes common boolean flags) before rebuilding models
+  - queued and immediate cancel completion now always delete the realized row,
+    even when no FIFO allocation rows exist
+  - added regression coverage for purchase delete undo/redo round-trips and the
+    historical queued-cancel stale-realized-row scenario
+
+  Validation:
+  - /usr/local/bin/python3 -m pytest tests/integration/test_purchase_undo_redo.py -q
+  - /usr/local/bin/python3 -m pytest tests/integration/test_redemption_cancel_uncancel.py -q -k 'queued_historical_zero_basis_cancel_clears_realized_row_on_close'
+files_changed:
+  - services/undo_redo_service.py
+  - services/redemption_service.py
+  - tests/integration/test_purchase_undo_redo.py
+  - tests/integration/test_redemption_cancel_uncancel.py
+  - docs/status/CHANGELOG.md
+```
+
+```yaml
+id: 2026-03-14-01
+type: fix
+areas: [redemptions, undo-redo, audit, tests]
+issue: 187
+summary: "Audit and undo full redemption reprocess edits"
+details: >
+  Fixed an accounting integrity gap where `update_redemption_reprocess()` wrote
+  direct redemption updates without creating an audit snapshot or undoable
+  operation. That allowed full accounting edits to change redemption amounts in
+  the database with no matching row-level audit trail, and undo could not
+  restore the prior value.
+
+  Implemented:
+  - full redemption reprocess updates now log an audited `UPDATE` snapshot
+  - the same operation now pushes a dedicated undo/redo entry
+  - added regression coverage proving the reprocess path records the old/new
+    amount and undo restores the original amount
+
+  Validation:
+  - /usr/local/bin/python3 -m pytest tests/integration/test_issue_40_redemption_receipt_date.py -q
+files_changed:
+  - app_facade.py
+  - tests/integration/test_issue_40_redemption_receipt_date.py
+  - docs/status/CHANGELOG.md
+```
+
 ## 2026-03-13
+
+```yaml
+id: 2026-03-13-05
+type: fix
+areas: [redemptions, sessions, undo-redo, tests, docs]
+issue: 187
+summary: "Close recursive cancel-pipeline drift found by deep war-game replay"
+details: >
+  Follow-up red-team simulation for Issue #187 compared live cancel/uncancel
+  state against canonical `recalculate_everything()` output under nested
+  purchase/redemption/cancel/delete/session/undo/redo chains.
+
+  Implemented:
+  - FIFO rebuilds now ignore soft-deleted purchases and clear stale derived rows
+    for deleted/canceled redemptions within the affected pair scope.
+  - Scoped FIFO seeding now ignores deleted/canceled predecessor redemptions so
+    undo/delete chains cannot leak orphan allocation history forward.
+  - Queued `PENDING_CANCEL` transitions now rebuild immediately so prior closed
+    sessions stop counting the redemption in links and `redemptions_during`.
+  - Post-change session links and closed-session totals now rebuild for the
+    whole pair after scoped FIFO correction, eliminating suffix-only drift from
+    nested cancel/delete/undo sequences.
+  - Added regression coverage for queued-cancel deletion keeping closed-session
+    totals clean alongside the new artifact-cleanup tests.
+
+  Validation:
+  - python3 tools/issue_187_wargame.py
+    - Result: NO_FINDINGS
+files_changed:
+  - services/recalculation_service.py
+  - app_facade.py
+  - tests/integration/test_redemption_cancel_uncancel.py
+  - docs/PROJECT_SPEC.md
+  - docs/status/CHANGELOG.md
+```
+
+```yaml
+id: 2026-03-13-04
+type: fix
+areas: [redemptions, sessions, undo-redo, ui, tests, docs]
+issue: 187
+summary: "Align redemption cancel semantics across session recalculation, event links, undo/redo, and UI gating"
+details: >
+  Fixed Issue #187 where redemption cancellation updated the row lifecycle and
+  expected-balance timeline, but left downstream accounting and UI behavior out
+  of sync.
+
+  Implemented:
+  - Closed-session recalculation now uses cancellation-aware redemption balance
+    events, including canceled credit events and SC-rate conversion parity.
+  - Session-event link rebuilds now exclude canceled redemptions so
+    `redemptions_during` and related session views do not keep counting canceled
+    rows.
+  - Cancel / uncancel flows now apply FIFO, realized-transaction, and status
+    changes atomically.
+  - Uncancel now restores row lifecycle first and rebuilds FIFO from the
+    original redemption timestamp, preventing later redemptions from keeping
+    stale post-cancel allocations.
+  - FIFO rebuilds now keep `PENDING_CANCEL` rows in allocation / realized
+    rebuilds until queued cancellation completes, preventing rebuilds from
+    corrupting queued state or breaking later session close.
+  - Session close now commits queued-cancel completion atomically with the
+    session status update, preventing partial close / partial cancel outcomes
+    when one queued cancellation fails mid-batch.
+  - The full `recalculate_everything()` path now uses the current rebuild API
+    and re-syncs links/session fields in the correct order.
+  - Undo/redo now reconciles redemption physical state after snapshot restore so
+    cancellation-related statuses do not leave missing allocations or other
+    impossible states.
+  - Added delete/undo regression coverage for queued and canceled redemption
+    lifecycle restoration.
+  - Redemptions tab action gating now hides Cancel for received rows and locks
+    `PENDING_CANCEL` rows from editing.
+
+  Validation:
+  - pytest -q tests/integration/test_redemption_cancel_uncancel.py -k "uncancel_rebuilds_fifo_chronologically_when_later_redemption_exists or nested_cancel_uncancel_sequence_stays_rebuild_stable or recalculate_everything_preserves_pending_cancel_accounting_state"
+  - pytest -q tests/integration/test_redemption_cancel_uncancel.py -k "pending_cancel_batch_failure_rolls_back_all_and_session_close or undo_delete_pending_cancel_restores_queued_state_with_fifo or undo_delete_canceled_redemption_restores_canceled_without_fifo"
+  - pytest -q tests/integration/test_redemption_cancel_uncancel.py tests/ui/test_redemption_cancel_visibility.py tests/integration/test_issue_40_redemption_receipt_date.py tests/unit/test_redemption_service.py
+  - pytest -q tests/integration/test_redemption_cancel_uncancel.py tests/ui/test_redemption_cancel_visibility.py
+  - pytest -q
+files_changed:
+  - services/game_session_service.py
+  - services/game_session_event_link_service.py
+  - services/redemption_service.py
+  - repositories/game_session_repository.py
+  - services/recalculation_service.py
+  - app_facade.py
+  - ui/tabs/redemptions_tab.py
+  - tests/integration/test_redemption_cancel_uncancel.py
+  - tests/ui/test_redemption_cancel_visibility.py
+  - docs/PROJECT_SPEC.md
+  - docs/status/CHANGELOG.md
+```
 
 ```yaml
 id: 2026-03-13-03

--- a/repositories/game_session_repository.py
+++ b/repositories/game_session_repository.py
@@ -225,6 +225,16 @@ class GameSessionRepository:
     
     def update(self, session: GameSession) -> GameSession:
         """Update an existing session"""
+        self._update_internal(session, auto_commit=True)
+        return session
+
+    def update_no_commit(self, session: GameSession) -> GameSession:
+        """Update an existing session without committing."""
+        self._update_internal(session, auto_commit=False)
+        return session
+
+    def _update_internal(self, session: GameSession, *, auto_commit: bool) -> None:
+        """Internal session update helper supporting explicit transaction control."""
         start_entry_tz = session.start_entry_time_zone or get_entry_timezone_name()
         utc_session_date, utc_session_time = local_date_time_to_utc(
             session.session_date,
@@ -254,34 +264,34 @@ class GameSessionRepository:
         """
         def str_or_none(val):
             return str(val) if val is not None else None
-        
-        self.db.execute(
-            query,
-            (
-                session.user_id, session.site_id, session.game_id, session.game_type_id,
-                utc_session_date, utc_session_time,
-                start_entry_tz,
-                utc_end_date,
-                utc_end_time,
-                end_entry_tz,
-                str(session.starting_balance), str(session.ending_balance),
-                str(session.starting_redeemable), str(session.ending_redeemable),
-                str(session.purchases_during), str(session.redemptions_during),
-                str(session.wager_amount), session.rtp,
-                str_or_none(session.expected_start_total),
-                str_or_none(session.expected_start_redeemable),
-                str_or_none(session.discoverable_sc),
-                str_or_none(session.delta_total),
-                str_or_none(session.delta_redeem),
-                str_or_none(session.session_basis),
-                str_or_none(session.basis_consumed),
-                str_or_none(session.net_taxable_pl),
-                session.status, session.notes, session.id
-            )
+
+        params = (
+            session.user_id, session.site_id, session.game_id, session.game_type_id,
+            utc_session_date, utc_session_time,
+            start_entry_tz,
+            utc_end_date,
+            utc_end_time,
+            end_entry_tz,
+            str(session.starting_balance), str(session.ending_balance),
+            str(session.starting_redeemable), str(session.ending_redeemable),
+            str(session.purchases_during), str(session.redemptions_during),
+            str(session.wager_amount), session.rtp,
+            str_or_none(session.expected_start_total),
+            str_or_none(session.expected_start_redeemable),
+            str_or_none(session.discoverable_sc),
+            str_or_none(session.delta_total),
+            str_or_none(session.delta_redeem),
+            str_or_none(session.session_basis),
+            str_or_none(session.basis_consumed),
+            str_or_none(session.net_taxable_pl),
+            session.status, session.notes, session.id
         )
+        if auto_commit:
+            self.db.execute(query, params)
+        else:
+            self.db.execute_no_commit(query, params)
         session.start_entry_time_zone = start_entry_tz
         session.end_entry_time_zone = end_entry_tz
-        return session
     
     def delete(self, session_id: int) -> None:
         """Soft delete a session by setting deleted_at timestamp"""

--- a/services/game_session_event_link_service.py
+++ b/services/game_session_event_link_service.py
@@ -98,6 +98,8 @@ class GameSessionEventLinkService:
             SELECT id, redemption_date, COALESCE(redemption_time, '00:00:00') as redemption_time
             FROM redemptions
             WHERE site_id = ? AND user_id = ?
+                            AND deleted_at IS NULL
+                                                        AND COALESCE(status, 'PENDING') NOT IN ('CANCELED', 'PENDING_CANCEL')
               AND redemption_date IS NOT NULL
             ORDER BY redemption_date ASC, COALESCE(redemption_time, '00:00:00') ASC, id ASC
             """,
@@ -260,6 +262,8 @@ class GameSessionEventLinkService:
             SELECT id, redemption_date, COALESCE(redemption_time, '00:00:00') as redemption_time
             FROM redemptions
             WHERE site_id = ? AND user_id = ?
+                            AND deleted_at IS NULL
+                                                        AND COALESCE(status, 'PENDING') NOT IN ('CANCELED', 'PENDING_CANCEL')
               AND redemption_date IS NOT NULL
               AND (redemption_date > ? OR (redemption_date = ? AND COALESCE(redemption_time, '00:00:00') > ?))
             ORDER BY redemption_date ASC, COALESCE(redemption_time, '00:00:00') ASC, id ASC

--- a/services/game_session_service.py
+++ b/services/game_session_service.py
@@ -220,12 +220,36 @@ class GameSessionService:
             if active is not None and active.id != session.id:
                 raise ValueError("An active session already exists for this User/Site.")
 
-        updated = self.session_repo.update(session)
-        
-        # Log update to audit and undo/redo stack
+        just_closed = target_status == "Closed" and old_status != "Closed"
         group_id = str(uuid.uuid4())
-        if self.audit_service:
-            self.audit_service.log_update('game_sessions', session.id, old_data, asdict(updated), group_id=group_id)
+
+        if just_closed:
+            with self.session_repo.db.transaction():
+                updated = self.session_repo.update_no_commit(session)
+
+                # Process any PENDING_CANCEL redemptions before returning so facade-level
+                # rebuilds see the final post-close state.
+                if self.redemption_service is not None:
+                    self.redemption_service.process_pending_cancels(
+                        session.user_id,
+                        session.site_id,
+                        group_id=group_id,
+                        push_undo=False,
+                        auto_commit=False,
+                    )
+
+                if self.audit_service:
+                    self.audit_service.log_update(
+                        'game_sessions', session.id, old_data, asdict(updated),
+                        group_id=group_id,
+                        auto_commit=False,
+                    )
+        else:
+            updated = self.session_repo.update(session)
+
+            # Log update to audit and undo/redo stack
+            if self.audit_service:
+                self.audit_service.log_update('game_sessions', session.id, old_data, asdict(updated), group_id=group_id)
         
         if self.undo_redo_service:
             self.undo_redo_service.push_operation(
@@ -318,18 +342,6 @@ class GameSessionService:
                 )
                 return refreshed
             return updated
-
-        # Process any PENDING_CANCEL redemptions now that the session is closed
-        # (Issue #148 — fires regardless of recalculate_pl flag so deferred cancels
-        # always execute when a session transitions Active → Closed.)
-        if target_status == "Closed" and old_status != "Closed" and self.redemption_service is not None:
-            try:
-                self.redemption_service.process_pending_cancels(
-                    session.user_id,
-                    session.site_id,
-                )
-            except Exception as exc:
-                print(f"Warning: process_pending_cancels failed: {exc}")
 
         return updated
     
@@ -710,9 +722,60 @@ class GameSessionService:
             time_str = f"{time_str}:00"
         return datetime.combine(d, datetime.strptime(time_str, "%H:%M:%S").time())
 
+    def _get_site_sc_rate(self, site_id: int) -> Decimal:
+        sc_rate = Decimal("1.00")
+        if self.site_repo:
+            site = self.site_repo.get_by_id(site_id)
+            if site:
+                try:
+                    parsed = Decimal(str(getattr(site, "sc_rate", "1.0")))
+                    if parsed > 0:
+                        sc_rate = parsed
+                except Exception:
+                    pass
+        return sc_rate
+
+    def _load_redemption_balance_events(self, user_id: int, site_id: int):
+        """Load signed redemption balance events in SC units.
+
+        Debit events are positive amounts consumed by the recalculation formulas,
+        which subtract `red_between`. Canceled credit events are therefore
+        represented as negative amounts.
+        """
+        events = []
+        if self.redemption_repo is None:
+            return events
+
+        sc_rate = self._get_site_sc_rate(site_id)
+        for r in self.redemption_repo.get_by_user_and_site(user_id, site_id):
+            amount_sc = Decimal(str(r.amount)) / sc_rate
+            r_dt = self._to_dt(r.redemption_date, r.redemption_time)
+            if r_dt is not None:
+                events.append((r_dt, amount_sc))
+
+            if getattr(r, "status", "PENDING") == "CANCELED":
+                canceled_at = getattr(r, "canceled_at", None)
+                if canceled_at:
+                    try:
+                        canceled_utc = datetime.strptime(canceled_at[:19], "%Y-%m-%d %H:%M:%S")
+                    except (TypeError, ValueError):
+                        canceled_utc = None
+                    if canceled_utc is not None:
+                        local_cancel_date, local_cancel_time = utc_date_time_to_accounting_local(
+                            self.session_repo.db,
+                            canceled_utc.date(),
+                            canceled_utc.strftime("%H:%M:%S"),
+                        )
+                        cancel_dt = self._to_dt(local_cancel_date, local_cancel_time)
+                    if cancel_dt is not None:
+                        events.append((cancel_dt, -amount_sc))
+
+        events.sort(key=lambda x: x[0] or datetime.min)
+        return events
+
     def _load_pair_events(self, user_id: int, site_id: int):
         purchases = []
-        redemptions = []
+        redemptions = self._load_redemption_balance_events(user_id, site_id)
 
         if self.purchase_repo is not None:
             for p in self.purchase_repo.get_by_user_and_site(user_id, site_id):
@@ -721,14 +784,7 @@ class GameSessionService:
                 sc_amt = Decimal(str(p.sc_received))
                 purchases.append((dt, cash_amt, sc_amt))
 
-        if self.redemption_repo is not None:
-            for r in self.redemption_repo.get_by_user_and_site(user_id, site_id):
-                dt = self._to_dt(r.redemption_date, r.redemption_time)
-                amt = Decimal(str(r.amount))
-                redemptions.append((dt, amt))
-
         purchases.sort(key=lambda x: (x[0] or datetime.min))
-        redemptions.sort(key=lambda x: (x[0] or datetime.min))
         return purchases, redemptions
 
     def _recalculate_closed_sessions_for_pair(self, user_id: int, site_id: int) -> None:
@@ -957,6 +1013,8 @@ class GameSessionService:
             WHERE gsel.game_session_id = ? 
               AND gsel.event_type = 'redemption'
               AND gsel.relation = 'DURING'
+                            AND r.deleted_at IS NULL
+                            AND COALESCE(r.status, 'PENDING') NOT IN ('CANCELED', 'PENDING_CANCEL')
         """, (session_id,)).fetchone()
         return Decimal(str(row['total'])) if row else Decimal("0.00")
 

--- a/services/recalculation_service.py
+++ b/services/recalculation_service.py
@@ -115,7 +115,7 @@ class RecalculationService:
         """Return distinct (user_id, site_id) pairs with any activity."""
         rows = self.db.fetch_all(
             """
-            SELECT DISTINCT user_id, site_id FROM purchases
+            SELECT DISTINCT user_id, site_id FROM purchases WHERE deleted_at IS NULL
             UNION
             SELECT DISTINCT user_id, site_id FROM redemptions WHERE deleted_at IS NULL
             UNION
@@ -192,7 +192,7 @@ class RecalculationService:
             """
             SELECT id, amount, purchase_date, COALESCE(purchase_time,'00:00:00') AS pt
             FROM purchases
-            WHERE user_id = ? AND site_id = ?
+            WHERE user_id = ? AND site_id = ? AND deleted_at IS NULL
             ORDER BY purchase_date ASC, COALESCE(purchase_time,'00:00:00') ASC, id ASC
             """,
             (user_id, site_id),
@@ -232,22 +232,23 @@ class RecalculationService:
                      COALESCE(is_free_sc, 0) AS is_free_sc, COALESCE(more_remaining, 0) AS more_remaining, notes
             FROM redemptions
             WHERE user_id = ? AND site_id = ? AND deleted_at IS NULL
-              AND COALESCE(status, 'PENDING') NOT IN ('CANCELED', 'PENDING_CANCEL')
+                            AND COALESCE(status, 'PENDING') != 'CANCELED'
             ORDER BY redemption_date ASC, COALESCE(redemption_time,'00:00:00') ASC, id ASC
             """,
             (user_id, site_id),
         )
         redemption_rows = cursor.fetchall()
 
-        redemption_ids = [int(r["id"]) for r in redemption_rows]
-
         # Clear existing derived records for this pair
-        if redemption_ids:
-            placeholders = ",".join(["?"] * len(redemption_ids))
-            cursor.execute(
-                f"DELETE FROM redemption_allocations WHERE redemption_id IN ({placeholders})",
-                tuple(redemption_ids),
+        cursor.execute(
+            """
+            DELETE FROM redemption_allocations
+            WHERE redemption_id IN (
+                SELECT id FROM redemptions WHERE user_id = ? AND site_id = ?
             )
+            """,
+            (user_id, site_id),
+        )
         cursor.execute(
             "DELETE FROM realized_transactions WHERE user_id = ? AND site_id = ?",
             (user_id, site_id),
@@ -413,7 +414,7 @@ class RecalculationService:
             """
             SELECT id, amount, purchase_date, COALESCE(purchase_time,'00:00:00') AS pt
             FROM purchases
-            WHERE user_id = ? AND site_id = ?
+            WHERE user_id = ? AND site_id = ? AND deleted_at IS NULL
             ORDER BY purchase_date ASC, COALESCE(purchase_time,'00:00:00') ASC, id ASC
             """,
             (user_id, site_id),
@@ -451,6 +452,8 @@ class RecalculationService:
             FROM redemption_allocations ra
             JOIN redemptions r ON ra.redemption_id = r.id
             WHERE r.user_id = ? AND r.site_id = ?
+                            AND r.deleted_at IS NULL
+                            AND COALESCE(r.status, 'PENDING') != 'CANCELED'
               AND (r.redemption_date < ?
                    OR (r.redemption_date = ? AND COALESCE(r.redemption_time,'00:00:00') < ?))
             """,
@@ -469,7 +472,7 @@ class RecalculationService:
                    COALESCE(is_free_sc, 0) AS is_free_sc, COALESCE(more_remaining, 0) AS more_remaining, notes
                         FROM redemptions
                         WHERE user_id = ? AND site_id = ? AND deleted_at IS NULL
-              AND COALESCE(status, 'PENDING') NOT IN ('CANCELED', 'PENDING_CANCEL')
+                AND COALESCE(status, 'PENDING') != 'CANCELED'
               AND (redemption_date > ?
                    OR (redemption_date = ? AND COALESCE(redemption_time,'00:00:00') >= ?))
             ORDER BY redemption_date ASC, COALESCE(redemption_time,'00:00:00') ASC, id ASC
@@ -478,17 +481,30 @@ class RecalculationService:
         )
         redemption_rows = cursor.fetchall()
 
-        redemption_ids = [int(r["id"]) for r in redemption_rows]
-        if redemption_ids:
-            placeholders = ",".join(["?"] * len(redemption_ids))
-            cursor.execute(
-                f"DELETE FROM redemption_allocations WHERE redemption_id IN ({placeholders})",
-                tuple(redemption_ids),
+        cursor.execute(
+            """
+            DELETE FROM redemption_allocations
+            WHERE redemption_id IN (
+                SELECT id FROM redemptions
+                WHERE user_id = ? AND site_id = ?
+                  AND (redemption_date > ?
+                       OR (redemption_date = ? AND COALESCE(redemption_time,'00:00:00') >= ?))
             )
-            cursor.execute(
-                f"DELETE FROM realized_transactions WHERE redemption_id IN ({placeholders})",
-                tuple(redemption_ids),
+            """,
+            (user_id, site_id, from_date, from_date, from_time),
+        )
+        cursor.execute(
+            """
+            DELETE FROM realized_transactions
+            WHERE redemption_id IN (
+                SELECT id FROM redemptions
+                WHERE user_id = ? AND site_id = ?
+                  AND (redemption_date > ?
+                       OR (redemption_date = ? AND COALESCE(redemption_time,'00:00:00') >= ?))
             )
+            """,
+            (user_id, site_id, from_date, from_date, from_time),
+        )
 
         allocations_to_write: List[Tuple[int, int, str]] = []
         realized_to_write: List[Tuple[str, int, int, int, str, str, str]] = []

--- a/services/redemption_service.py
+++ b/services/redemption_service.py
@@ -7,7 +7,7 @@ from typing import List, Optional, Tuple, TYPE_CHECKING
 from decimal import Decimal
 from datetime import date, datetime, timezone
 from models.redemption import Redemption
-from tools.timezone_utils import get_entry_timezone_name
+from tools.timezone_utils import get_entry_timezone_name, local_date_time_to_utc
 from repositories.redemption_repository import RedemptionRepository
 from services.fifo_service import FIFOService
 
@@ -185,6 +185,20 @@ class RedemptionService:
         redemption = self.redemption_repo.get_by_id(redemption_id)
         if not redemption:
             raise ValueError(f"Redemption {redemption_id} not found")
+        if getattr(redemption, 'status', 'PENDING') != 'PENDING':
+            raise ValueError("Only PENDING redemptions may be updated through the lightweight update path.")
+
+        forbidden_fields = {
+            'status',
+            'canceled_at',
+            'cancel_reason',
+            'cost_basis',
+            'taxable_profit',
+        }
+        attempted_forbidden = sorted(field for field in kwargs if field in forbidden_fields)
+        if attempted_forbidden:
+            names = ", ".join(attempted_forbidden)
+            raise ValueError(f"Cancel lifecycle/accounting fields are not directly editable: {names}")
         
         # Capture old state for audit (BEFORE any modifications)
         old_data = asdict(redemption)
@@ -404,21 +418,11 @@ class RedemptionService:
         group_id: str,
         old_data: dict,
         notification_service=None,
+        push_undo: bool = True,
     ) -> None:
         """Inner helper that performs the actual FIFO reversal and status update."""
-        allocations = self._get_allocations(redemption.id)
-
-        if allocations:
-            self.fifo_service.reverse_allocation(allocations)
-            self._delete_allocations(redemption.id)
-            self._delete_realized_transaction(redemption.id)
-
-        # Mark canceled with UTC timestamp
-        canceled_at = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
-        redemption.status = 'CANCELED'
-        redemption.canceled_at = canceled_at
-        redemption.cancel_reason = reason
-        self.redemption_repo.update(redemption)
+        with self.db.transaction():
+            self._execute_cancel_no_commit(redemption, reason, group_id, old_data)
 
         # Dismiss any pending-receipt notification for this redemption
         if notification_service is not None:
@@ -430,22 +434,50 @@ class RedemptionService:
             except Exception:
                 pass
 
-        if self.audit_service:
-            self.audit_service.log_update(
-                'redemptions', redemption.id, old_data, asdict(redemption),
-                group_id=group_id,
-            )
-        if self.undo_redo_service:
+        if push_undo and self.undo_redo_service:
             self.undo_redo_service.push_operation(
                 group_id=group_id,
                 description=f"Cancel redemption #{redemption.id}",
                 timestamp=datetime.now().isoformat(),
             )
 
+    def _execute_cancel_no_commit(
+        self,
+        redemption: Redemption,
+        reason: str,
+        group_id: str,
+        old_data: dict,
+    ) -> None:
+        """Apply cancel accounting changes without committing."""
+        allocations = self._get_allocations(redemption.id)
+        if allocations:
+            self._reverse_allocations_no_commit(allocations)
+            self._delete_allocations_no_commit(redemption.id)
+
+        # Realized rows must be removed for every completed cancel, including
+        # zero-basis/full redemptions that never had FIFO allocation rows.
+        self._delete_realized_transaction_no_commit(redemption.id)
+
+        canceled_at = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+        redemption.status = 'CANCELED'
+        redemption.canceled_at = canceled_at
+        redemption.cancel_reason = reason
+        redemption.cost_basis = None
+        redemption.taxable_profit = None
+        self._update_redemption_no_commit(redemption)
+
+        if self.audit_service:
+            self.audit_service.log_update(
+                'redemptions', redemption.id, old_data, asdict(redemption),
+                group_id=group_id,
+                auto_commit=False,
+            )
+
     def uncancel_redemption(
         self,
         redemption_id: int,
         group_id: Optional[str] = None,
+        restore_fifo: bool = True,
     ) -> Redemption:
         """Uncancel a previously canceled redemption, re-applying FIFO.
 
@@ -464,9 +496,204 @@ class RedemptionService:
         old_data = asdict(redemption)
         group_id = group_id or str(uuid.uuid4())
 
+        if not restore_fifo:
+            with self.db.transaction():
+                redemption.status = 'PENDING'
+                redemption.canceled_at = None
+                redemption.cancel_reason = None
+                redemption.receipt_date = None
+                redemption.cost_basis = None
+                redemption.taxable_profit = None
+                self._update_redemption_no_commit(redemption)
+
+                if self.audit_service:
+                    self.audit_service.log_update(
+                        'redemptions', redemption.id, old_data, asdict(redemption),
+                        group_id=group_id,
+                        auto_commit=False,
+                    )
+
+            if self.undo_redo_service:
+                self.undo_redo_service.push_operation(
+                    group_id=group_id,
+                    description=f"Uncancel redemption #{redemption_id}",
+                    timestamp=datetime.now().isoformat(),
+                )
+
+            refreshed = self.redemption_repo.get_by_id(redemption_id)
+            if refreshed is None:
+                raise ValueError(f"Redemption {redemption_id} not found after uncancel")
+            return refreshed
+
         # Re-apply FIFO — same logic as create_redemption
+        cost_basis, taxable_profit, allocations = self._calculate_fifo_for_redemption(redemption)
+
+        # Persist allocations and restore accounting records
+        with self.db.transaction():
+            self._save_allocations_no_commit(redemption.id, allocations)
+            self._apply_allocations_no_commit(allocations)
+            self._create_realized_transaction_no_commit(
+                redemption_id=redemption.id,
+                redemption_date=redemption.redemption_date,
+                user_id=redemption.user_id,
+                site_id=redemption.site_id,
+                cost_basis=cost_basis,
+                payout=Decimal(str(redemption.amount)),
+                net_pl=taxable_profit,
+            )
+
+            # Restore to PENDING
+            redemption.status = 'PENDING'
+            redemption.canceled_at = None
+            redemption.cancel_reason = None
+            redemption.receipt_date = None   # returning to pending state
+            redemption.cost_basis = cost_basis
+            redemption.taxable_profit = taxable_profit
+            self._update_redemption_no_commit(redemption)
+
+            if self.audit_service:
+                self.audit_service.log_update(
+                    'redemptions', redemption.id, old_data, asdict(redemption),
+                    group_id=group_id,
+                    auto_commit=False,
+                )
+
+        if self.undo_redo_service:
+            self.undo_redo_service.push_operation(
+                group_id=group_id,
+                description=f"Uncancel redemption #{redemption_id}",
+                timestamp=datetime.now().isoformat(),
+            )
+
+        return self.redemption_repo.get_by_id(redemption_id)
+
+    def process_pending_cancels(
+        self,
+        user_id: int,
+        site_id: int,
+        notification_service=None,
+        group_id: Optional[str] = None,
+        push_undo: bool = True,
+        auto_commit: bool = True,
+    ) -> List[int]:
+        """Complete all PENDING_CANCEL redemptions for a user/site after a session ends.
+
+        Called by GameSessionService.update_session() when status transitions
+        to 'Closed'.  Processes in chronological order of redemption_date so
+        FIFO reversal is applied in the correct sequence.
+
+        Returns:
+            List of redemption IDs that were fully canceled.
+        """
+        pending = self.redemption_repo.get_pending_cancel_for_user_site(user_id, site_id)
+        canceled_ids: List[int] = []
+        if not pending:
+            return canceled_ids
+
+        gid = group_id or str(uuid.uuid4())
+
+        def _run_batch() -> None:
+            for r in pending:
+                old_data = asdict(r)
+                old_data['status'] = 'PENDING'
+                old_data['canceled_at'] = None
+                old_data['cancel_reason'] = None
+                self._execute_cancel_no_commit(
+                    r,
+                    r.cancel_reason or "",
+                    gid,
+                    old_data,
+                )
+                canceled_ids.append(r.id)
+
+        if auto_commit:
+            with self.db.transaction():
+                _run_batch()
+        else:
+            _run_batch()
+
+        if notification_service is not None:
+            for redemption_id in canceled_ids:
+                try:
+                    notification_service.dismiss_by_type(
+                        'redemption_pending_receipt',
+                        subject_id=str(redemption_id),
+                    )
+                except Exception:
+                    pass
+
+        if push_undo and self.undo_redo_service:
+            count = len(canceled_ids)
+            noun = "redemption" if count == 1 else "redemptions"
+            self.undo_redo_service.push_operation(
+                group_id=gid,
+                description=f"Process pending cancel for {count} {noun}",
+                timestamp=datetime.now().isoformat(),
+            )
+        return canceled_ids
+
+    def reconcile_post_undo_redo(self, redemption_id: int, has_active_session: bool) -> Optional[Redemption]:
+        """Repair physical accounting state after an external snapshot restore.
+
+        Undo/redo restores row snapshots but does not restore related FIFO rows.
+        This helper brings allocations/realized rows back in sync with the
+        current redemption status.
+        """
+        redemption = self.redemption_repo.get_by_id(redemption_id)
+        if redemption is None:
+            return None
+
+        if redemption.status == 'PENDING_CANCEL' and not has_active_session:
+            redemption.status = 'PENDING'
+            redemption.canceled_at = None
+            redemption.cancel_reason = None
+            self.redemption_repo.update(redemption)
+            redemption = self.redemption_repo.get_by_id(redemption_id)
+            if redemption is None:
+                return None
+
+        allocations = self._get_allocations(redemption_id)
+        needs_fifo = (
+            redemption.status in ('PENDING', 'PENDING_CANCEL')
+            and redemption.receipt_date is None
+            and Decimal(str(redemption.amount or 0)) > 0
+        )
+
+        if redemption.status == 'CANCELED':
+            if allocations:
+                with self.db.transaction():
+                    self._reverse_allocations_no_commit(allocations)
+                    self._delete_allocations_no_commit(redemption_id)
+                    self._delete_realized_transaction_no_commit(redemption_id)
+            return self.redemption_repo.get_by_id(redemption_id)
+
+        if needs_fifo and not allocations:
+            cost_basis, taxable_profit, new_allocations = self._calculate_fifo_for_redemption(redemption)
+            with self.db.transaction():
+                self._save_allocations_no_commit(redemption_id, new_allocations)
+                self._apply_allocations_no_commit(new_allocations)
+                if not self._has_realized_transaction(redemption_id):
+                    self._create_realized_transaction_no_commit(
+                        redemption_id=redemption.id,
+                        redemption_date=redemption.redemption_date,
+                        user_id=redemption.user_id,
+                        site_id=redemption.site_id,
+                        cost_basis=cost_basis,
+                        payout=Decimal(str(redemption.amount)),
+                        net_pl=taxable_profit,
+                    )
+                redemption.cost_basis = cost_basis
+                redemption.taxable_profit = taxable_profit
+                self._update_redemption_no_commit(redemption)
+            return self.redemption_repo.get_by_id(redemption_id)
+
+        return redemption
+
+    def _calculate_fifo_for_redemption(
+        self,
+        redemption: Redemption,
+    ) -> Tuple[Decimal, Decimal, List[Tuple[int, Decimal]]]:
         if not redemption.more_remaining:
-            # Full redemption: consume ALL remaining basis as of original timestamp
             available = self.redemption_repo.db.fetch_one(
                 """
                 SELECT COALESCE(SUM(remaining_amount), 0) AS total_remaining
@@ -493,79 +720,16 @@ class RedemptionService:
                 redemption_entry_time_zone=redemption.redemption_entry_time_zone,
             )
             taxable_profit = Decimal(str(redemption.amount)) - cost_basis
-        else:
-            cost_basis, taxable_profit, allocations = self.fifo_service.calculate_cost_basis(
-                redemption.user_id,
-                redemption.site_id,
-                Decimal(str(redemption.amount)),
-                redemption.redemption_date,
-                redemption.redemption_time or "23:59:59",
-                redemption_entry_time_zone=redemption.redemption_entry_time_zone,
-            )
+            return cost_basis, taxable_profit, allocations
 
-        # Persist allocations and restore accounting records
-        self._save_allocations(redemption.id, allocations)
-        self.fifo_service.apply_allocation(allocations)
-        self._create_realized_transaction(
-            redemption_id=redemption.id,
-            redemption_date=redemption.redemption_date,
-            user_id=redemption.user_id,
-            site_id=redemption.site_id,
-            cost_basis=cost_basis,
-            payout=Decimal(str(redemption.amount)),
-            net_pl=taxable_profit,
+        return self.fifo_service.calculate_cost_basis(
+            redemption.user_id,
+            redemption.site_id,
+            Decimal(str(redemption.amount)),
+            redemption.redemption_date,
+            redemption.redemption_time or "23:59:59",
+            redemption_entry_time_zone=redemption.redemption_entry_time_zone,
         )
-
-        # Restore to PENDING
-        redemption.status = 'PENDING'
-        redemption.canceled_at = None
-        redemption.cancel_reason = None
-        redemption.receipt_date = None   # returning to pending state
-        redemption.cost_basis = cost_basis
-        redemption.taxable_profit = taxable_profit
-        self.redemption_repo.update(redemption)
-
-        if self.audit_service:
-            self.audit_service.log_update(
-                'redemptions', redemption.id, old_data, asdict(redemption),
-                group_id=group_id,
-            )
-        if self.undo_redo_service:
-            self.undo_redo_service.push_operation(
-                group_id=group_id,
-                description=f"Uncancel redemption #{redemption_id}",
-                timestamp=datetime.now().isoformat(),
-            )
-
-        return self.redemption_repo.get_by_id(redemption_id)
-
-    def process_pending_cancels(
-        self,
-        user_id: int,
-        site_id: int,
-        notification_service=None,
-    ) -> List[int]:
-        """Complete all PENDING_CANCEL redemptions for a user/site after a session ends.
-
-        Called by GameSessionService.update_session() when status transitions
-        to 'Closed'.  Processes in chronological order of redemption_date so
-        FIFO reversal is applied in the correct sequence.
-
-        Returns:
-            List of redemption IDs that were fully canceled.
-        """
-        pending = self.redemption_repo.get_pending_cancel_for_user_site(user_id, site_id)
-        canceled_ids: List[int] = []
-        for r in pending:
-            old_data = asdict(r)
-            gid = str(uuid.uuid4())
-            try:
-                self._execute_cancel(r, r.cancel_reason or "", gid, old_data, notification_service)
-                canceled_ids.append(r.id)
-            except Exception as exc:
-                # Don't let one failed cancel block the rest; log and continue
-                print(f"Warning: could not process pending cancel for redemption #{r.id}: {exc}")
-        return canceled_ids
     
     def list_redemptions(
         self, 
@@ -597,6 +761,18 @@ class RedemptionService:
                 VALUES (?, ?, ?)
             """
             self.db.execute(query, (redemption_id, purchase_id, str(amount)))
+
+    def _save_allocations_no_commit(self, redemption_id: int, allocations: List[Tuple[int, Decimal]]) -> None:
+        if not self.db:
+            return
+        for purchase_id, amount in allocations:
+            self.db.execute_no_commit(
+                """
+                INSERT INTO redemption_allocations (redemption_id, purchase_id, allocated_amount)
+                VALUES (?, ?, ?)
+                """,
+                (redemption_id, purchase_id, str(amount)),
+            )
     
     def _get_allocations(self, redemption_id: int) -> List[Tuple[int, Decimal]]:
         """Retrieve FIFO allocations from redemption_allocations table"""
@@ -618,6 +794,14 @@ class RedemptionService:
         
         query = "DELETE FROM redemption_allocations WHERE redemption_id = ?"
         self.db.execute(query, (redemption_id,))
+
+    def _delete_allocations_no_commit(self, redemption_id: int) -> None:
+        if not self.db:
+            return
+        self.db.execute_no_commit(
+            "DELETE FROM redemption_allocations WHERE redemption_id = ?",
+            (redemption_id,),
+        )
     
     def _create_realized_transaction(
         self, 
@@ -647,6 +831,35 @@ class RedemptionService:
             str(payout),
             str(net_pl)
         ))
+
+    def _create_realized_transaction_no_commit(
+        self,
+        redemption_id: int,
+        redemption_date,
+        user_id: int,
+        site_id: int,
+        cost_basis: Decimal,
+        payout: Decimal,
+        net_pl: Decimal,
+    ) -> None:
+        if not self.db:
+            return
+        self.db.execute_no_commit(
+            """
+            INSERT INTO realized_transactions
+            (redemption_id, redemption_date, user_id, site_id, cost_basis, payout, net_pl)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                redemption_id,
+                redemption_date.isoformat() if hasattr(redemption_date, 'isoformat') else redemption_date,
+                user_id,
+                site_id,
+                str(cost_basis),
+                str(payout),
+                str(net_pl),
+            ),
+        )
     
     def _delete_realized_transaction(self, redemption_id: int) -> None:
         """Delete realized_transaction record for a redemption"""
@@ -655,6 +868,93 @@ class RedemptionService:
         
         query = "DELETE FROM realized_transactions WHERE redemption_id = ?"
         self.db.execute(query, (redemption_id,))
+
+    def _delete_realized_transaction_no_commit(self, redemption_id: int) -> None:
+        if not self.db:
+            return
+        self.db.execute_no_commit(
+            "DELETE FROM realized_transactions WHERE redemption_id = ?",
+            (redemption_id,),
+        )
+
+    def _has_realized_transaction(self, redemption_id: int) -> bool:
+        if not self.db:
+            return False
+        row = self.db.fetch_one(
+            "SELECT 1 FROM realized_transactions WHERE redemption_id = ? LIMIT 1",
+            (redemption_id,),
+        )
+        return bool(row)
+
+    def _apply_allocations_no_commit(self, allocations: List[Tuple[int, Decimal]]) -> None:
+        for purchase_id, amount_allocated in allocations:
+            purchase = self.fifo_service.purchase_repo.get_by_id(purchase_id)
+            if not purchase:
+                raise ValueError(f"Purchase {purchase_id} not found")
+            new_remaining = purchase.remaining_amount - amount_allocated
+            if new_remaining < 0:
+                raise ValueError(
+                    f"Cannot allocate ${amount_allocated} from purchase {purchase_id}. "
+                    f"Only ${purchase.remaining_amount} remaining."
+                )
+            self.db.execute_no_commit(
+                "UPDATE purchases SET remaining_amount = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?",
+                (str(new_remaining), purchase_id),
+            )
+
+    def _reverse_allocations_no_commit(self, allocations: List[Tuple[int, Decimal]]) -> None:
+        for purchase_id, amount_allocated in allocations:
+            purchase = self.fifo_service.purchase_repo.get_by_id(purchase_id)
+            if not purchase:
+                raise ValueError(f"Purchase {purchase_id} not found")
+            new_remaining = purchase.remaining_amount + amount_allocated
+            if new_remaining > purchase.amount:
+                raise ValueError(
+                    f"Cannot restore ${amount_allocated} to purchase {purchase_id}. "
+                    f"Would exceed original amount ${purchase.amount}."
+                )
+            self.db.execute_no_commit(
+                "UPDATE purchases SET remaining_amount = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?",
+                (str(new_remaining), purchase_id),
+            )
+
+    def _update_redemption_no_commit(self, redemption: Redemption) -> None:
+        entry_tz = redemption.redemption_entry_time_zone or get_entry_timezone_name()
+        utc_date, utc_time = local_date_time_to_utc(
+            redemption.redemption_date,
+            redemption.redemption_time,
+            entry_tz,
+        )
+        self.db.execute_no_commit(
+            """
+            UPDATE redemptions
+            SET user_id = ?, site_id = ?, amount = ?, fees = ?, redemption_date = ?,
+                redemption_time = ?, redemption_entry_time_zone = ?, redemption_method_id = ?, is_free_sc = ?,
+                receipt_date = ?, processed = ?, more_remaining = ?,
+                notes = ?, status = ?, canceled_at = ?, cancel_reason = ?,
+                updated_at = CURRENT_TIMESTAMP
+            WHERE id = ?
+            """,
+            (
+                redemption.user_id,
+                redemption.site_id,
+                str(redemption.amount),
+                str(redemption.fees),
+                utc_date,
+                utc_time,
+                entry_tz,
+                redemption.redemption_method_id,
+                1 if redemption.is_free_sc else 0,
+                redemption.receipt_date.isoformat() if redemption.receipt_date else None,
+                1 if redemption.processed else 0,
+                1 if redemption.more_remaining else 0,
+                redemption.notes,
+                getattr(redemption, 'status', 'PENDING') or 'PENDING',
+                getattr(redemption, 'canceled_at', None),
+                getattr(redemption, 'cancel_reason', None),
+                redemption.id,
+            ),
+        )
 
     def get_deletion_impact(self, redemption_id: int) -> str:
         """

--- a/services/undo_redo_service.py
+++ b/services/undo_redo_service.py
@@ -535,7 +535,7 @@ class UndoRedoService:
                 else:
                     result[key] = value
             # Decimal fields: amount, fees, cost_basis, balances, etc.
-            elif key in {'amount', 'sc_received', 'starting_sc_balance', 'cashback_earned', 
+            elif key in {'amount', 'sc_received', 'starting_sc_balance', 'starting_redeemable_balance', 'cashback_earned', 
                         'remaining_amount', 'fees', 'cost_basis', 'taxable_profit',
                         'starting_balance', 'ending_balance', 'starting_redeemable', 'ending_redeemable',
                         'purchases_during', 'redemptions_during', 'wager_amount',
@@ -547,6 +547,11 @@ class UndoRedoService:
                     result[key] = Decimal(str(value))
                 else:
                     result[key] = value
+            elif key in {'cashback_is_manual', 'processed', 'more_remaining', 'is_free_sc'}:
+                if isinstance(value, str):
+                    result[key] = value.strip().lower() in {'1', 'true', 'yes', 'on'}
+                else:
+                    result[key] = bool(value)
             else:
                 result[key] = value
         

--- a/tests/integration/test_issue_40_redemption_receipt_date.py
+++ b/tests/integration/test_issue_40_redemption_receipt_date.py
@@ -149,6 +149,60 @@ def test_accounting_field_update_still_validates(app_facade):
     assert updated_redemption.amount == Decimal("75.00")
 
 
+def test_accounting_reprocess_update_is_audited_and_undoable(app_facade):
+    """Accounting reprocess edits must hit audit/undo so values can be restored."""
+    user = app_facade.create_user("TestUser")
+    site = app_facade.create_site("TestSite", sc_rate=1.0)
+
+    app_facade.create_purchase(
+        user_id=user.id,
+        site_id=site.id,
+        amount=Decimal("1000.00"),
+        purchase_date=date.today() - timedelta(days=10),
+        sc_received=Decimal("1000.00"),
+    )
+
+    redemption = app_facade.create_redemption(
+        user_id=user.id,
+        site_id=site.id,
+        amount=Decimal("500.00"),
+        redemption_date=date.today() - timedelta(days=5),
+        apply_fifo=True,
+    )
+
+    # Isolate the reprocess edit as the only undoable operation.
+    app_facade.undo_redo_service.clear_stacks()
+
+    updated_redemption = app_facade.update_redemption_reprocess(
+        redemption.id,
+        amount=Decimal("250.00"),
+    )
+
+    assert updated_redemption.amount == Decimal("250.00")
+    assert app_facade.undo_redo_service.can_undo()
+
+    audit_row = app_facade.db.fetch_one(
+        """
+        SELECT old_data, new_data
+        FROM audit_log
+        WHERE action = 'UPDATE' AND table_name = 'redemptions' AND record_id = ?
+        ORDER BY id DESC
+        LIMIT 1
+        """,
+        (redemption.id,),
+    )
+
+    assert audit_row is not None
+    assert '"amount": "500.00"' in audit_row["old_data"] or '"amount": "500"' in audit_row["old_data"]
+    assert '"amount": "250.00"' in audit_row["new_data"] or '"amount": "250"' in audit_row["new_data"]
+
+    app_facade.undo_redo_service.undo()
+
+    reverted = app_facade.get_redemption(redemption.id)
+    assert reverted is not None
+    assert reverted.amount == Decimal("500.00")
+
+
 def test_processed_flag_only_update_no_rebuild(app_facade):
     """
     Verify that updating only the 'processed' flag (another metadata field)

--- a/tests/integration/test_purchase_undo_redo.py
+++ b/tests/integration/test_purchase_undo_redo.py
@@ -1,0 +1,44 @@
+from datetime import date
+from decimal import Decimal
+
+import pytest
+
+from app_facade import AppFacade
+
+
+@pytest.fixture
+def facade(tmp_path):
+    app = AppFacade(str(tmp_path / "purchase_undo_redo.db"))
+    yield app
+    app.db.close()
+
+
+def test_undo_redo_deleted_purchase_restores_and_redeletes_purchase(facade):
+    """Undo/redo for purchase delete should round-trip a fully reconstructed purchase."""
+    user = facade.create_user("Undo User")
+    site = facade.create_site("Undo Site", sc_rate=1.0)
+
+    purchase = facade.create_purchase(
+        user_id=user.id,
+        site_id=site.id,
+        amount=Decimal("25.00"),
+        purchase_date=date(2026, 3, 1),
+        purchase_time="10:00:00",
+        sc_received=Decimal("25.00"),
+    )
+
+    facade.delete_purchase(purchase.id)
+    assert facade.get_purchase(purchase.id) is None
+
+    undone = facade.undo_redo_service.undo()
+    assert undone == f"Delete purchase #{purchase.id}"
+
+    restored = facade.get_purchase(purchase.id)
+    assert restored is not None
+    assert restored.amount == Decimal("25.00")
+    assert restored.starting_redeemable_balance == Decimal("0.00")
+    assert restored.remaining_amount == Decimal("25.00")
+
+    redone = facade.undo_redo_service.redo()
+    assert redone == f"Delete purchase #{purchase.id}"
+    assert facade.get_purchase(purchase.id) is None

--- a/tests/integration/test_redemption_cancel_uncancel.py
+++ b/tests/integration/test_redemption_cancel_uncancel.py
@@ -20,7 +20,7 @@ Torture-test matrix:
     F1 — Invariant: canceling does not affect OTHER redemptions' FIFO allocations
 """
 import pytest
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta
 from decimal import Decimal
 from app_facade import AppFacade
 
@@ -70,6 +70,34 @@ def _has_fifo(facade, redemption_id: int) -> bool:
     """Check whether a redemption currently has FIFO allocation rows."""
     r = facade.get_redemption(redemption_id)
     return r is not None and getattr(r, '_has_fifo_allocation', False)
+
+
+def _allocation_map(facade) -> dict[tuple[int, int], Decimal]:
+    rows = facade.db.fetch_all(
+        """
+        SELECT redemption_id, purchase_id, allocated_amount
+        FROM redemption_allocations
+        ORDER BY redemption_id, purchase_id
+        """
+    )
+    return {
+        (int(row["redemption_id"]), int(row["purchase_id"])): Decimal(str(row["allocated_amount"]))
+        for row in rows
+    }
+
+
+def _realized_cost_basis_map(facade) -> dict[int, Decimal]:
+    rows = facade.db.fetch_all(
+        """
+        SELECT redemption_id, cost_basis
+        FROM realized_transactions
+        ORDER BY redemption_id
+        """
+    )
+    return {
+        int(row["redemption_id"]): Decimal(str(row["cost_basis"]))
+        for row in rows
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -189,6 +217,276 @@ def test_h4_pending_cancels_execute_on_session_close(facade, setup):
     executed = facade.get_redemption(redemption.id)
     assert executed.status == "CANCELED"
     assert not executed.has_fifo_allocation
+
+
+def test_h4_pending_cancels_execute_on_session_close_with_default_recalc(facade, setup):
+    """Closing a session through the normal path must complete queued cancels before rebuild."""
+    anchor = facade.create_game_session(
+        user_id=setup["user"].id,
+        site_id=setup["site"].id,
+        game_id=None,
+        session_date=date.today() - timedelta(days=3),
+        session_time="08:00:00",
+        starting_balance=Decimal("0.00"),
+        ending_balance=Decimal("100.00"),
+        starting_redeemable=Decimal("0.00"),
+        ending_redeemable=Decimal("100.00"),
+        calculate_pl=False,
+    )
+    facade.update_game_session(
+        session_id=anchor.id,
+        ending_balance=Decimal("100.00"),
+        ending_redeemable=Decimal("100.00"),
+        end_date=date.today() - timedelta(days=3),
+        end_time="09:00:00",
+        status="Closed",
+        recalculate_pl=False,
+    )
+
+    active = facade.create_game_session(
+        user_id=setup["user"].id,
+        site_id=setup["site"].id,
+        game_id=None,
+        session_date=date.today() - timedelta(days=1),
+        session_time="10:00:00",
+        starting_balance=Decimal("100.00"),
+        ending_balance=Decimal("100.00"),
+        starting_redeemable=Decimal("100.00"),
+        ending_redeemable=Decimal("100.00"),
+        calculate_pl=False,
+    )
+    redemption = facade.create_redemption(
+        user_id=setup["user"].id,
+        site_id=setup["site"].id,
+        amount=Decimal("25.00"),
+        redemption_date=date.today() - timedelta(days=1),
+        redemption_time="12:00:00",
+        apply_fifo=True,
+        receipt_date=None,
+    )
+
+    facade.cancel_redemption(redemption.id, reason="queued during active session")
+    assert facade.get_redemption(redemption.id).status == "PENDING_CANCEL"
+
+    facade.update_game_session(
+        session_id=active.id,
+        ending_balance=Decimal("100.00"),
+        ending_redeemable=Decimal("100.00"),
+        end_date=date.today(),
+        end_time="22:00:00",
+        status="Closed",
+    )
+
+    executed = facade.get_redemption(redemption.id)
+    assert executed.status == "CANCELED"
+    assert executed.has_fifo_allocation is False
+
+    events = facade.get_linked_events_for_session(active.id)
+    assert [r.id for r in events["redemptions"]] == []
+    closed_session = facade.get_game_session(active.id)
+    assert closed_session.redemptions_during == Decimal("0.00")
+
+
+def test_pending_cancel_immediately_drops_from_closed_session_links_and_totals(facade):
+    """Queued cancels should stop counting in closed-session links/totals before the later active session closes."""
+    user = facade.create_user("Queued Link User")
+    site = facade.create_site("Queued Link Site", sc_rate=1.0)
+
+    facade.create_purchase(
+        user_id=user.id,
+        site_id=site.id,
+        amount=Decimal("100.00"),
+        purchase_date=date.today() - timedelta(days=10),
+        sc_received=Decimal("100.00"),
+    )
+
+    closed_session = facade.create_game_session(
+        user_id=user.id,
+        site_id=site.id,
+        game_id=None,
+        session_date=date.today() - timedelta(days=4),
+        session_time="08:00:00",
+        starting_balance=Decimal("0.00"),
+        ending_balance=Decimal("100.00"),
+        starting_redeemable=Decimal("0.00"),
+        ending_redeemable=Decimal("100.00"),
+        calculate_pl=False,
+    )
+    facade.update_game_session(
+        session_id=closed_session.id,
+        ending_balance=Decimal("100.00"),
+        ending_redeemable=Decimal("100.00"),
+        end_date=date.today() - timedelta(days=1),
+        end_time="09:00:00",
+        status="Closed",
+        recalculate_pl=False,
+    )
+
+    redemption = facade.create_redemption(
+        user_id=user.id,
+        site_id=site.id,
+        amount=Decimal("15.00"),
+        redemption_date=date.today() - timedelta(days=2),
+        redemption_time="12:00:00",
+        apply_fifo=True,
+        more_remaining=True,
+    )
+    assert facade.get_game_session(closed_session.id).redemptions_during == Decimal("15.00")
+
+    active_session = facade.create_game_session(
+        user_id=user.id,
+        site_id=site.id,
+        game_id=None,
+        session_date=date.today(),
+        session_time="10:00:00",
+        starting_balance=Decimal("85.00"),
+        ending_balance=Decimal("85.00"),
+        starting_redeemable=Decimal("85.00"),
+        ending_redeemable=Decimal("85.00"),
+        calculate_pl=False,
+    )
+    assert active_session.status == "Active"
+
+    facade.cancel_redemption(redemption.id, reason="queue but exclude now")
+
+    queued = facade.get_redemption(redemption.id)
+    assert queued.status == "PENDING_CANCEL"
+    assert queued.has_fifo_allocation is True
+
+    linked = facade.get_linked_events_for_session(closed_session.id)
+    assert [r.id for r in linked["redemptions"]] == []
+    refreshed_closed = facade.get_game_session(closed_session.id)
+    assert refreshed_closed.redemptions_during == Decimal("0.00")
+
+
+def test_delete_queued_redemption_keeps_closed_session_totals_clean(facade):
+    """Deleting a queued cancel should not let prior closed sessions keep stale redemption totals."""
+    user = facade.create_user("Queued Delete User")
+    site = facade.create_site("Queued Delete Site", sc_rate=1.0)
+
+    facade.create_purchase(
+        user_id=user.id,
+        site_id=site.id,
+        amount=Decimal("100.00"),
+        purchase_date=date.today() - timedelta(days=10),
+        sc_received=Decimal("100.00"),
+    )
+
+    closed_session = facade.create_game_session(
+        user_id=user.id,
+        site_id=site.id,
+        game_id=None,
+        session_date=date.today() - timedelta(days=4),
+        session_time="08:00:00",
+        starting_balance=Decimal("0.00"),
+        ending_balance=Decimal("100.00"),
+        starting_redeemable=Decimal("0.00"),
+        ending_redeemable=Decimal("100.00"),
+        calculate_pl=False,
+    )
+    facade.update_game_session(
+        session_id=closed_session.id,
+        ending_balance=Decimal("100.00"),
+        ending_redeemable=Decimal("100.00"),
+        end_date=date.today() - timedelta(days=1),
+        end_time="09:00:00",
+        status="Closed",
+        recalculate_pl=False,
+    )
+
+    redemption = facade.create_redemption(
+        user_id=user.id,
+        site_id=site.id,
+        amount=Decimal("15.00"),
+        redemption_date=date.today() - timedelta(days=2),
+        redemption_time="12:00:00",
+        apply_fifo=True,
+        more_remaining=True,
+    )
+    assert facade.get_game_session(closed_session.id).redemptions_during == Decimal("15.00")
+
+    active_session = facade.create_game_session(
+        user_id=user.id,
+        site_id=site.id,
+        game_id=None,
+        session_date=date.today(),
+        session_time="10:00:00",
+        starting_balance=Decimal("85.00"),
+        ending_balance=Decimal("85.00"),
+        starting_redeemable=Decimal("85.00"),
+        ending_redeemable=Decimal("85.00"),
+        calculate_pl=False,
+    )
+    assert active_session.status == "Active"
+
+    facade.cancel_redemption(redemption.id, reason="queue then delete")
+    facade.delete_redemption(redemption.id)
+
+    assert facade.get_redemption(redemption.id) is None
+    linked = facade.get_linked_events_for_session(closed_session.id)
+    assert [r.id for r in linked["redemptions"]] == []
+    refreshed_closed = facade.get_game_session(closed_session.id)
+    assert refreshed_closed.redemptions_during == Decimal("0.00")
+
+
+def test_queued_historical_zero_basis_cancel_clears_realized_row_on_close(facade):
+    """Queued cancel completion must delete realized rows even when the redemption had no FIFO allocations."""
+    user = facade.create_user("Zero Basis User")
+    site = facade.create_site("Zero Basis Site", sc_rate=1.0)
+
+    redemption = facade.create_redemption(
+        user_id=user.id,
+        site_id=site.id,
+        amount=Decimal("15.00"),
+        redemption_date=date.today() - timedelta(days=10),
+        redemption_time="09:00:00",
+        apply_fifo=True,
+        more_remaining=False,
+    )
+
+    realized_before = facade.db.fetch_all(
+        "SELECT redemption_id FROM realized_transactions WHERE redemption_id = ?",
+        (redemption.id,),
+    )
+    redemption = facade.get_redemption(redemption.id)
+    assert realized_before == [{"redemption_id": redemption.id}]
+    assert redemption.has_fifo_allocation is False
+
+    session = facade.create_game_session(
+        user_id=user.id,
+        site_id=site.id,
+        game_id=None,
+        session_date=date.today() - timedelta(days=1),
+        session_time="10:00:00",
+        starting_balance=Decimal("0.00"),
+        ending_balance=Decimal("0.00"),
+        starting_redeemable=Decimal("0.00"),
+        ending_redeemable=Decimal("0.00"),
+        calculate_pl=False,
+    )
+
+    facade.cancel_redemption(redemption.id, reason="queue historical zero-basis")
+    assert facade.get_redemption(redemption.id).status == "PENDING_CANCEL"
+
+    facade.update_game_session(
+        session_id=session.id,
+        ending_balance=Decimal("0.00"),
+        ending_redeemable=Decimal("0.00"),
+        end_date=date.today(),
+        end_time="22:00:00",
+        status="Closed",
+        recalculate_pl=False,
+    )
+
+    refreshed = facade.get_redemption(redemption.id)
+    realized_after = facade.db.fetch_all(
+        "SELECT redemption_id FROM realized_transactions WHERE redemption_id = ?",
+        (redemption.id,),
+    )
+
+    assert refreshed.status == "CANCELED"
+    assert refreshed.has_fifo_allocation is False
+    assert realized_after == []
 
 
 # ---------------------------------------------------------------------------
@@ -354,3 +652,595 @@ def test_f1_cancel_does_not_affect_other_redemptions(facade, setup):
     r2_after = facade.get_redemption(r2.id)
     assert r2_after.status == "PENDING"
     assert r2_after.has_fifo_allocation
+
+
+def test_cancel_rebuilds_closed_session_expected_start_values(facade):
+    """Cancel must propagate into closed-session recalculation, not only expected balances."""
+    user = facade.create_user("Session Recalc User")
+    site = facade.create_site("Session Recalc Site", sc_rate=1.0)
+
+    facade.create_purchase(
+        user_id=user.id,
+        site_id=site.id,
+        amount=Decimal("200.00"),
+        purchase_date=date.today() - timedelta(days=10),
+        sc_received=Decimal("200.00"),
+    )
+
+    anchor = facade.create_game_session(
+        user_id=user.id,
+        site_id=site.id,
+        game_id=None,
+        session_date=date.today() - timedelta(days=8),
+        session_time="10:00:00",
+        starting_balance=Decimal("0.00"),
+        ending_balance=Decimal("200.00"),
+        starting_redeemable=Decimal("0.00"),
+        ending_redeemable=Decimal("200.00"),
+        calculate_pl=False,
+    )
+    facade.update_game_session(
+        session_id=anchor.id,
+        ending_balance=Decimal("200.00"),
+        ending_redeemable=Decimal("200.00"),
+        end_date=date.today() - timedelta(days=8),
+        end_time="22:00:00",
+        status="Closed",
+        recalculate_pl=False,
+    )
+
+    redemption = facade.create_redemption(
+        user_id=user.id,
+        site_id=site.id,
+        amount=Decimal("50.00"),
+        redemption_date=date.today() - timedelta(days=5),
+        redemption_time="12:00:00",
+        apply_fifo=True,
+        receipt_date=None,
+    )
+
+    facade.cancel_redemption(redemption.id, reason="session recalc")
+
+    session = facade.create_game_session(
+        user_id=user.id,
+        site_id=site.id,
+        game_id=None,
+        session_date=date.today() + timedelta(days=1),
+        session_time="10:00:00",
+        starting_balance=Decimal("200.00"),
+        ending_balance=Decimal("200.00"),
+        starting_redeemable=Decimal("200.00"),
+        ending_redeemable=Decimal("200.00"),
+        calculate_pl=False,
+    )
+    facade.update_game_session(
+        session_id=session.id,
+        ending_balance=Decimal("200.00"),
+        ending_redeemable=Decimal("200.00"),
+        end_date=date.today() + timedelta(days=1),
+        end_time="11:00:00",
+        status="Closed",
+        recalculate_pl=False,
+    )
+
+    after = facade.get_game_session(session.id)
+    assert after.expected_start_total == Decimal("200.00")
+    assert after.expected_start_redeemable == Decimal("200.00")
+
+
+def test_cancel_removes_redemption_from_session_links_and_redemptions_during(facade):
+    """Canceled redemptions must not remain linked into closed-session DURING totals."""
+    user = facade.create_user("Link User")
+    site = facade.create_site("Link Site", sc_rate=1.0)
+
+    facade.create_purchase(
+        user_id=user.id,
+        site_id=site.id,
+        amount=Decimal("100.00"),
+        purchase_date=date.today() - timedelta(days=10),
+        sc_received=Decimal("100.00"),
+    )
+
+    anchor = facade.create_game_session(
+        user_id=user.id,
+        site_id=site.id,
+        game_id=None,
+        session_date=date.today() - timedelta(days=5),
+        session_time="08:00:00",
+        starting_balance=Decimal("0.00"),
+        ending_balance=Decimal("100.00"),
+        starting_redeemable=Decimal("0.00"),
+        ending_redeemable=Decimal("100.00"),
+        calculate_pl=False,
+    )
+    facade.update_game_session(
+        session_id=anchor.id,
+        ending_balance=Decimal("100.00"),
+        ending_redeemable=Decimal("100.00"),
+        end_date=date.today() - timedelta(days=5),
+        end_time="09:00:00",
+        status="Closed",
+        recalculate_pl=False,
+    )
+
+    session = facade.create_game_session(
+        user_id=user.id,
+        site_id=site.id,
+        game_id=None,
+        session_date=date.today() - timedelta(days=2),
+        session_time="10:00:00",
+        starting_balance=Decimal("100.00"),
+        ending_balance=Decimal("100.00"),
+        starting_redeemable=Decimal("100.00"),
+        ending_redeemable=Decimal("100.00"),
+        calculate_pl=False,
+    )
+    facade.update_game_session(
+        session_id=session.id,
+        ending_balance=Decimal("100.00"),
+        ending_redeemable=Decimal("100.00"),
+        end_date=date.today() - timedelta(days=2),
+        end_time="11:00:00",
+        status="Closed",
+        recalculate_pl=False,
+    )
+
+    redemption = facade.create_redemption(
+        user_id=user.id,
+        site_id=site.id,
+        amount=Decimal("50.00"),
+        redemption_date=date.today() - timedelta(days=2),
+        redemption_time="10:30:00",
+        apply_fifo=True,
+        receipt_date=None,
+    )
+
+    linked_before = facade.get_linked_events_for_session(session.id)
+    assert [r.id for r in linked_before["redemptions"]] == [redemption.id]
+    assert facade.get_game_session(session.id).redemptions_during == Decimal("50.00")
+
+    facade.cancel_redemption(redemption.id, reason="remove links")
+
+    linked_after = facade.get_linked_events_for_session(session.id)
+    assert [r.id for r in linked_after["redemptions"]] == []
+    assert facade.get_game_session(session.id).redemptions_during == Decimal("0.00")
+
+
+def test_cancel_rollback_restores_allocations_when_status_update_fails(facade, setup, monkeypatch):
+    """Failure injection: cancel must roll back to the original state atomically."""
+    redemption = _make_redemption(facade, setup)
+    purchase = facade.purchase_repo.get_by_user_and_site(setup["user"].id, setup["site"].id)[0]
+    remaining_before = purchase.remaining_amount
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("forced failure")
+
+    monkeypatch.setattr(facade.redemption_service, "_update_redemption_no_commit", boom)
+
+    with pytest.raises(RuntimeError, match="forced failure"):
+        facade.cancel_redemption(redemption.id, reason="rollback test")
+
+    refreshed = facade.get_redemption(redemption.id)
+    refreshed_purchase = facade.purchase_repo.get_by_user_and_site(setup["user"].id, setup["site"].id)[0]
+    assert refreshed.status == "PENDING"
+    assert refreshed.has_fifo_allocation is True
+    assert refreshed_purchase.remaining_amount == remaining_before
+
+
+def test_update_redemption_rejects_cancel_lifecycle_fields(facade, setup):
+    """Lightweight metadata updates must not mutate cancel lifecycle/accounting fields."""
+    redemption = _make_redemption(facade, setup)
+
+    with pytest.raises(ValueError, match=r"(?i)cancel lifecycle|not directly editable"):
+        facade.update_redemption(
+            redemption.id,
+            status="CANCELED",
+            canceled_at="2026-03-13 12:00:00",
+        )
+
+    refreshed = facade.get_redemption(redemption.id)
+    assert refreshed.status == "PENDING"
+    assert refreshed.canceled_at is None
+
+
+def test_uncancel_rebuilds_fifo_chronologically_when_later_redemption_exists(facade, setup):
+    """Uncancel must rebuild from the original timestamp when later pending redemptions exist."""
+    first = facade.create_redemption(
+        user_id=setup["user"].id,
+        site_id=setup["site"].id,
+        amount=Decimal("60.00"),
+        redemption_date=date.today() - timedelta(days=10),
+        redemption_time="10:00:00",
+        apply_fifo=True,
+        more_remaining=True,
+    )
+
+    facade.cancel_redemption(first.id, reason="re-open chronology")
+
+    later = facade.create_redemption(
+        user_id=setup["user"].id,
+        site_id=setup["site"].id,
+        amount=Decimal("80.00"),
+        redemption_date=date.today() - timedelta(days=9),
+        redemption_time="10:00:00",
+        apply_fifo=True,
+        more_remaining=True,
+    )
+
+    facade.uncancel_redemption(first.id)
+
+    allocations = _allocation_map(facade)
+    realized = _realized_cost_basis_map(facade)
+    purchase = facade.purchase_repo.get_by_user_and_site(setup["user"].id, setup["site"].id)[0]
+
+    assert allocations[(first.id, purchase.id)] == Decimal("60.00")
+    assert allocations[(later.id, purchase.id)] == Decimal("40.00")
+    assert realized[first.id] == Decimal("60.00")
+    assert realized[later.id] == Decimal("40.00")
+    assert purchase.remaining_amount == Decimal("0.00")
+
+
+def test_nested_cancel_uncancel_sequence_stays_rebuild_stable(facade, setup):
+    """Nested cancel/uncancel chains should land in the same FIFO state as a fresh rebuild."""
+    original_purchase = facade.purchase_repo.get_by_user_and_site(setup["user"].id, setup["site"].id)[0]
+    first = facade.create_redemption(
+        user_id=setup["user"].id,
+        site_id=setup["site"].id,
+        amount=Decimal("60.00"),
+        redemption_date=date.today() - timedelta(days=10),
+        redemption_time="10:00:00",
+        apply_fifo=True,
+        more_remaining=True,
+    )
+    facade.cancel_redemption(first.id, reason="first off")
+
+    extra_purchase = facade.create_purchase(
+        user_id=setup["user"].id,
+        site_id=setup["site"].id,
+        amount=Decimal("40.00"),
+        purchase_date=date.today() - timedelta(days=9),
+        purchase_time="09:00:00",
+        sc_received=Decimal("40.00"),
+    )
+    second = facade.create_redemption(
+        user_id=setup["user"].id,
+        site_id=setup["site"].id,
+        amount=Decimal("80.00"),
+        redemption_date=date.today() - timedelta(days=8),
+        redemption_time="10:00:00",
+        apply_fifo=True,
+        more_remaining=True,
+    )
+    facade.cancel_redemption(second.id, reason="second off")
+
+    facade.uncancel_redemption(first.id)
+    facade.uncancel_redemption(second.id)
+
+    allocations = _allocation_map(facade)
+    realized = _realized_cost_basis_map(facade)
+    original_purchase = facade.purchase_repo.get_by_id(original_purchase.id)
+    extra_purchase = facade.purchase_repo.get_by_id(extra_purchase.id)
+
+    assert allocations[(first.id, original_purchase.id)] == Decimal("60.00")
+    assert allocations[(second.id, original_purchase.id)] == Decimal("40.00")
+    assert allocations[(second.id, extra_purchase.id)] == Decimal("40.00")
+    assert realized[first.id] == Decimal("60.00")
+    assert realized[second.id] == Decimal("80.00")
+    assert original_purchase.remaining_amount == Decimal("0.00")
+    assert extra_purchase.remaining_amount == Decimal("0.00")
+
+
+def test_recalculate_everything_preserves_pending_cancel_accounting_state(facade, setup):
+    """Full rebuild must not corrupt queued-cancel FIFO/realized state or break later close."""
+    redemption = facade.create_redemption(
+        user_id=setup["user"].id,
+        site_id=setup["site"].id,
+        amount=Decimal("20.00"),
+        redemption_date=date.today() - timedelta(days=2),
+        redemption_time="10:00:00",
+        apply_fifo=True,
+        more_remaining=True,
+    )
+    session = facade.create_game_session(
+        user_id=setup["user"].id,
+        site_id=setup["site"].id,
+        game_id=None,
+        session_date=date.today() - timedelta(days=1),
+        session_time="09:00:00",
+        starting_balance=Decimal("80.00"),
+        ending_balance=Decimal("80.00"),
+        starting_redeemable=Decimal("80.00"),
+        ending_redeemable=Decimal("80.00"),
+        calculate_pl=False,
+    )
+
+    facade.cancel_redemption(redemption.id, reason="queued before rebuild")
+    assert facade.get_redemption(redemption.id).status == "PENDING_CANCEL"
+
+    facade.recalculate_everything()
+
+    queued = facade.get_redemption(redemption.id)
+    purchase = facade.purchase_repo.get_by_user_and_site(setup["user"].id, setup["site"].id)[0]
+    realized = _realized_cost_basis_map(facade)
+
+    assert queued.status == "PENDING_CANCEL"
+    assert queued.has_fifo_allocation is True
+    assert purchase.remaining_amount == Decimal("80.00")
+    assert realized[redemption.id] == Decimal("20.00")
+
+    facade.update_game_session(
+        session_id=session.id,
+        ending_balance=Decimal("80.00"),
+        ending_redeemable=Decimal("80.00"),
+        end_date=date.today() - timedelta(days=1),
+        end_time="22:00:00",
+        status="Closed",
+        recalculate_pl=False,
+    )
+
+    executed = facade.get_redemption(redemption.id)
+    assert executed.status == "CANCELED"
+    assert executed.has_fifo_allocation is False
+
+
+def test_canceled_at_is_localized_for_closed_session_recalc_events(facade, setup, monkeypatch):
+    """Closed-session recalculation must place cancel credits on the accounting-local timeline."""
+    redemption = _make_redemption(facade, setup, amount="10.00")
+    facade.cancel_redemption(redemption.id, reason="timezone parity")
+    facade.db.execute(
+        "UPDATE redemptions SET canceled_at = ? WHERE id = ?",
+        ("2026-03-13 01:30:00", redemption.id),
+    )
+
+    monkeypatch.setattr(
+        "services.game_session_service.utc_date_time_to_accounting_local",
+        lambda db, utc_date, utc_time, settings=None: (date(2026, 3, 12), "20:30:00"),
+    )
+
+    events = facade.game_session_service._load_redemption_balance_events(
+        setup["user"].id,
+        setup["site"].id,
+    )
+
+    assert (datetime(2026, 3, 12, 20, 30, 0), Decimal("-10.00")) in events
+
+
+def test_undo_completed_pending_cancel_restores_pending_with_fifo_allocation(facade, setup):
+    """Undoing deferred-cancel completion must restore a usable pending redemption state."""
+    redemption = _make_redemption(facade, setup)
+
+    session = facade.create_game_session(
+        user_id=setup["user"].id,
+        site_id=setup["site"].id,
+        game_id=None,
+        session_date=date.today() - timedelta(days=1),
+        session_time="10:00:00",
+        starting_balance=Decimal("0.00"),
+        ending_balance=Decimal("0.00"),
+        starting_redeemable=Decimal("0.00"),
+        ending_redeemable=Decimal("0.00"),
+        calculate_pl=False,
+    )
+
+    facade.cancel_redemption(redemption.id, reason="queued")
+    assert facade.get_redemption(redemption.id).status == "PENDING_CANCEL"
+
+    facade.update_game_session(
+        session_id=session.id,
+        ending_balance=Decimal("0.00"),
+        ending_redeemable=Decimal("0.00"),
+        end_date=date.today(),
+        end_time="22:00:00",
+        status="Closed",
+        recalculate_pl=False,
+    )
+    assert facade.get_redemption(redemption.id).status == "CANCELED"
+
+    facade.undo_redo_service.undo()
+
+    restored = facade.get_redemption(redemption.id)
+    assert restored.status == "PENDING"
+    assert restored.receipt_date is None
+    assert restored.has_fifo_allocation is True
+
+
+def test_pending_cancel_batch_failure_rolls_back_all_and_session_close(facade, setup, monkeypatch):
+    """Deferred-cancel completion should be all-or-nothing across the whole close operation."""
+    first = facade.create_redemption(
+        user_id=setup["user"].id,
+        site_id=setup["site"].id,
+        amount=Decimal("20.00"),
+        redemption_date=date.today() - timedelta(days=1),
+        redemption_time="11:00:00",
+        apply_fifo=True,
+        more_remaining=True,
+    )
+    second = facade.create_redemption(
+        user_id=setup["user"].id,
+        site_id=setup["site"].id,
+        amount=Decimal("30.00"),
+        redemption_date=date.today() - timedelta(days=1),
+        redemption_time="12:00:00",
+        apply_fifo=True,
+        more_remaining=True,
+    )
+    session = facade.create_game_session(
+        user_id=setup["user"].id,
+        site_id=setup["site"].id,
+        game_id=None,
+        session_date=date.today() - timedelta(days=1),
+        session_time="10:00:00",
+        starting_balance=Decimal("50.00"),
+        ending_balance=Decimal("50.00"),
+        starting_redeemable=Decimal("50.00"),
+        ending_redeemable=Decimal("50.00"),
+        calculate_pl=False,
+    )
+
+    facade.cancel_redemption(first.id, reason="queue first")
+    facade.cancel_redemption(second.id, reason="queue second")
+    assert facade.get_redemption(first.id).status == "PENDING_CANCEL"
+    assert facade.get_redemption(second.id).status == "PENDING_CANCEL"
+
+    purchase_before = facade.purchase_repo.get_by_user_and_site(setup["user"].id, setup["site"].id)[0]
+    realized_before = _realized_cost_basis_map(facade)
+    original_update = facade.redemption_service._update_redemption_no_commit
+
+    def fail_on_second(redemption):
+        if redemption.id == second.id and getattr(redemption, "status", None) == "CANCELED":
+            raise RuntimeError("forced second pending cancel failure")
+        return original_update(redemption)
+
+    monkeypatch.setattr(facade.redemption_service, "_update_redemption_no_commit", fail_on_second)
+
+    with pytest.raises(RuntimeError, match="forced second pending cancel failure"):
+        facade.update_game_session(
+            session_id=session.id,
+            ending_balance=Decimal("50.00"),
+            ending_redeemable=Decimal("50.00"),
+            end_date=date.today(),
+            end_time="22:00:00",
+            status="Closed",
+            recalculate_pl=False,
+        )
+
+    refreshed_session = facade.get_game_session(session.id)
+    refreshed_first = facade.get_redemption(first.id)
+    refreshed_second = facade.get_redemption(second.id)
+    purchase_after = facade.purchase_repo.get_by_user_and_site(setup["user"].id, setup["site"].id)[0]
+    realized_after = _realized_cost_basis_map(facade)
+
+    assert refreshed_session.status == "Active"
+    assert refreshed_first.status == "PENDING_CANCEL"
+    assert refreshed_second.status == "PENDING_CANCEL"
+    assert refreshed_first.has_fifo_allocation is True
+    assert refreshed_second.has_fifo_allocation is True
+    assert purchase_after.remaining_amount == purchase_before.remaining_amount
+    assert realized_after == realized_before
+
+
+def test_undo_delete_pending_cancel_restores_queued_state_with_fifo(facade, setup):
+    """Undoing delete of a queued cancel should restore the queued row plus preserved FIFO state."""
+    session = facade.create_game_session(
+        user_id=setup["user"].id,
+        site_id=setup["site"].id,
+        game_id=None,
+        session_date=date.today() - timedelta(days=1),
+        session_time="10:00:00",
+        starting_balance=Decimal("0.00"),
+        ending_balance=Decimal("0.00"),
+        starting_redeemable=Decimal("0.00"),
+        ending_redeemable=Decimal("0.00"),
+        calculate_pl=False,
+    )
+    redemption = _make_redemption(facade, setup)
+    facade.cancel_redemption(redemption.id, reason="queue before delete")
+    assert facade.get_redemption(redemption.id).status == "PENDING_CANCEL"
+
+    facade.delete_redemption(redemption.id)
+    assert facade.get_redemption(redemption.id) is None
+
+    facade.undo_redo_service.undo()
+
+    restored = facade.get_redemption(redemption.id)
+    assert session.status == "Active"
+    assert restored.status == "PENDING_CANCEL"
+    assert restored.has_fifo_allocation is True
+
+
+def test_undo_delete_canceled_redemption_restores_canceled_without_fifo(facade, setup):
+    """Undoing delete of a canceled redemption should not resurrect live FIFO allocations."""
+    redemption = _make_redemption(facade, setup)
+    facade.cancel_redemption(redemption.id, reason="cancel before delete")
+    canceled = facade.get_redemption(redemption.id)
+    assert canceled.status == "CANCELED"
+    assert canceled.has_fifo_allocation is False
+
+    facade.delete_redemption(redemption.id)
+    assert facade.get_redemption(redemption.id) is None
+
+    facade.undo_redo_service.undo()
+
+    restored = facade.get_redemption(redemption.id)
+    assert restored.status == "CANCELED"
+    assert restored.has_fifo_allocation is False
+
+
+def test_undo_create_redemption_cleans_fifo_artifacts_and_restores_purchase(facade, setup):
+    """Undoing redemption creation must remove FIFO/realized artifacts for the soft-deleted row."""
+    redemption = facade.create_redemption(
+        user_id=setup["user"].id,
+        site_id=setup["site"].id,
+        amount=Decimal("10.00"),
+        redemption_date=date.today() - timedelta(days=2),
+        redemption_time="12:00:00",
+        apply_fifo=True,
+        more_remaining=True,
+    )
+
+    purchase_before_undo = facade.purchase_repo.get_by_user_and_site(setup["user"].id, setup["site"].id)[0]
+    assert purchase_before_undo.remaining_amount == Decimal("90.00")
+
+    facade.undo_redo_service.undo()
+
+    purchase_after_undo = facade.purchase_repo.get_by_user_and_site(setup["user"].id, setup["site"].id)[0]
+    allocation_rows = facade.db.fetch_all(
+        "SELECT redemption_id, purchase_id FROM redemption_allocations WHERE redemption_id = ?",
+        (redemption.id,),
+    )
+    realized_rows = facade.db.fetch_all(
+        "SELECT redemption_id FROM realized_transactions WHERE redemption_id = ?",
+        (redemption.id,),
+    )
+
+    assert facade.get_redemption(redemption.id) is None
+    assert purchase_after_undo.remaining_amount == Decimal("100.00")
+    assert allocation_rows == []
+    assert realized_rows == []
+
+
+def test_rebuild_ignores_soft_deleted_purchases_after_undo(facade):
+    """Scoped/full rebuilds must not reallocate against soft-deleted purchases restored only in audit history."""
+    user = facade.create_user("Deleted Purchase User")
+    site = facade.create_site("Deleted Purchase Site", sc_rate=1.0)
+
+    purchase_1 = facade.create_purchase(
+        user_id=user.id,
+        site_id=site.id,
+        amount=Decimal("100.00"),
+        purchase_date=date.today() - timedelta(days=20),
+        sc_received=Decimal("100.00"),
+    )
+    facade.undo_redo_service.undo()
+    assert facade.get_purchase(purchase_1.id) is None
+
+    purchase_2 = facade.create_purchase(
+        user_id=user.id,
+        site_id=site.id,
+        amount=Decimal("40.00"),
+        purchase_date=date.today() - timedelta(days=10),
+        purchase_time="10:00:00",
+        sc_received=Decimal("40.00"),
+    )
+
+    redemption = facade.create_redemption(
+        user_id=user.id,
+        site_id=site.id,
+        amount=Decimal("20.00"),
+        redemption_date=date.today() - timedelta(days=5),
+        redemption_time="14:00:00",
+        apply_fifo=True,
+        more_remaining=True,
+    )
+
+    allocation_rows = facade.db.fetch_all(
+        "SELECT purchase_id, allocated_amount FROM redemption_allocations WHERE redemption_id = ?",
+        (redemption.id,),
+    )
+    refreshed_purchase = facade.get_purchase(purchase_2.id)
+
+    assert allocation_rows == [{"purchase_id": purchase_2.id, "allocated_amount": "20.00"}]
+    assert refreshed_purchase.remaining_amount == Decimal("20.00")
+
+    facade.delete_redemption(redemption.id)
+    assert facade.get_redemption(redemption.id) is None

--- a/tests/ui/test_redemption_cancel_visibility.py
+++ b/tests/ui/test_redemption_cancel_visibility.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+from datetime import date, timedelta
+from decimal import Decimal
+
+import pytest
+from PySide6 import QtCore
+
+from app_facade import AppFacade
+from ui.settings import Settings
+from ui.tabs.redemptions_tab import RedemptionsTab
+
+
+class _MainWindowStub:
+    def __init__(self, settings: Settings):
+        self.settings = settings
+
+    def refresh_all_tabs(self):
+        pass
+
+
+@pytest.fixture
+def facade(tmp_path):
+    app = AppFacade(str(tmp_path / "issue_187_ui.db"))
+    yield app
+    app.db.close()
+
+
+@pytest.fixture
+def settings(tmp_path):
+    return Settings(settings_file=str(tmp_path / "settings.json"))
+
+
+def _row_for_redemption(tab: RedemptionsTab, redemption_id: int) -> int:
+    for row in range(tab.table.rowCount()):
+        item = tab.table.item(row, 0)
+        if item is not None and item.data(QtCore.Qt.UserRole) == redemption_id:
+            return row
+    raise AssertionError(f"redemption row {redemption_id} not found")
+
+
+def _select_row(tab: RedemptionsTab, row: int) -> None:
+    tab.table.clearSelection()
+    tab.table.selectRow(row)
+    tab._on_selection_changed()
+
+
+def test_cancel_button_hidden_for_received_and_edit_hidden_for_pending_cancel(qtbot, facade, settings):
+    user = facade.create_user("UI User")
+    site = facade.create_site("UI Site", sc_rate=1.0)
+
+    facade.create_purchase(
+        user_id=user.id,
+        site_id=site.id,
+        amount=Decimal("100.00"),
+        purchase_date=date.today() - timedelta(days=10),
+        sc_received=Decimal("100.00"),
+    )
+
+    pending = facade.create_redemption(
+        user_id=user.id,
+        site_id=site.id,
+        amount=Decimal("10.00"),
+        redemption_date=date.today() - timedelta(days=3),
+        redemption_time="08:00:00",
+        receipt_date=None,
+        processed=False,
+        more_remaining=True,
+        apply_fifo=False,
+    )
+    received = facade.create_redemption(
+        user_id=user.id,
+        site_id=site.id,
+        amount=Decimal("20.00"),
+        redemption_date=date.today() - timedelta(days=2),
+        redemption_time="09:00:00",
+        receipt_date=date.today() - timedelta(days=1),
+        processed=False,
+        more_remaining=True,
+        apply_fifo=False,
+    )
+
+    active_session = facade.create_game_session(
+        user_id=user.id,
+        site_id=site.id,
+        game_id=None,
+        session_date=date.today() - timedelta(days=1),
+        session_time="10:00:00",
+        starting_balance=Decimal("0.00"),
+        ending_balance=Decimal("0.00"),
+        starting_redeemable=Decimal("0.00"),
+        ending_redeemable=Decimal("0.00"),
+        calculate_pl=False,
+    )
+    queued = facade.create_redemption(
+        user_id=user.id,
+        site_id=site.id,
+        amount=Decimal("15.00"),
+        redemption_date=date.today() - timedelta(days=1),
+        redemption_time="10:30:00",
+        receipt_date=None,
+        processed=False,
+        more_remaining=True,
+        apply_fifo=True,
+    )
+    facade.cancel_redemption(queued.id, reason="queue it")
+    assert facade.get_redemption(queued.id).status == "PENDING_CANCEL"
+    assert active_session.status == "Active"
+
+    tab = RedemptionsTab(facade, main_window=_MainWindowStub(settings))
+    qtbot.addWidget(tab)
+    tab.show()
+    tab.date_filter.set_all_time()
+    tab.refresh_data()
+
+    pending_row = _row_for_redemption(tab, pending.id)
+    _select_row(tab, pending_row)
+    assert tab.cancel_btn.isHidden() is False
+    assert tab.edit_btn.isHidden() is False
+
+    received_row = _row_for_redemption(tab, received.id)
+    _select_row(tab, received_row)
+    assert tab.cancel_btn.isHidden() is True
+    assert tab.uncancel_btn.isHidden() is True
+
+    queued_row = _row_for_redemption(tab, queued.id)
+    _select_row(tab, queued_row)
+    assert tab.cancel_btn.isHidden() is True
+    assert tab.edit_btn.isHidden() is True
+    assert tab.uncancel_btn.isHidden() is True
+
+    tab.table.clearSelection()
+    tab._on_selection_changed()
+    assert tab.cancel_btn.isHidden() is True
+    assert tab.uncancel_btn.isHidden() is True

--- a/ui/tabs/redemptions_tab.py
+++ b/ui/tabs/redemptions_tab.py
@@ -613,12 +613,20 @@ class RedemptionsTab(QtWidgets.QWidget):
             len(selected_redemptions) == 1
             and getattr(selected_redemptions[0], 'status', 'PENDING') == 'PENDING'
         )
+        single_cancellable = (
+            single_pending
+            and getattr(selected_redemptions[0], 'receipt_date', None) is None
+        )
         single_canceled = (
             len(selected_redemptions) == 1
             and getattr(selected_redemptions[0], 'status', 'PENDING') == 'CANCELED'
         )
+        single_pending_cancel = (
+            len(selected_redemptions) == 1
+            and getattr(selected_redemptions[0], 'status', 'PENDING') == 'PENDING_CANCEL'
+        )
 
-        self.edit_btn.setVisible(len(selected_rows) == 1 and not single_canceled)
+        self.edit_btn.setVisible(len(selected_rows) == 1 and not single_canceled and not single_pending_cancel)
         self.delete_btn.setVisible(len(selected_rows) > 0)
         # Bulk actions: only for PENDING rows
         pending_count = sum(
@@ -629,7 +637,7 @@ class RedemptionsTab(QtWidgets.QWidget):
         self.mark_processed_btn.setVisible(pending_count > 0)
 
         # Cancel / Uncancel (Issue #148)
-        self.cancel_btn.setVisible(single_pending)
+        self.cancel_btn.setVisible(single_cancellable)
         self.uncancel_btn.setVisible(single_canceled)
 
         # Update spreadsheet stats bar
@@ -817,6 +825,13 @@ class RedemptionsTab(QtWidgets.QWidget):
 
         redemption = self.facade.get_redemption(redemption_id)
         if not redemption:
+            return
+        if getattr(redemption, 'status', 'PENDING') != 'PENDING':
+            QtWidgets.QMessageBox.information(
+                self,
+                "Edit Locked",
+                "Only PENDING redemptions can be edited.",
+            )
             return
 
         dialog = RedemptionDialog(self.facade, self, redemption)


### PR DESCRIPTION
Fixes #187.

## Summary
- harden redemption cancel/uncancel lifecycle accounting, queued cancel processing, and undo/redo reconciliation
- add regressions for queued cancel cleanup, purchase delete undo/redo, and redemption UI/state gating
- update the product spec and changelog for the Issue 187 accounting contract

## Validation
- pytest -q
- randomized live-vs-canonical rebuild replay across seeds 1..250 -> BAD []
- isolated rerun of tests/ui/test_expenses_autocomplete.py::test_expense_dialog_vendor_and_notes_inline_prediction_with_tab_accept passed after one unrelated flaky full-suite failure

## Pitfalls / Follow-ups
- pre-existing sqlite ResourceWarning noise remains
- the expenses autocomplete failure appears unrelated and intermittent