### PR TITLE
Guard session close against inconsistent start balances

### DIFF
--- a/docs/PROJECT_SPEC.md
+++ b/docs/PROJECT_SPEC.md
@@ -368,6 +368,12 @@ When editing a purchase or creating/editing a game session, the system computes 
 - Event 2 (redemption): `$5.00` after purchase and before cutoff (`500 SC` at `sc_rate=0.01`).
 - Expected at cutoff after both events:
   - `expected_total = 1300 - 500 = 800`
+
+**Close-time chronology guard (Issue #196, 2026-03-26):**
+- Legitimate mid-session purchases remain supported and continue to link as `DURING`.
+- When closing a session, if `DURING` purchases exist, the recorded session start balances must still match the expected balance check at the session start timestamp.
+- If the stored `starting_balance` / `starting_redeemable` already include a later `DURING` purchase, close must be blocked with a validation error instead of writing impossible session basis / taxable P&L.
+- User correction path: fix the session start balances or fix the purchase/session timestamps so the chronology is consistent, then close the session again.
   - `expected_redeemable = 1000 - 500 = 500`
 - Regression guard: `tests/integration/test_compute_expected_balances_cancel.py::test_redemption_after_purchase_before_cutoff_is_applied_chronologically`.
 
@@ -1368,6 +1374,7 @@ When derived data (FIFO allocations, cost basis, P/L) becomes corrupted, automat
 - Game session recalculation uses local timestamps converted to UTC when finding containing sessions.
 - Expected balance checks compare UTC instants across entry time zones to avoid out-of-order inclusion.
 - Session close validation blocks saves when end time is before start time after UTC conversion.
+- Session close validation also blocks saves when later `DURING` purchases make the recorded session start balances inconsistent with the session-start balance check.
 - Soft-deleted redemptions are excluded from FIFO rebuilds and realized transaction listings.
 - Expected redeemable balances are derived from sessions/checkpoints (purchases do not increase redeemable).
 - One-time migration converts existing local timestamps to UTC using the currently selected time zone.

--- a/docs/archive/2026-03-26-pr-issue-196.md
+++ b/docs/archive/2026-03-26-pr-issue-196.md
@@ -1,0 +1,34 @@
+## Summary
+- block session close when the recorded session start already includes a later `DURING` purchase
+- preserve valid mid-session purchase flows by only validating this on close when `DURING` purchases exist
+- add regression coverage plus spec/changelog updates for the narrowed Issue #196 behavior
+
+Closes #196.
+
+## Test Matrix
+### Happy path
+- valid mid-session purchase after session start still allows the session to close normally
+
+### Edge cases
+- no `DURING` purchases: close path remains unchanged
+- `DURING` purchases exist but recorded start still matches the expected balance check: close is allowed
+- inconsistent Stake/Punt-style chronology: close is blocked before impossible basis math is written
+
+### Failure injection
+- attempt to close an inconsistent session and assert `ValueError` is raised and the session remains `Active`
+
+### Invariants
+- legitimate `DURING` purchase linking still works
+- blocked close does not partially persist a `Closed` status
+- the guard runs before the close transaction commits
+
+## Validation
+- `pytest -q tests/ui/test_end_session_auto_redeemable.py tests/integration/test_issue_196_session_start_consistency.py tests/integration/test_purchase_active_session_link.py`
+- `pytest -q` → 1092 passed, 1 skipped, 1 unrelated flaky failure in `tests/ui/test_expenses_autocomplete.py::test_expense_dialog_vendor_and_notes_inline_prediction_with_tab_accept`
+- `QT_QPA_PLATFORM=offscreen pytest -q tests/ui/test_expenses_autocomplete.py::test_expense_dialog_vendor_and_notes_inline_prediction_with_tab_accept` → passed on rerun
+
+## Manual Verification
+- compared a valid mid-session purchase chronology against the live-style inconsistent chronology and confirmed only the inconsistent case is blocked on close
+
+## Pitfalls / Follow-ups
+- the guard currently surfaces as a service-layer validation error; a future UX improvement could highlight the mismatched start balances directly in the End Session dialog before the user attempts the save

--- a/docs/status/CHANGELOG.md
+++ b/docs/status/CHANGELOG.md
@@ -12,6 +12,39 @@ Rules:
 ## 2026-03-26
 
 ```yaml
+id: 2026-03-26-02
+type: fix
+areas: [sessions, purchases, accounting, tests, docs]
+issue: 196
+summary: "Block closing sessions whose stored start already includes a later DURING purchase"
+details: >
+  Narrowed and fixed the Stake/Punt chronology bug without breaking legitimate
+  mid-session purchase workflows. Verified that true `DURING` purchases still
+  close correctly, then added a close-time consistency guard in
+  `GameSessionService`: when a session has linked purchases during the session,
+  the recorded starting total/redeemable balances must still match the
+  expected-balance calculation at the session start timestamp. If they do not,
+  close is rejected with a validation error instead of writing impossible
+  `session_basis`, `basis_consumed`, and `net_taxable_pl` values.
+
+  Implemented:
+  - added an integration regression proving a valid mid-session purchase can
+    still close normally
+  - added an integration regression proving close is blocked when the stored
+    session start already includes a later `DURING` purchase
+  - added a narrow service-layer close guard so inconsistent chronology is
+    rejected before the close transaction commits
+
+  Validation:
+  - pytest -q tests/ui/test_end_session_auto_redeemable.py tests/integration/test_issue_196_session_start_consistency.py tests/integration/test_purchase_active_session_link.py
+files_changed:
+  - services/game_session_service.py
+  - tests/integration/test_issue_196_session_start_consistency.py
+  - docs/PROJECT_SPEC.md
+  - docs/status/CHANGELOG.md
+```
+
+```yaml
 id: 2026-03-26-01
 type: fix
 areas: [redemptions, fifo, unrealized, timezone, tests, docs]

--- a/services/game_session_service.py
+++ b/services/game_session_service.py
@@ -47,6 +47,46 @@ class GameSessionService:
         self.redemption_service = redemption_service  # for PENDING_CANCEL processing
         self.audit_service: Optional['AuditService'] = None
         self.undo_redo_service: Optional['UndoRedoService'] = None
+
+    @staticmethod
+    def _rounded_money(value: Decimal) -> Decimal:
+        return Decimal(str(value or 0)).quantize(Decimal("0.01"))
+
+    def _validate_start_balance_consistency_on_close(self, session: GameSession) -> None:
+        """Block closing a session whose recorded start no longer matches chronology.
+
+        This guard is intentionally narrow: it only applies when purchases were
+        linked DURING the session. Valid mid-session purchases are allowed, but
+        a session must not be closed if its starting balances already include a
+        later DURING purchase, because that produces impossible basis math.
+        """
+        purchases_during_sc = self._sum_linked_purchases_during(session.id)
+        if purchases_during_sc <= Decimal("0.00"):
+            return
+
+        expected_total, expected_redeem = self.compute_expected_balances(
+            user_id=session.user_id,
+            site_id=session.site_id,
+            session_date=session.session_date,
+            session_time=session.session_time,
+        )
+        actual_total = Decimal(str(session.starting_balance or 0))
+        actual_redeem = Decimal(str(session.starting_redeemable or 0))
+
+        if (
+            self._rounded_money(actual_total) == self._rounded_money(expected_total)
+            and self._rounded_money(actual_redeem) == self._rounded_money(expected_redeem)
+        ):
+            return
+
+        raise ValueError(
+            "Cannot close session because the recorded starting balances no longer match the balance check at session start. "
+            f"Expected {expected_total:.2f} total / {expected_redeem:.2f} redeemable, but the session has "
+            f"{actual_total:.2f} / {actual_redeem:.2f}. "
+            f"This session also has {purchases_during_sc:.2f} SC linked as purchases during the session. "
+            "This usually means the session was started with balances that already included a later mid-session purchase. "
+            "Adjust the session start balances or timestamps so the chronology is consistent, then try closing again."
+        )
     
     def create_session(
         self,
@@ -224,6 +264,7 @@ class GameSessionService:
         group_id = str(uuid.uuid4())
 
         if just_closed:
+            self._validate_start_balance_consistency_on_close(session)
             with self.session_repo.db.transaction():
                 updated = self.session_repo.update_no_commit(session)
 

--- a/tests/integration/test_issue_196_session_start_consistency.py
+++ b/tests/integration/test_issue_196_session_start_consistency.py
@@ -1,0 +1,115 @@
+from datetime import date
+from decimal import Decimal
+
+import pytest
+
+from app_facade import AppFacade
+
+
+@pytest.fixture
+def facade():
+    app = AppFacade(":memory:")
+    try:
+        yield app
+    finally:
+        app.db.close()
+
+
+def _seed_user_site(facade: AppFacade) -> tuple[int, int]:
+    user = facade.create_user("Issue196 User")
+    site = facade.create_site("Issue196 Site", sc_rate=1.0)
+    return user.id, site.id
+
+
+def test_issue_196_valid_mid_session_purchase_can_still_close(facade):
+    user_id, site_id = _seed_user_site(facade)
+
+    facade.create_purchase(
+        user_id=user_id,
+        site_id=site_id,
+        amount=Decimal("100.00"),
+        purchase_date=date(2026, 3, 26),
+        purchase_time="09:50:00",
+        sc_received=Decimal("100.00"),
+        starting_sc_balance=Decimal("100.00"),
+    )
+    session = facade.create_game_session(
+        user_id=user_id,
+        site_id=site_id,
+        game_id=None,
+        session_date=date(2026, 3, 26),
+        session_time="10:00:00",
+        starting_balance=Decimal("100.00"),
+        ending_balance=Decimal("100.00"),
+        starting_redeemable=Decimal("0.00"),
+        ending_redeemable=Decimal("0.00"),
+    )
+    facade.create_purchase(
+        user_id=user_id,
+        site_id=site_id,
+        amount=Decimal("50.00"),
+        purchase_date=date(2026, 3, 26),
+        purchase_time="11:00:00",
+        sc_received=Decimal("50.00"),
+        starting_sc_balance=Decimal("150.00"),
+    )
+
+    closed = facade.update_game_session(
+        session_id=session.id,
+        ending_balance=Decimal("180.00"),
+        ending_redeemable=Decimal("80.00"),
+        end_date=date(2026, 3, 26),
+        end_time="12:00:00",
+        status="Closed",
+    )
+
+    assert closed.status == "Closed"
+    assert Decimal(str(closed.expected_start_total)) == Decimal("100.00")
+    assert Decimal(str(closed.basis_consumed)) == Decimal("50.000")
+
+
+def test_issue_196_close_blocks_if_start_already_includes_later_during_purchase(facade):
+    user_id, site_id = _seed_user_site(facade)
+
+    facade.create_purchase(
+        user_id=user_id,
+        site_id=site_id,
+        amount=Decimal("2000.00"),
+        purchase_date=date(2026, 3, 26),
+        purchase_time="13:51:51",
+        sc_received=Decimal("2005.00"),
+        starting_sc_balance=Decimal("2009.98"),
+    )
+    session = facade.create_game_session(
+        user_id=user_id,
+        site_id=site_id,
+        game_id=None,
+        session_date=date(2026, 3, 26),
+        session_time="13:52:00",
+        starting_balance=Decimal("3012.48"),
+        ending_balance=Decimal("3012.48"),
+        starting_redeemable=Decimal("4.98"),
+        ending_redeemable=Decimal("4.98"),
+    )
+    facade.create_purchase(
+        user_id=user_id,
+        site_id=site_id,
+        amount=Decimal("1000.00"),
+        purchase_date=date(2026, 3, 26),
+        purchase_time="13:52:05",
+        sc_received=Decimal("1002.50"),
+        starting_sc_balance=Decimal("3012.48"),
+    )
+
+    with pytest.raises(ValueError, match="starting balances no longer match the balance check"):
+        facade.update_game_session(
+            session_id=session.id,
+            ending_balance=Decimal("3072.48"),
+            ending_redeemable=Decimal("24.98"),
+            end_date=date(2026, 3, 26),
+            end_time="14:22:25",
+            status="Closed",
+        )
+
+    still_active = facade.get_game_session(session.id)
+    assert still_active.status == "Active"


### PR DESCRIPTION
## Summary
- block session close when the recorded session start already includes a later `DURING` purchase
- preserve valid mid-session purchase flows by only validating this on close when `DURING` purchases exist
- add regression coverage plus spec/changelog updates for the narrowed Issue #196 behavior

Closes #196.

## Test Matrix
### Happy path
- valid mid-session purchase after session start still allows the session to close normally

### Edge cases
- no `DURING` purchases: close path remains unchanged
- `DURING` purchases exist but recorded start still matches the expected balance check: close is allowed
- inconsistent Stake/Punt-style chronology: close is blocked before impossible basis math is written

### Failure injection
- attempt to close an inconsistent session and assert `ValueError` is raised and the session remains `Active`

### Invariants
- legitimate `DURING` purchase linking still works
- blocked close does not partially persist a `Closed` status
- the guard runs before the close transaction commits

## Validation
- `pytest -q tests/ui/test_end_session_auto_redeemable.py tests/integration/test_issue_196_session_start_consistency.py tests/integration/test_purchase_active_session_link.py`
- `pytest -q` → 1092 passed, 1 skipped, 1 unrelated flaky failure in `tests/ui/test_expenses_autocomplete.py::test_expense_dialog_vendor_and_notes_inline_prediction_with_tab_accept`
- `QT_QPA_PLATFORM=offscreen pytest -q tests/ui/test_expenses_autocomplete.py::test_expense_dialog_vendor_and_notes_inline_prediction_with_tab_accept` → passed on rerun

## Manual Verification
- compared a valid mid-session purchase chronology against the live-style inconsistent chronology and confirmed only the inconsistent case is blocked on close

## Pitfalls / Follow-ups
- the guard currently surfaces as a service-layer validation error; a future UX improvement could highlight the mismatched start balances directly in the End Session dialog before the user attempts the save
