### PR TITLE
Prompt to close low-balance sessions after session end

### DIFF
--- a/app_facade.py
+++ b/app_facade.py
@@ -2437,6 +2437,54 @@ class AppFacade:
         """Get specific unrealized position for a site/user pair."""
         return self.unrealized_position_repo.get_position_by_site_user(site_id, user_id)
 
+    def get_low_balance_close_prompt_data(
+        self,
+        site_id: int,
+        user_id: int,
+        ending_total_sc: Decimal,
+    ) -> Optional[Dict[str, Any]]:
+        """Return close-prompt context for low-value ended sessions.
+
+        Prompts are based on dollar-equivalent value, not raw SC, so sites with
+        different `sc_rate` values use the same $1.00 threshold.
+        """
+        site = self.get_site(site_id)
+        user = self.get_user(user_id)
+        if not site or not user:
+            return None
+
+        current_sc = Decimal(str(ending_total_sc or 0))
+        sc_rate = Decimal(str(getattr(site, "sc_rate", 1.0) or 1.0))
+        current_value = current_sc * sc_rate
+        close_threshold = Decimal("1.00")
+        if current_value >= close_threshold:
+            return None
+
+        basis_row = self.db.fetch_one(
+            """
+            SELECT COALESCE(SUM(remaining_amount), 0) AS remaining_basis
+            FROM purchases
+            WHERE site_id = ? AND user_id = ?
+              AND deleted_at IS NULL
+              AND (status IS NULL OR status = 'active')
+            """,
+            (site_id, user_id),
+        )
+        total_basis = Decimal("0.00")
+        if basis_row:
+            total_basis = Decimal(str(basis_row["remaining_basis"] or 0))
+
+        return {
+            "site_id": site_id,
+            "user_id": user_id,
+            "site_name": site.name,
+            "user_name": user.name,
+            "current_sc": current_sc,
+            "current_value": current_value,
+            "total_basis": total_basis,
+            "close_threshold": close_threshold,
+        }
+
     def update_unrealized_notes(self, site_id: int, user_id: int, notes: str) -> None:
         self.unrealized_position_repo.update_notes(site_id, user_id, notes)
 

--- a/docs/PROJECT_SPEC.md
+++ b/docs/PROJECT_SPEC.md
@@ -425,6 +425,11 @@ When editing a purchase or creating/editing a game session, the system computes 
     - If `Remaining Basis = $0.00`, Sezzions creates only an explicit `Balance Closed` marker with `more_remaining=1`, does **not** run FIFO, does **not** create a realized cashflow loss row, and leaves historical purchase rows untouched.
     - In the Redemptions tab, any synthetic `Balance Closed` marker is labeled as `Closed` rather than `Full`/`Partial` or `Loss`, so UI wording reflects close-marker intent instead of underlying redemption flags.
     - In both cases the position is hidden until later activity occurs after the close timestamp, at which point Unrealized reopens the position naturally.
+  - **Issue #193 (2026-03-25):** Ending a session through the normal **End Session** flow now checks whether the ending balance is below the `$1.00` equivalent close threshold using `ending_total_sc × sc_rate`.
+    - If the dollar-equivalent ending balance is `< $1.00`, Sezzions prompts the user to close the position immediately after the session is saved.
+    - The prompt reuses the same close semantics as the Unrealized tab: basis-bearing positions consume remaining FIFO basis and create the matching realized cashflow loss; zero-basis positions create only the dormant `Balance Closed` marker with no FIFO change and no realized loss row.
+    - The prompt is informational only; declining it leaves the session closed and leaves the position open.
+    - **End & Start New** intentionally skips this prompt so chained-session workflow stays uninterrupted.
   - **Recalculation invariant (Issue #156, 2026-03-09):** During FIFO rebuild, a close marker with parsable `Net Loss: $X.XX` is treated as basis-consuming closeout accounting for that timestamp window.
     - Rebuild allocates FIFO basis to the close marker redemption up to `min(parsed_loss, available_basis_at_or_before_close_time)`.
     - Allocations are written to `redemption_allocations`, and `purchases.remaining_amount` is reduced accordingly.
@@ -861,6 +866,7 @@ Game Sessions convenience:
 - Sezzions keeps **1 game per session** (accounting clarity), but provides a fast workflow to chain sessions across games:
   - End Session dialog: **"End & Start New"**
   - New Start Session dialog is prefilled with the ended session’s ending balances (same user/site); game selection is intentionally left blank.
+- Normal **End Session** may show a follow-up low-balance close prompt when the saved ending balance is worth `< $1.00` at the site’s `sc_rate`; choosing **End & Start New** skips that prompt.
 
 Session redeemable entry (Issue #160):
 - End Session and Edit Closed Session include an `Auto-Calc Redeemable SC` toggle (checkbox-only row; no extra label).

--- a/docs/archive/2026-03-25-issue-low-balance-close-prompt.md
+++ b/docs/archive/2026-03-25-issue-low-balance-close-prompt.md
@@ -1,0 +1,107 @@
+Problem / motivation
+Closing a session with an effectively empty leftover balance does not currently offer a direct close-out step for the still-open position. This can leave prior purchase basis open across a later rebuy cycle, causing Unrealized to reopen with old still-open basis and making the row look like a massive loss.
+
+The desired workflow is:
+- if a closed session leaves less than $1.00 equivalent on-site, prompt the user to close the position immediately
+- reuse the existing close-position semantics so basis-bearing closes still abandon basis and zero-basis closes still write only a dormant close marker
+- preserve the recently added zero-basis Unrealized close behavior for profit-only / no-basis rows
+
+Proposed solution
+What:
+- After a normal session close (not the “End & Start New” flow), detect whether the ending total balance is below a configurable-equivalent threshold of $1.00 using the site’s `sc_rate`
+- If below threshold and there is still an open position for that site/user pair, prompt the user to close the position now
+- If the user confirms, route through the existing `close_unrealized_position()` flow so:
+  - `Remaining Basis > 0` keeps the current basis-abandoning close behavior
+  - `Remaining Basis = 0` keeps the zero-basis dormant close-marker behavior with no FIFO / realized loss row
+
+Why:
+- prevents silent carry-forward of stale basis into a new cycle after a near-zero bust-out
+- preserves explicit user intent instead of auto-closing without confirmation
+- keeps the current two close semantics intact instead of inventing a third accounting path
+
+Notes:
+- The prompt threshold must use dollar-equivalent value, not raw SC count
+- Example: `sc_rate = 1.0` => prompt when ending balance < 1 SC
+- Example: `sc_rate = 0.01` (100 SC = $1) => prompt when ending balance < 100 SC
+- Preserve the zero-basis close path added recently for Unrealized positions
+
+Scope
+In-scope:
+- Game Sessions tab normal end-session flow
+- Threshold check based on ending balance × `sc_rate`
+- Prompt-to-close UX after successful session close
+- Reuse of existing basis-bearing vs zero-basis close semantics
+- Regression coverage for basis-bearing and zero-basis prompt flows
+- Spec/changelog updates
+
+Out-of-scope:
+- Auto-closing positions without user confirmation
+- Changing FIFO accounting semantics for ordinary close-position behavior
+- Changing the “End & Start New” workflow unless necessary for guardrails
+- Changing how pure session-only/no-purchase remainders become visible in Unrealized
+
+UX / fields / checkboxes
+Screen/Tab:
+- Game Sessions tab
+- End Session dialog follow-up flow after successful close
+
+Fields:
+- uses existing ending total SC / ending redeemable SC fields
+
+Checkboxes/toggles:
+- none
+
+Buttons/actions:
+- after a qualifying session close, show a follow-up confirmation to close the position now
+- confirmed action reuses existing close-position service logic
+
+Warnings/confirmations:
+- confirmation text must distinguish:
+  - basis-bearing closeout: abandons remaining basis and records realized cash-flow loss
+  - zero-basis closeout: writes dormant close marker only with $0.00 loss and no tax impact
+
+Implementation notes / strategy
+Approach:
+- add a service/facade helper that determines whether a just-closed session qualifies for low-balance close prompting and returns the data needed for the prompt
+- trigger the prompt from the normal end-session UI flow after the session close succeeds and the UI refreshes
+- use the existing `close_unrealized_position()` implementation for the actual closeout
+- skip prompting on “End & Start New” because the user is explicitly continuing the cycle immediately
+
+Data model / migrations (if any):
+- no schema changes expected
+
+Risk areas:
+- breaking the zero-basis close path added recently
+- prompting when there is no meaningful open position left to close
+- prompting on raw SC instead of dollar-equivalent value
+- double prompts or prompt timing issues during end-session UI flows
+
+Acceptance criteria
+- Given a site with `sc_rate = 1.0`, when a session is closed with ending total balance < 1.00 SC and open basis remains, then the app prompts to close the position
+- Given a site with `sc_rate = 0.01`, when a session is closed with ending total balance < 100.00 SC and open basis remains, then the app prompts to close the position
+- Given the user confirms a qualifying prompt and remaining basis > 0, then existing basis close behavior runs unchanged
+- Given the user confirms a qualifying prompt and remaining basis = 0, then the existing zero-basis dormant close-marker behavior runs unchanged
+- Given the user declines the prompt, then the session remains closed and no close marker / realized close row is created
+- Given the user uses “End & Start New”, then no low-balance close prompt interrupts the continuation workflow
+
+Test plan
+Automated tests:
+- UI/integration test for end-session low-balance prompt on a 1:1 site with remaining basis
+- UI/integration test for end-session low-balance prompt on a non-1:1 site (e.g. `sc_rate = 0.01`)
+- Regression test proving confirmed zero-basis prompt reuses dormant close-marker path
+- Regression test proving declined prompt leaves session close intact without position close
+- Regression test proving “End & Start New” skips the low-balance prompt
+- Headless smoke coverage for touched UI flows
+
+Manual verification:
+- End a low-balance Modo session and confirm the follow-up close prompt appears
+- Confirm yes/no behavior for both basis-bearing and zero-basis cases
+- Confirm a later rebuy after confirmed close starts a fresh cycle in Unrealized
+
+Area
+UI
+
+Notes
+- This change likely requires updating `docs/PROJECT_SPEC.md`.
+- This change likely requires adding/updating scenario-based tests.
+- This change includes destructive actions (must add warnings/backup prompts).

--- a/docs/archive/2026-03-25-pr-193-body.md
+++ b/docs/archive/2026-03-25-pr-193-body.md
@@ -1,0 +1,15 @@
+## Summary
+- add a low-balance follow-up prompt after the normal End Session flow when `ending_total_sc * sc_rate < $1.00`
+- reuse the existing Unrealized close behavior so basis-bearing closes still create realized cashflow losses while zero-basis closes only write a dormant close marker
+- document the workflow and add regression coverage for prompt acceptance, decline, SC-rate thresholds, zero-basis compatibility, and End & Start New bypass
+
+## Testing
+- QT_QPA_PLATFORM=offscreen pytest -q tests/integration/test_issue_193_low_balance_close_prompt.py tests/integration/test_issue_191_zero_basis_unrealized_close.py tests/ui/test_issue_191_unrealized_zero_basis_close_ui.py
+- QT_QPA_PLATFORM=offscreen pytest -q
+
+## Manual verification
+- Reviewed the headless End Session flow exercised by the new integration test to confirm the prompt appears only on the normal close path and not on End & Start New.
+
+## Pitfalls / Follow-ups
+- The prompt only appears after a session is saved. If users want a setup toggle or a different threshold, that should be tracked as a separate issue.
+- The current prompt uses the saved ending total and site `sc_rate`; if future workflows allow per-session exchange overrides, this prompt should follow the same source of truth.

--- a/docs/status/CHANGELOG.md
+++ b/docs/status/CHANGELOG.md
@@ -9,6 +9,37 @@ Rules:
 
 ---
 
+## 2026-03-25
+
+```yaml
+id: 2026-03-25-01
+type: feat
+areas: [sessions, unrealized, redemptions, ui, tests, docs]
+issue: 193
+summary: "Prompt to close low-balance positions after ending a session"
+details: >
+  Added a post-close prompt to the normal End Session flow when the saved ending
+  balance is worth less than $1.00 at the site's SC conversion rate. The prompt
+  uses dollar-equivalent value (`ending_total_sc × sc_rate`) so non-1:1 sites
+  behave consistently, and it reuses the existing Unrealized close semantics:
+  basis-bearing positions create the usual FIFO-backed realized loss while
+  zero-basis positions create only a dormant `Balance Closed` marker with no
+  FIFO change and no realized loss row. Declining the prompt leaves the session
+  closed and the position open, while `End & Start New` intentionally skips the
+  prompt to preserve the fast chained-session workflow.
+
+  Validation:
+  - QT_QPA_PLATFORM=offscreen pytest -q tests/integration/test_issue_193_low_balance_close_prompt.py tests/integration/test_issue_191_zero_basis_unrealized_close.py tests/ui/test_issue_191_unrealized_zero_basis_close_ui.py
+  - QT_QPA_PLATFORM=offscreen pytest -q
+files_changed:
+  - app_facade.py
+  - ui/tabs/game_sessions_tab.py
+  - tests/integration/test_issue_193_low_balance_close_prompt.py
+  - docs/PROJECT_SPEC.md
+  - docs/status/CHANGELOG.md
+  - docs/archive/2026-03-25-issue-low-balance-close-prompt.md
+```
+
 ## 2026-03-23
 
 ```yaml

--- a/tests/integration/test_issue_193_low_balance_close_prompt.py
+++ b/tests/integration/test_issue_193_low_balance_close_prompt.py
@@ -1,0 +1,254 @@
+import os
+import tempfile
+from datetime import date
+from decimal import Decimal
+
+import pytest
+from PySide6.QtCore import QTimer, Qt
+from PySide6.QtWidgets import QApplication, QMessageBox
+
+from app_facade import AppFacade
+from ui.tabs.game_sessions_tab import EndSessionDialog, GameSessionsTab, StartSessionDialog
+
+
+@pytest.fixture
+def temp_db_path():
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    yield path
+    if os.path.exists(path):
+        os.unlink(path)
+
+
+@pytest.fixture
+def facade(temp_db_path):
+    app = AppFacade(temp_db_path)
+    yield app
+    app.db.close()
+
+
+def _find_visible_dialog(dialog_type):
+    for widget in QApplication.topLevelWidgets():
+        if isinstance(widget, dialog_type) and widget.isVisible():
+            return widget
+    return None
+
+
+def _seed_low_balance_session(
+    facade: AppFacade,
+    *,
+    sc_rate: float = 1.0,
+    purchase_amount: Decimal = Decimal("20.00"),
+    remaining_basis: Decimal = Decimal("20.00"),
+    session_date: date = date(2026, 3, 25),
+):
+    user = facade.create_user("Prompt User")
+    site = facade.create_site("Prompt Site", "https://example.com", sc_rate=sc_rate)
+    game_type = facade.create_game_type("Slots")
+    game = facade.create_game("Prompt Game", game_type.id, rtp=96.0)
+
+    facade.db.execute(
+        """
+        INSERT INTO purchases
+            (user_id, site_id, purchase_date, purchase_time, amount, sc_received, remaining_amount, status)
+        VALUES
+            (?, ?, ?, '09:00:00', ?, ?, ?, 'active')
+        """,
+        (
+            user.id,
+            site.id,
+            (session_date).isoformat(),
+            str(purchase_amount),
+            str(purchase_amount),
+            str(remaining_basis),
+        ),
+    )
+    facade.db.commit()
+
+    facade.db.execute(
+        """
+        INSERT INTO game_sessions
+            (user_id, site_id, game_id, session_date, session_time,
+             starting_balance, ending_balance, starting_redeemable, ending_redeemable,
+             purchases_during, redemptions_during, notes, status)
+        VALUES
+            (?, ?, ?, ?, '10:00:00', ?, 0.00, 0.00, 0.00, 0.00, 0.00, '', 'Active')
+        """,
+        (
+            user.id,
+            site.id,
+            game.id,
+            session_date.isoformat(),
+            str(purchase_amount),
+        ),
+    )
+    facade.db.commit()
+    session = facade.get_game_session(1)
+    return user, site, session
+
+
+def _drive_end_session_dialog(qtbot, *, end_total: str, end_redeem: str, start_new: bool = False):
+    def drive():
+        dlg = _find_visible_dialog(EndSessionDialog)
+        if dlg is None:
+            QTimer.singleShot(10, drive)
+            return
+        dlg.end_total_edit.setText(end_total)
+        dlg.end_redeem_edit.setText(end_redeem)
+        target = dlg.end_and_start_btn if start_new else dlg.save_btn
+        qtbot.mouseClick(target, Qt.LeftButton)
+
+    QTimer.singleShot(0, drive)
+
+
+def test_low_balance_prompt_context_uses_sc_rate_threshold(facade):
+    user, site, _session = _seed_low_balance_session(
+        facade,
+        sc_rate=0.01,
+        purchase_amount=Decimal("150.00"),
+        remaining_basis=Decimal("150.00"),
+    )
+
+    prompt = facade.get_low_balance_close_prompt_data(
+        site_id=site.id,
+        user_id=user.id,
+        ending_total_sc=Decimal("99.99"),
+    )
+    assert prompt is not None
+    assert prompt["current_value"] < Decimal("1.00")
+
+    no_prompt = facade.get_low_balance_close_prompt_data(
+        site_id=site.id,
+        user_id=user.id,
+        ending_total_sc=Decimal("100.00"),
+    )
+    assert no_prompt is None
+
+
+def test_confirmed_low_balance_prompt_reuses_basis_close_path(qtbot, facade, monkeypatch):
+    _seed_low_balance_session(facade, remaining_basis=Decimal("20.00"))
+
+    prompts = []
+    infos = []
+    warnings = []
+
+    monkeypatch.setattr(QMessageBox, "question", lambda _p, _t, message: prompts.append(message) or QMessageBox.Yes)
+    monkeypatch.setattr(QMessageBox, "information", lambda _p, title, message: infos.append((title, message)) or QMessageBox.Ok)
+    monkeypatch.setattr(QMessageBox, "warning", lambda _p, title, message: warnings.append((title, message)) or QMessageBox.Ok)
+    monkeypatch.setattr(QMessageBox, "critical", lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("Unexpected critical dialog")))
+
+    tab = GameSessionsTab(facade)
+    qtbot.addWidget(tab)
+
+    _drive_end_session_dialog(qtbot, end_total="0.40", end_redeem="0.40")
+    tab._end_session_by_id(1)
+
+    assert prompts, "Expected low-balance close prompt"
+    assert "below the $1.00 equivalent close threshold" in prompts[0]
+    assert "Remaining basis: $20.00" in prompts[0]
+    assert not warnings
+
+    session = facade.get_game_session(1)
+    assert (session.status or "") == "Closed"
+
+    redemption = facade.db.fetch_one(
+        "SELECT amount, more_remaining, notes FROM redemptions ORDER BY id DESC LIMIT 1"
+    )
+    assert Decimal(str(redemption["amount"])) == Decimal("0.00")
+    assert redemption["more_remaining"] == 0
+    assert redemption["notes"].startswith("Balance Closed - Net Loss: $20.00")
+
+    realized = facade.db.fetch_one(
+        "SELECT cost_basis, payout, net_pl FROM realized_transactions ORDER BY id DESC LIMIT 1"
+    )
+    assert Decimal(str(realized["cost_basis"])) == Decimal("20.00")
+    assert Decimal(str(realized["payout"])) == Decimal("0.00")
+    assert Decimal(str(realized["net_pl"])) == Decimal("-20.00")
+    assert infos and "Position also closed" in infos[-1][1]
+
+
+def test_confirmed_low_balance_prompt_reuses_zero_basis_close_path(qtbot, facade, monkeypatch):
+    _seed_low_balance_session(facade, remaining_basis=Decimal("0.00"))
+
+    prompts = []
+    infos = []
+
+    monkeypatch.setattr(QMessageBox, "question", lambda _p, _t, message: prompts.append(message) or QMessageBox.Yes)
+    monkeypatch.setattr(QMessageBox, "information", lambda _p, title, message: infos.append((title, message)) or QMessageBox.Ok)
+    monkeypatch.setattr(QMessageBox, "warning", lambda *args, **kwargs: QMessageBox.Ok)
+    monkeypatch.setattr(QMessageBox, "critical", lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("Unexpected critical dialog")))
+
+    tab = GameSessionsTab(facade)
+    qtbot.addWidget(tab)
+
+    _drive_end_session_dialog(qtbot, end_total="0.14", end_redeem="0.14")
+    tab._end_session_by_id(1)
+
+    assert prompts
+    assert "No FIFO basis change" in prompts[0]
+
+    redemption = facade.db.fetch_one(
+        "SELECT amount, more_remaining, notes FROM redemptions ORDER BY id DESC LIMIT 1"
+    )
+    assert Decimal(str(redemption["amount"])) == Decimal("0.00")
+    assert redemption["more_remaining"] == 1
+    assert redemption["notes"].startswith("Balance Closed - Net Loss: $0.00")
+
+    realized_count = facade.db.fetch_one(
+        "SELECT COUNT(*) AS count FROM realized_transactions"
+    )["count"]
+    assert realized_count == 0
+    assert infos and "No cash flow loss recorded" in infos[-1][1]
+
+
+def test_declining_low_balance_prompt_keeps_session_closed_without_position_close(qtbot, facade, monkeypatch):
+    _seed_low_balance_session(facade, remaining_basis=Decimal("20.00"))
+
+    prompts = []
+    infos = []
+
+    monkeypatch.setattr(QMessageBox, "question", lambda _p, _t, message: prompts.append(message) or QMessageBox.No)
+    monkeypatch.setattr(QMessageBox, "information", lambda _p, title, message: infos.append((title, message)) or QMessageBox.Ok)
+    monkeypatch.setattr(QMessageBox, "warning", lambda *args, **kwargs: QMessageBox.Ok)
+    monkeypatch.setattr(QMessageBox, "critical", lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("Unexpected critical dialog")))
+
+    tab = GameSessionsTab(facade)
+    qtbot.addWidget(tab)
+
+    _drive_end_session_dialog(qtbot, end_total="0.40", end_redeem="0.40")
+    tab._end_session_by_id(1)
+
+    assert prompts
+    session = facade.get_game_session(1)
+    assert (session.status or "") == "Closed"
+    redemption_count = facade.db.fetch_one("SELECT COUNT(*) AS count FROM redemptions")["count"]
+    assert redemption_count == 0
+    assert infos and infos[-1][1] == "Session closed successfully!"
+
+
+def test_end_and_start_new_skips_low_balance_prompt(qtbot, facade, monkeypatch):
+    _seed_low_balance_session(facade, remaining_basis=Decimal("20.00"))
+
+    prompts = []
+    monkeypatch.setattr(QMessageBox, "question", lambda _p, _t, message: prompts.append(message) or QMessageBox.Yes)
+    monkeypatch.setattr(QMessageBox, "information", lambda *args, **kwargs: QMessageBox.Ok)
+    monkeypatch.setattr(QMessageBox, "warning", lambda *args, **kwargs: QMessageBox.Ok)
+    monkeypatch.setattr(QMessageBox, "critical", lambda *args, **kwargs: QMessageBox.Ok)
+
+    tab = GameSessionsTab(facade)
+    qtbot.addWidget(tab)
+
+    def cancel_start_dialog():
+        dlg = _find_visible_dialog(StartSessionDialog)
+        if dlg is None:
+            QTimer.singleShot(10, cancel_start_dialog)
+            return
+        qtbot.mouseClick(dlg.cancel_btn, Qt.LeftButton)
+
+    _drive_end_session_dialog(qtbot, end_total="0.40", end_redeem="0.40", start_new=True)
+    QTimer.singleShot(0, cancel_start_dialog)
+    tab._end_session_by_id(1)
+
+    assert prompts == []
+    session = facade.get_game_session(1)
+    assert (session.status or "") == "Closed"

--- a/ui/tabs/game_sessions_tab.py
+++ b/ui/tabs/game_sessions_tab.py
@@ -237,6 +237,86 @@ class GameSessionsTab(QWidget):
             self.main_window.refresh_all_tabs()
         else:
             self.load_data()
+
+    def _format_low_balance_close_prompt(self, prompt_data: dict) -> str:
+        current_sc = Decimal(str(prompt_data["current_sc"]))
+        current_value = Decimal(str(prompt_data["current_value"]))
+        total_basis = Decimal(str(prompt_data["total_basis"]))
+        close_threshold = Decimal(str(prompt_data["close_threshold"]))
+
+        if total_basis <= Decimal("0.00"):
+            impact_lines = (
+                "This will:\n"
+                f"• Mark {current_sc:.2f} SC as dormant until later activity\n"
+                "• Remove the position from Unrealized\n"
+                "• Create a close marker only (No FIFO basis change)\n"
+                "• Record no cash flow loss in Realized\n"
+                "• Reactivate automatically if you play this site again"
+            )
+        else:
+            impact_lines = (
+                "This will:\n"
+                f"• Mark {current_sc:.2f} SC as dormant (no basis attached)\n"
+                "• Remove the position from Unrealized\n"
+                f"• Record a -${total_basis:.2f} cash flow loss in Realized\n"
+                "• Reactivate dormant SC automatically if you play this site again"
+            )
+
+        return (
+            f"Session closed for {prompt_data['site_name']} ({prompt_data['user_name']}).\n\n"
+            f"Ending balance: {current_sc:.2f} SC (${current_value:.2f})\n"
+            f"Remaining basis: ${total_basis:.2f}\n\n"
+            f"This balance is below the ${close_threshold:.2f} equivalent close threshold.\n\n"
+            f"{impact_lines}\n\n"
+            "Close the position now?"
+        )
+
+    def _format_low_balance_close_success(self, prompt_data: dict, result: dict) -> str:
+        total_basis = Decimal(str(prompt_data["total_basis"]))
+        if total_basis <= Decimal("0.00"):
+            return (
+                "Session closed successfully!\n\n"
+                f"Position also closed for {prompt_data['site_name']} ({prompt_data['user_name']})\n"
+                f"Dormant SC balance: {result['current_sc']:.2f} SC (${result['current_value']:.2f})\n\n"
+                "No cash flow loss recorded in Realized\n"
+                f"Dormant ${result['current_value']:.2f} will reactivate on next session"
+            )
+
+        return (
+            "Session closed successfully!\n\n"
+            f"Position also closed for {prompt_data['site_name']} ({prompt_data['user_name']})\n"
+            f"Net cash flow loss: -${result['net_loss']:.2f}\n"
+            f"Dormant SC balance: {result['current_sc']:.2f} SC (${result['current_value']:.2f})\n\n"
+            f"The -${result['net_loss']:.2f} will show in Realized tab\n"
+            f"Dormant ${result['current_value']:.2f} will reactivate on next session"
+        )
+
+    def _maybe_prompt_low_balance_close(self, prompt_data: dict | None) -> bool:
+        if prompt_data is None:
+            return False
+
+        confirm = QMessageBox.question(
+            self,
+            "Close Low Balance Position",
+            self._format_low_balance_close_prompt(prompt_data),
+        )
+        if confirm != QMessageBox.Yes:
+            return False
+
+        result = self.facade.close_unrealized_position(
+            prompt_data["site_id"],
+            prompt_data["user_id"],
+            current_sc=Decimal(str(prompt_data["current_sc"])),
+            current_value=Decimal(str(prompt_data["current_value"])),
+            total_basis=Decimal(str(prompt_data["total_basis"])),
+        )
+        self._refresh_after_mutation()
+        QMessageBox.information(
+            self,
+            "Success",
+            self._format_low_balance_close_success(prompt_data, result),
+        )
+        return True
     
     def _filter_sessions(self):
         """Filter sessions based on search text"""
@@ -857,6 +937,14 @@ class GameSessionsTab(QWidget):
                 QMessageBox.warning(self, "Invalid Entry", error)
                 return
             try:
+                low_balance_prompt_data = None
+                if not then_start_new:
+                    low_balance_prompt_data = self.facade.get_low_balance_close_prompt_data(
+                        site_id=session.site_id,
+                        user_id=session.user_id,
+                        ending_total_sc=data["ending_total_sc"],
+                    )
+
                 start_tz = session.start_entry_time_zone or get_accounting_timezone_name()
                 end_tz = get_entry_timezone_name() or get_accounting_timezone_name()
                 start_utc_date, start_utc_time = local_date_time_to_utc(
@@ -900,7 +988,8 @@ class GameSessionsTab(QWidget):
                 if then_start_new:
                     open_prefilled_next_session_dialog(data["ending_total_sc"], data["ending_redeemable_sc"])
                 else:
-                    QMessageBox.information(self, "Success", "Session closed successfully!")
+                    if not self._maybe_prompt_low_balance_close(low_balance_prompt_data):
+                        QMessageBox.information(self, "Success", "Session closed successfully!")
             except Exception as e:
                 QMessageBox.critical(self, "Error", f"Failed to close session: {e}")
 


### PR DESCRIPTION
## Summary
- add a low-balance follow-up prompt after the normal End Session flow when `ending_total_sc * sc_rate < $1.00`
- reuse the existing Unrealized close behavior so basis-bearing closes still create realized cashflow losses while zero-basis closes only write a dormant close marker
- document the workflow and add regression coverage for prompt acceptance, decline, SC-rate thresholds, zero-basis compatibility, and End & Start New bypass

## Testing
- QT_QPA_PLATFORM=offscreen pytest -q tests/integration/test_issue_193_low_balance_close_prompt.py tests/integration/test_issue_191_zero_basis_unrealized_close.py tests/ui/test_issue_191_unrealized_zero_basis_close_ui.py
- QT_QPA_PLATFORM=offscreen pytest -q

## Manual verification
- Reviewed the headless End Session flow exercised by the new integration test to confirm the prompt appears only on the normal close path and not on End & Start New.

## Pitfalls / Follow-ups
- The prompt only appears after a session is saved. If users want a setup toggle or a different threshold, that should be tracked as a separate issue.
- The current prompt uses the saved ending total and site `sc_rate`; if future workflows allow per-session exchange overrides, this prompt should follow the same source of truth.
