### PR TITLE
Add protected Supabase API session handshake

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,11 @@ The current desktop product still runs on local SQLite. The shared desktop + web
 - API layer: FastAPI scaffold under `api/`
 - first migration source: `sezzions.db`
 
+Current authenticated backend slice:
+- `GET /v1/session` is the first protected endpoint
+- it expects a Supabase bearer access token from the web client
+- the API verifies the token against Supabase JWKS before returning session identity details
+
 Important boundary:
 - the current SQLite `users` table is a business-domain entity, not the hosted auth/account model
 - hosted identity and ownership must live separately from the existing tracked-player records

--- a/api/app.py
+++ b/api/app.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI
 
+from api.auth import AuthenticatedSession, get_authenticated_session
 from api.config import load_hosted_backend_config
 
 
@@ -17,11 +18,24 @@ def healthz() -> dict[str, str]:
 
 @app.get("/v1/foundation")
 def foundation() -> dict[str, object]:
-    config = load_hosted_backend_config(required=False)
+    config = load_hosted_backend_config(required=False, require_db_password=False)
     return {
         "auth_provider": "supabase-google",
         "configured": config is not None,
         "supabase_url": config.supabase_url if config else None,
         "google_auth_enabled": config.google_auth_enabled if config else False,
         "project_ref": config.project_ref if config else None,
+    }
+
+
+@app.get("/v1/session")
+def session_summary(
+    session: AuthenticatedSession = Depends(get_authenticated_session),
+) -> dict[str, object]:
+    return {
+        "authenticated": True,
+        "user_id": session.user_id,
+        "email": session.email,
+        "audience": session.audience,
+        "role": session.role,
     }

--- a/api/auth.py
+++ b/api/auth.py
@@ -1,0 +1,76 @@
+"""Supabase access-token verification for protected API endpoints."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Any
+
+import jwt
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+from api.config import HostedBackendConfig, HostedConfigurationError, load_hosted_backend_config
+
+
+bearer_scheme = HTTPBearer(auto_error=False)
+
+
+@dataclass(frozen=True)
+class AuthenticatedSession:
+    user_id: str
+    email: str | None
+    audience: str | list[str] | None
+    role: str | None
+
+
+@lru_cache(maxsize=8)
+def _jwks_client(jwks_url: str) -> jwt.PyJWKClient:
+    return jwt.PyJWKClient(jwks_url)
+
+
+def decode_supabase_access_token(token: str, config: HostedBackendConfig) -> dict[str, Any]:
+    signing_key = _jwks_client(config.supabase_jwks_url).get_signing_key_from_jwt(token)
+    return jwt.decode(
+        token,
+        signing_key.key,
+        algorithms=["RS256"],
+        audience=config.jwt_audience,
+        issuer=config.supabase_issuer,
+    )
+
+
+def _unauthorized(detail: str) -> HTTPException:
+    return HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail=detail,
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+
+
+def get_authenticated_session(
+    credentials: HTTPAuthorizationCredentials | None = Depends(bearer_scheme),
+) -> AuthenticatedSession:
+    if not credentials or credentials.scheme.lower() != "bearer":
+        raise _unauthorized("Bearer token is required.")
+
+    try:
+        config = load_hosted_backend_config(require_db_password=False)
+    except HostedConfigurationError as exc:
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(exc)) from exc
+
+    try:
+        claims = decode_supabase_access_token(credentials.credentials, config)
+    except jwt.InvalidTokenError as exc:
+        raise _unauthorized("Invalid bearer token.") from exc
+
+    user_id = str(claims.get("sub") or "")
+    if not user_id:
+        raise _unauthorized("Bearer token is missing subject.")
+
+    return AuthenticatedSession(
+        user_id=user_id,
+        email=claims.get("email"),
+        audience=claims.get("aud"),
+        role=claims.get("role"),
+    )

--- a/api/config.py
+++ b/api/config.py
@@ -17,7 +17,7 @@ class HostedBackendConfig:
     """Resolved hosted backend configuration derived from Supabase inputs."""
 
     supabase_url: str
-    supabase_db_password: str
+    supabase_db_password: Optional[str] = None
     db_user: str = "postgres"
     db_name: str = "postgres"
     db_port: int = 5432
@@ -30,11 +30,6 @@ class HostedBackendConfig:
             raise HostedConfigurationError(
                 "SUPABASE_URL must be a valid https URL."
             )
-        if not self.supabase_db_password:
-            raise HostedConfigurationError(
-                "SUPABASE_DB_PASSWORD is required for hosted database access."
-            )
-
     @property
     def project_ref(self) -> str:
         hostname = urlparse(self.supabase_url).hostname or ""
@@ -50,7 +45,19 @@ class HostedBackendConfig:
         return f"db.{self.project_ref}.supabase.co"
 
     @property
+    def supabase_issuer(self) -> str:
+        return f"{self.supabase_url.rstrip('/')}/auth/v1"
+
+    @property
+    def supabase_jwks_url(self) -> str:
+        return f"{self.supabase_issuer}/.well-known/jwks.json"
+
+    @property
     def sqlalchemy_url(self) -> str:
+        if not self.supabase_db_password:
+            raise HostedConfigurationError(
+                "SUPABASE_DB_PASSWORD is required for hosted database access."
+            )
         encoded_password = quote_plus(self.supabase_db_password)
         return (
             "postgresql+psycopg2://"
@@ -62,6 +69,7 @@ def load_hosted_backend_config(
     env: Optional[Mapping[str, str]] = None,
     *,
     required: bool = True,
+    require_db_password: bool = True,
 ) -> Optional[HostedBackendConfig]:
     """Build hosted configuration from environment variables.
 
@@ -84,7 +92,7 @@ def load_hosted_backend_config(
     if not supabase_url and not db_password and not required:
         return None
 
-    if not supabase_url or not db_password:
+    if not supabase_url or (require_db_password and not db_password):
         if required:
             raise HostedConfigurationError(
                 "SUPABASE_URL and SUPABASE_DB_PASSWORD must both be set."
@@ -109,7 +117,7 @@ def load_hosted_backend_config(
 
     return HostedBackendConfig(
         supabase_url=supabase_url,
-        supabase_db_password=db_password,
+        supabase_db_password=db_password or None,
         db_user=db_user,
         db_name=db_name,
         db_port=db_port,

--- a/docs/PROJECT_SPEC.md
+++ b/docs/PROJECT_SPEC.md
@@ -133,6 +133,9 @@ Hosted backend foundation (Issue #203):
 - `tools/inspect_sqlite_for_hosted_import.py` is the read-only planning tool for inventorying a local SQLite file before hosted import work.
 - The web frontend consumes Supabase configuration through `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` and may optionally target the hosted API through `VITE_API_BASE_URL`.
 - Initial web auth flow is Google sign-in via Supabase; the first authenticated UI state must support sign-in, sign-out, and current session display.
+- The first protected hosted API endpoint is `GET /v1/session`.
+- `GET /v1/session` must require a bearer token, verify the Supabase access token against Supabase JWKS, and return the authenticated session identity summary.
+- After successful Google sign-in, the web shell should call `GET /v1/session` with the Supabase access token and reflect the protected API handshake status in the UI.
 
 ### Application Update Infrastructure (Issue #171, MVP)
 

--- a/docs/status/CHANGELOG.md
+++ b/docs/status/CHANGELOG.md
@@ -12,6 +12,43 @@ Rules:
 ## 2026-03-28
 
 ```yaml
+id: 2026-03-28-06
+type: feat
+areas: [api, auth, frontend, docs, tests]
+issue: 203
+summary: "Add the first protected Supabase-to-Render API handshake"
+details: >
+  Extended the hosted foundation with the first authenticated API slice.
+  The FastAPI service now exposes `GET /v1/session`, which requires a bearer
+  token and verifies the Supabase access token against Supabase JWKS before
+  returning the authenticated identity summary. The web shell now uses the
+  signed-in Supabase session token to call that protected endpoint and displays
+  the Render handshake status in the UI.
+
+  Implemented:
+  - JWT/JWKS verification for Supabase access tokens in the API layer
+  - protected `GET /v1/session` endpoint
+  - web-side protected API call after Google sign-in
+  - focused tests for the protected endpoint and frontend handshake behavior
+
+  Validation:
+  - PYTHONPATH=$PWD /usr/local/bin/python3 -m pytest -q tests/api/test_app.py tests/services/hosted/test_config.py
+  - cd web && npm test
+files_changed:
+  - requirements.txt
+  - api/auth.py
+  - api/app.py
+  - api/config.py
+  - tests/api/test_app.py
+  - tests/services/hosted/test_config.py
+  - web/src/App.jsx
+  - web/src/App.test.jsx
+  - README.md
+  - docs/PROJECT_SPEC.md
+  - docs/status/CHANGELOG.md
+```
+
+```yaml
 id: 2026-03-28-04
 type: feat
 areas: [api, auth, database, migration, docs, tests, tools]

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ pydantic>=2.5.0
 fastapi>=0.115.0
 uvicorn>=0.30.0
 httpx>=0.27.0
+PyJWT[crypto]>=2.10.0
 
 # Testing
 pytest>=7.4.3

--- a/tests/api/test_app.py
+++ b/tests/api/test_app.py
@@ -1,5 +1,6 @@
 from fastapi.testclient import TestClient
 
+from api.auth import AuthenticatedSession, get_authenticated_session
 from api.app import app
 
 
@@ -19,3 +20,32 @@ def test_foundation_reports_unconfigured_without_env() -> None:
     assert response.status_code == 200
     assert response.json()["configured"] is False
     assert response.json()["auth_provider"] == "supabase-google"
+
+
+def test_session_endpoint_requires_bearer_auth() -> None:
+    response = client.get("/v1/session")
+
+    assert response.status_code == 401
+
+
+def test_session_endpoint_returns_authenticated_session() -> None:
+    app.dependency_overrides[get_authenticated_session] = lambda: AuthenticatedSession(
+        user_id="user-123",
+        email="owner@sezzions.com",
+        audience="authenticated",
+        role="authenticated",
+    )
+
+    try:
+        response = client.get("/v1/session")
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "authenticated": True,
+        "user_id": "user-123",
+        "email": "owner@sezzions.com",
+        "audience": "authenticated",
+        "role": "authenticated",
+    }

--- a/tests/services/hosted/test_config.py
+++ b/tests/services/hosted/test_config.py
@@ -27,3 +27,15 @@ def test_load_hosted_backend_config_can_skip_when_not_required() -> None:
 def test_load_hosted_backend_config_requires_url_and_password() -> None:
     with pytest.raises(HostedConfigurationError):
         load_hosted_backend_config({"SUPABASE_URL": "https://nztovvajnrokzsetliwz.supabase.co"})
+
+
+def test_load_hosted_backend_config_can_load_auth_only_settings() -> None:
+    config = load_hosted_backend_config(
+        {"SUPABASE_URL": "https://nztovvajnrokzsetliwz.supabase.co"},
+        require_db_password=False,
+    )
+
+    assert config is not None
+    assert config.supabase_db_password is None
+    assert config.supabase_issuer == "https://nztovvajnrokzsetliwz.supabase.co/auth/v1"
+    assert config.supabase_jwks_url.endswith("/.well-known/jwks.json")

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -39,13 +39,49 @@ const launchPlan = [
   "Port feature areas incrementally without rewriting accounting rules twice."
 ];
 
-const apiBaseUrl = import.meta.env.VITE_API_BASE_URL?.trim() || null;
-
 export default function App() {
   const [sessionEmail, setSessionEmail] = useState(null);
   const [authMessage, setAuthMessage] = useState(
     supabaseConfigured ? "Sign in with Google to activate the hosted web shell." : supabaseConfigError
   );
+  const [apiStatus, setApiStatus] = useState(
+    "Protected API handshake will run after Google sign-in."
+  );
+  const apiBaseUrl = import.meta.env.VITE_API_BASE_URL?.trim() || null;
+
+  async function syncProtectedApi(nextSession) {
+    if (!nextSession?.access_token) {
+      setApiStatus("Protected API handshake will run after Google sign-in.");
+      return;
+    }
+
+    if (!apiBaseUrl) {
+      setApiStatus("Set VITE_API_BASE_URL to enable the protected API handshake.");
+      return;
+    }
+
+    setApiStatus("Calling the protected Render API with the Supabase session token...");
+
+    try {
+      const response = await fetch(`${apiBaseUrl}/v1/session`, {
+        headers: {
+          Authorization: `Bearer ${nextSession.access_token}`
+        }
+      });
+
+      if (!response.ok) {
+        setApiStatus(`Protected API handshake failed (${response.status}).`);
+        return;
+      }
+
+      const data = await response.json();
+      setApiStatus(
+        `Protected API handshake ready for ${data.email || data.user_id}.`
+      );
+    } catch (error) {
+      setApiStatus(error instanceof Error ? error.message : "Protected API handshake failed.");
+    }
+  }
 
   useEffect(() => {
     if (!supabase) {
@@ -71,6 +107,7 @@ export default function App() {
           ? "Google session active. The web app is ready for the first authenticated API call."
           : "Sign in with Google to activate the hosted web shell."
       );
+      void syncProtectedApi(data.session || null);
     });
 
     const {
@@ -83,6 +120,7 @@ export default function App() {
           ? "Google session active. The web app is ready for the first authenticated API call."
           : "Sign in with Google to activate the hosted web shell."
       );
+      void syncProtectedApi(nextSession || null);
     });
 
     return () => {
@@ -122,6 +160,7 @@ export default function App() {
 
     setSessionEmail(null);
     setAuthMessage("Signed out. Sign in with Google to reactivate the hosted web shell.");
+    setApiStatus("Protected API handshake will run after Google sign-in.");
   }
 
   return (
@@ -162,6 +201,10 @@ export default function App() {
             <div>
               <dt>API host</dt>
               <dd>{apiBaseUrl || "Set VITE_API_BASE_URL"}</dd>
+            </div>
+            <div>
+              <dt>API handshake</dt>
+              <dd>{apiStatus}</dd>
             </div>
           </dl>
           {sessionEmail ? (

--- a/web/src/App.test.jsx
+++ b/web/src/App.test.jsx
@@ -26,6 +26,7 @@ vi.mock("./lib/supabaseClient", () => ({
 
 describe("App", () => {
   beforeEach(() => {
+    vi.stubEnv("VITE_API_BASE_URL", "https://api.sezzions.test");
     authMocks.getSession.mockReset();
     authMocks.onAuthStateChange.mockReset();
     authMocks.signInWithOAuth.mockReset();
@@ -42,6 +43,16 @@ describe("App", () => {
     });
     authMocks.signInWithOAuth.mockResolvedValue({ error: null });
     authMocks.signOut.mockResolvedValue({ error: null });
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        authenticated: true,
+        user_id: "user-123",
+        email: "owner@sezzions.com",
+        audience: "authenticated",
+        role: "authenticated"
+      })
+    });
   });
 
   it("shows the Sezzions web heading", async () => {
@@ -77,6 +88,7 @@ describe("App", () => {
     authMocks.getSession.mockResolvedValue({
       data: {
         session: {
+          access_token: "access-token-123",
           user: {
             email: "owner@sezzions.com"
           }
@@ -91,5 +103,15 @@ describe("App", () => {
       expect(screen.getByText("owner@sezzions.com")).toBeInTheDocument();
     });
     expect(screen.getByRole("button", { name: /sign out/i })).toBeInTheDocument();
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith("https://api.sezzions.test/v1/session", {
+        headers: {
+          Authorization: "Bearer access-token-123"
+        }
+      });
+    });
+    expect(
+      screen.getByText(/protected api handshake ready for owner@sezzions.com/i)
+    ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- add verified Supabase JWT handling for the hosted FastAPI layer
- expose the first protected Render endpoint at `/v1/session`
- have the signed-in web shell call that endpoint with the Supabase access token
- document the protected handshake contract in the spec and changelog

## Validation
- PYTHONPATH=$PWD /usr/local/bin/python3 -m pytest -q tests/api/test_app.py tests/services/hosted/test_config.py
- cd web && npm test
- cd web && npm run build

## Notes
- branch CI may still be blocked by the unrelated pre-existing updater UI failure in `tests/ui/test_update_ui.py`
- the deployed frontend already has Google sign-in working on `develop`; this PR adds the next protected API slice after sign-in