### PR TITLE
Fix same-day close-marker basis window

### DIFF
--- a/docs/PROJECT_SPEC.md
+++ b/docs/PROJECT_SPEC.md
@@ -333,6 +333,10 @@ Derived invariants:
 #### Closeout vs Partial Redemption
 - `more_remaining = 0` (default behavior): treat redemption as a **closeout**; consume *all remaining basis* up to timestamp.
 - `more_remaining = 1`: treat redemption as **partial**; consume only the redemption amount.
+- **Issue #195 (2026-03-26): timezone-safe closeouts**
+  - The "all remaining basis up to timestamp" window must be evaluated in the **entry timezone**, then converted to UTC the same way repositories store purchase/redemption timestamps.
+  - Full-redemption pre-calculation and FIFO allocation must share the **same timestamp windowing rule**. Do not mix a local-time SQL cutoff for `SUM(remaining_amount)` with a UTC-aware FIFO allocator.
+  - Motivation: if a same-day purchase is entered in a non-UTC timezone (for example `America/New_York`), a local-time cutoff can incorrectly exclude that purchase after it has been stored as a later UTC clock time. That creates pathologically wrong full-close rows: understated `cost_basis`, stale `purchases.remaining_amount`, and Unrealized rows that stay orange even though the position was closed.
 
 This distinction is intentionally “business semantic” and must be preserved.
 
@@ -422,6 +426,7 @@ When editing a purchase or creating/editing a game session, the system computes 
   - **Semantics:** `more_remaining=0` means "I'm cashing out everything I want to/can; treat remaining balance as dormant." Position automatically reopens when new activity (purchases, sessions) occurs after closure datetime.
   - **Issue #191 (2026-03-23):** The Unrealized "Close Position" action now supports zero-basis profit-only positions in addition to basis-bearing positions.
     - If `Remaining Basis > $0.00`, close behavior is unchanged: Sezzions creates a `$0.00` close marker as a FULL redemption, consumes remaining basis via FIFO, and records the matching realized cashflow loss.
+    - **Issue #195 guardrail (2026-03-26):** For basis-bearing closes, the close-marker creation path must compute "remaining basis at close time" with the same entry-timezone→UTC conversion used by FIFO allocation itself. Same-day purchases entered before the close in local time must not be dropped merely because their stored UTC clock time is later than the naive local cutoff.
     - If `Remaining Basis = $0.00`, Sezzions creates only an explicit `Balance Closed` marker with `more_remaining=1`, does **not** run FIFO, does **not** create a realized cashflow loss row, and leaves historical purchase rows untouched.
     - In the Redemptions tab, any synthetic `Balance Closed` marker is labeled as `Closed` rather than `Full`/`Partial` or `Loss`, so UI wording reflects close-marker intent instead of underlying redemption flags.
     - In both cases the position is hidden until later activity occurs after the close timestamp, at which point Unrealized reopens the position naturally.

--- a/docs/archive/2026-03-26-pr-195-body.md
+++ b/docs/archive/2026-03-26-pr-195-body.md
@@ -1,0 +1,30 @@
+## Summary
+- fix full closeouts / `Balance Closed` markers to compute "remaining basis at close time" with the same timezone-aware purchase window used by FIFO allocation
+- add regression coverage for same-day local-time full redemptions and same-day Unrealized close markers
+- document the motivation and invariant in the spec and changelog
+
+## Problem
+Issue #195 surfaced a mismatch in the Fortune Coins close flow:
+- purchases are stored in UTC using their entry timezone
+- full-redemption pre-calculation was summing `remaining_amount` against the raw local redemption date/time
+- FIFO allocation itself was using the timezone-aware repository window
+
+That let a same-day local purchase be excluded from the initial full-close basis sum even though it was eligible for the close in local time. The result was understated `cost_basis`, stale `purchases.remaining_amount`, and lingering orange basis in Unrealized after an explicit close.
+
+## What changed
+- added `RedemptionService._get_total_remaining_basis_as_of(...)`
+- routed both full-redemption creation and reprocess-time FIFO calculation through that helper
+- helper reuses `PurchaseRepository.get_available_for_fifo_as_of(...)` so the timestamp rule is shared with FIFO allocation itself
+
+## Tests
+Red → Green:
+- `pytest -q tests/integration/test_issue_195_close_marker_timezone.py tests/unit/test_issue_195_full_redemption_timezone.py`
+
+Full suite:
+- `pytest -q`
+  - one unrelated flaky failure appeared in `tests/ui/test_expenses_autocomplete.py`
+  - reran `pytest -q tests/ui/test_expenses_autocomplete.py` immediately after and it passed
+
+## Pitfalls / Follow-ups
+- Separate from Issue #195, the Stake/Punt near-simultaneous purchase/session anomaly appears to be a session-boundary ordering bug, tracked in Issue #196.
+- If more closeout paths are added later, they should reuse the same timezone-aware helper instead of writing ad-hoc SQL timestamp filters.

--- a/docs/status/CHANGELOG.md
+++ b/docs/status/CHANGELOG.md
@@ -9,6 +9,51 @@ Rules:
 
 ---
 
+## 2026-03-26
+
+```yaml
+id: 2026-03-26-01
+type: fix
+areas: [redemptions, fifo, unrealized, timezone, tests, docs]
+issue: 195
+summary: "Fix same-day full closeouts dropping basis because of local-vs-UTC cutoff drift"
+details: >
+  Fixed a data-correctness bug in basis-bearing `Balance Closed` / full-redemption
+  flows where the pre-FIFO "total remaining basis" query used the raw local
+  redemption date/time while purchases had already been stored in UTC. On
+  same-day entries from non-UTC entry timezones, that mismatch could exclude
+  purchases that really occurred before the close in local time, causing the
+  close marker to record too little `cost_basis`, leave stale
+  `purchases.remaining_amount`, and keep the position highlighted in Unrealized
+  after the user had explicitly closed it.
+
+  Implemented:
+  - centralized full-redemption remaining-basis lookup inside
+    `RedemptionService` so both initial creation and reprocess paths reuse the
+    same timezone-aware purchase windowing as FIFO allocation
+  - added a unit regression proving a same-day full redemption at `09:30` local
+    consumes a `09:00` local purchase but not a later `10:00` local purchase
+  - added an integration regression proving `close_unrealized_position()` now
+    fully consumes same-day local basis and writes the expected realized loss
+
+  Motivation / intent:
+  - explicit close markers must be trustworthy bookkeeping anchors
+  - a full closeout cannot leave stale orange basis merely because local clock
+    time was compared directly against UTC-stored purchase timestamps
+  - pre-calculation and allocation must share one timestamp semantics rule to
+    avoid path-dependent accounting drift
+
+  Validation:
+  - pytest -q tests/integration/test_issue_195_close_marker_timezone.py tests/unit/test_issue_195_full_redemption_timezone.py
+  - pytest -q (full suite hit one unrelated flaky failure in `tests/ui/test_expenses_autocomplete.py`; rerunning that file alone passed)
+files_changed:
+  - services/redemption_service.py
+  - tests/integration/test_issue_195_close_marker_timezone.py
+  - tests/unit/test_issue_195_full_redemption_timezone.py
+  - docs/PROJECT_SPEC.md
+  - docs/status/CHANGELOG.md
+```
+
 ## 2026-03-25
 
 ```yaml

--- a/services/redemption_service.py
+++ b/services/redemption_service.py
@@ -30,6 +30,23 @@ class RedemptionService:
         self.db = db_manager
         self.audit_service: Optional['AuditService'] = None
         self.undo_redo_service: Optional['UndoRedoService'] = None
+
+    def _get_total_remaining_basis_as_of(
+        self,
+        user_id: int,
+        site_id: int,
+        redemption_date: date,
+        redemption_time: Optional[str],
+        redemption_entry_time_zone: Optional[str],
+    ) -> Decimal:
+        purchases = self.fifo_service.purchase_repo.get_available_for_fifo_as_of(
+            user_id,
+            site_id,
+            redemption_date,
+            redemption_time or "23:59:59",
+            entry_time_zone=redemption_entry_time_zone,
+        )
+        return sum((purchase.remaining_amount for purchase in purchases), Decimal("0.00"))
     
     def create_redemption(
         self,
@@ -72,19 +89,13 @@ class RedemptionService:
         if apply_fifo:
             # For Full redemptions (more_remaining=False), consume ALL remaining basis
             if not more_remaining:
-                # Get total remaining basis for this site/user as of redemption timestamp
-                available_purchases = self.redemption_repo.db.fetch_one(
-                    """
-                    SELECT COALESCE(SUM(remaining_amount), 0) as total_remaining
-                    FROM purchases
-                    WHERE user_id = ? AND site_id = ? AND remaining_amount > 0
-                      AND (purchase_date < ? OR 
-                           (purchase_date = ? AND COALESCE(purchase_time,'00:00:00') <= ?))
-                    """,
-                    (user_id, site_id, redemption_date, redemption_date, redemption_time or "23:59:59")
+                total_remaining = self._get_total_remaining_basis_as_of(
+                    user_id,
+                    site_id,
+                    redemption_date,
+                    redemption_time,
+                    redemption.redemption_entry_time_zone,
                 )
-                
-                total_remaining = Decimal(str(available_purchases['total_remaining'])) if available_purchases else Decimal("0.00")
                 
                 # Calculate FIFO for ALL remaining basis (not just redemption amount)
                 cost_basis, taxable_profit, allocations = self.fifo_service.calculate_cost_basis(
@@ -694,23 +705,13 @@ class RedemptionService:
         redemption: Redemption,
     ) -> Tuple[Decimal, Decimal, List[Tuple[int, Decimal]]]:
         if not redemption.more_remaining:
-            available = self.redemption_repo.db.fetch_one(
-                """
-                SELECT COALESCE(SUM(remaining_amount), 0) AS total_remaining
-                FROM purchases
-                WHERE user_id = ? AND site_id = ? AND remaining_amount > 0
-                  AND (purchase_date < ?
-                       OR (purchase_date = ? AND COALESCE(purchase_time,'00:00:00') <= ?))
-                """,
-                (
-                    redemption.user_id,
-                    redemption.site_id,
-                    redemption.redemption_date,
-                    redemption.redemption_date,
-                    redemption.redemption_time or "23:59:59",
-                ),
+            total_remaining = self._get_total_remaining_basis_as_of(
+                redemption.user_id,
+                redemption.site_id,
+                redemption.redemption_date,
+                redemption.redemption_time,
+                redemption.redemption_entry_time_zone,
             )
-            total_remaining = Decimal(str(available['total_remaining'])) if available else Decimal("0.00")
             cost_basis, taxable_profit, allocations = self.fifo_service.calculate_cost_basis(
                 redemption.user_id,
                 redemption.site_id,

--- a/tests/integration/test_issue_195_close_marker_timezone.py
+++ b/tests/integration/test_issue_195_close_marker_timezone.py
@@ -1,0 +1,86 @@
+from datetime import date, datetime
+from decimal import Decimal
+
+import pytest
+
+import app_facade as app_facade_module
+import services.redemption_service as redemption_service_module
+from app_facade import AppFacade
+from models.purchase import Purchase
+
+
+@pytest.fixture
+def facade():
+    app = AppFacade(":memory:")
+    try:
+        yield app
+    finally:
+        app.db.close()
+
+
+class _FixedDateTime(datetime):
+    @classmethod
+    def now(cls, tz=None):
+        return cls.combine(date.today(), datetime.strptime("09:30:00", "%H:%M:%S").time())
+
+
+def _seed_reference_data(facade: AppFacade) -> None:
+    facade.db.execute("INSERT INTO users (id, name) VALUES (1, 'Alice')")
+    facade.db.execute("INSERT INTO sites (id, name, sc_rate) VALUES (1, 'Fortune Coins', 0.01)")
+    facade.db.commit()
+
+
+def test_issue_195_close_marker_consumes_same_day_purchase_basis_with_local_time(facade, monkeypatch):
+    _seed_reference_data(facade)
+
+    facade.purchase_repo.create(
+        Purchase(
+            user_id=1,
+            site_id=1,
+            amount=Decimal("49.99"),
+            purchase_date=date.today(),
+            purchase_time="09:00:00",
+            purchase_entry_time_zone="America/New_York",
+            starting_sc_balance=Decimal("5608.00"),
+            starting_redeemable_balance=Decimal("8.00"),
+            remaining_amount=Decimal("49.99"),
+            status="active",
+            notes="Issue 195 same-day purchase",
+        )
+    )
+
+    monkeypatch.setattr(app_facade_module, "datetime", _FixedDateTime)
+    monkeypatch.setattr(redemption_service_module, "get_entry_timezone_name", lambda: "America/New_York")
+
+    result = facade.close_unrealized_position(
+        site_id=1,
+        user_id=1,
+        current_sc=Decimal("8.00"),
+        current_value=Decimal("0.08"),
+        total_basis=Decimal("49.99"),
+    )
+
+    assert result["net_loss"] == Decimal("49.99")
+
+    purchase = facade.db.fetch_one(
+        "SELECT remaining_amount FROM purchases WHERE id = 1"
+    )
+    assert Decimal(str(purchase["remaining_amount"])) == Decimal("0.00")
+
+    redemption = facade.db.fetch_one(
+        "SELECT more_remaining, notes FROM redemptions ORDER BY id DESC LIMIT 1"
+    )
+    assert redemption["more_remaining"] == 0
+    assert redemption["notes"].startswith("Balance Closed - Net Loss: $49.99")
+
+    realized = facade.db.fetch_one(
+        "SELECT cost_basis, payout, net_pl FROM realized_transactions ORDER BY id DESC LIMIT 1"
+    )
+    assert Decimal(str(realized["cost_basis"])) == Decimal("49.99")
+    assert Decimal(str(realized["payout"])) == Decimal("0.00")
+    assert Decimal(str(realized["net_pl"])) == Decimal("-49.99")
+
+    allocations = facade.db.fetch_all(
+        "SELECT purchase_id, allocated_amount FROM redemption_allocations ORDER BY id"
+    )
+    assert allocations == [{"purchase_id": 1, "allocated_amount": '49.99'}]

--- a/tests/unit/test_issue_195_full_redemption_timezone.py
+++ b/tests/unit/test_issue_195_full_redemption_timezone.py
@@ -1,0 +1,57 @@
+from datetime import date
+from decimal import Decimal
+
+from models.purchase import Purchase
+
+import services.redemption_service as redemption_service_module
+
+
+def test_issue_195_full_redemption_uses_local_timestamp_for_same_day_fifo_window(
+    redemption_service,
+    purchase_repo,
+    sample_user,
+    sample_site,
+    monkeypatch,
+):
+    monkeypatch.setattr(redemption_service_module, "get_entry_timezone_name", lambda: "America/New_York")
+
+    first = purchase_repo.create(
+        Purchase(
+            user_id=sample_user.id,
+            site_id=sample_site.id,
+            amount=Decimal("10.00"),
+            purchase_date=date(2026, 3, 26),
+            purchase_time="09:00:00",
+            purchase_entry_time_zone="America/New_York",
+        )
+    )
+    second = purchase_repo.create(
+        Purchase(
+            user_id=sample_user.id,
+            site_id=sample_site.id,
+            amount=Decimal("20.00"),
+            purchase_date=date(2026, 3, 26),
+            purchase_time="10:00:00",
+            purchase_entry_time_zone="America/New_York",
+        )
+    )
+
+    redemption = redemption_service.create_redemption(
+        user_id=sample_user.id,
+        site_id=sample_site.id,
+        amount=Decimal("0.00"),
+        redemption_date=date(2026, 3, 26),
+        redemption_time="09:30:00",
+        apply_fifo=True,
+        more_remaining=False,
+        processed=True,
+        notes="Balance Closed - Net Loss: $10.00 ($1.00 SC marked dormant)",
+    )
+
+    assert redemption.cost_basis == Decimal("10.00")
+    assert redemption.taxable_profit == Decimal("-10.00")
+
+    updated_first = purchase_repo.get_by_id(first.id)
+    updated_second = purchase_repo.get_by_id(second.id)
+    assert updated_first.remaining_amount == Decimal("0.00")
+    assert updated_second.remaining_amount == Decimal("20.00")


### PR DESCRIPTION
## Summary
- fix full closeouts / `Balance Closed` markers to compute "remaining basis at close time" with the same timezone-aware purchase window used by FIFO allocation
- add regression coverage for same-day local-time full redemptions and same-day Unrealized close markers
- document the motivation and invariant in the spec and changelog

## Problem
Issue #195 surfaced a mismatch in the Fortune Coins close flow:
- purchases are stored in UTC using their entry timezone
- full-redemption pre-calculation was summing `remaining_amount` against the raw local redemption date/time
- FIFO allocation itself was using the timezone-aware repository window

That let a same-day local purchase be excluded from the initial full-close basis sum even though it was eligible for the close in local time. The result was understated `cost_basis`, stale `purchases.remaining_amount`, and lingering orange basis in Unrealized after an explicit close.

## What changed
- added `RedemptionService._get_total_remaining_basis_as_of(...)`
- routed both full-redemption creation and reprocess-time FIFO calculation through that helper
- helper reuses `PurchaseRepository.get_available_for_fifo_as_of(...)` so the timestamp rule is shared with FIFO allocation itself

## Tests
Red → Green:
- `pytest -q tests/integration/test_issue_195_close_marker_timezone.py tests/unit/test_issue_195_full_redemption_timezone.py`

Full suite:
- `pytest -q`
  - one unrelated flaky failure appeared in `tests/ui/test_expenses_autocomplete.py`
  - reran `pytest -q tests/ui/test_expenses_autocomplete.py` immediately after and it passed

## Pitfalls / Follow-ups
- Separate from Issue #195, the Stake/Punt near-simultaneous purchase/session anomaly appears to be a session-boundary ordering bug, tracked in Issue #196.
- If more closeout paths are added later, they should reuse the same timezone-aware helper instead of writing ad-hoc SQL timestamp filters.
