### PR TITLE
Allow staged API auth requests via CORS

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Current authenticated backend slice:
 - `GET /v1/session` is the first protected endpoint
 - it expects a Supabase bearer access token from the web client
 - the API verifies the token against Supabase JWKS before returning session identity details
+- the API must allow browser CORS requests from the staged web host and local Vite host
 
 Important boundary:
 - the current SQLite `users` table is a business-domain entity, not the hosted auth/account model
@@ -177,6 +178,9 @@ Frontend environment variables for hosted sign-in:
 - `VITE_SUPABASE_URL`
 - `VITE_SUPABASE_ANON_KEY`
 - `VITE_API_BASE_URL`
+
+Backend environment variables for browser access control:
+- `CORS_ALLOWED_ORIGINS` as a comma-separated list, if you need to override the defaults
 
 Example values are provided in `web/.env.example`.
 

--- a/api/app.py
+++ b/api/app.py
@@ -3,12 +3,25 @@
 from __future__ import annotations
 
 from fastapi import Depends, FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 
 from api.auth import AuthenticatedSession, get_authenticated_session
 from api.config import load_hosted_backend_config
 
 
 app = FastAPI(title="Sezzions Hosted API", version="0.1.0")
+
+cors_config = load_hosted_backend_config(required=False, require_db_password=False)
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=list(cors_config.cors_allowed_origins) if cors_config else [
+        "https://dev.sezzions.com",
+        "http://localhost:5173",
+    ],
+    allow_credentials=True,
+    allow_methods=["GET", "OPTIONS"],
+    allow_headers=["*"],
+)
 
 
 @app.get("/healthz")

--- a/api/config.py
+++ b/api/config.py
@@ -23,6 +23,10 @@ class HostedBackendConfig:
     db_port: int = 5432
     jwt_audience: str = "authenticated"
     google_auth_enabled: bool = False
+    cors_allowed_origins: tuple[str, ...] = (
+        "https://dev.sezzions.com",
+        "http://localhost:5173",
+    )
 
     def __post_init__(self) -> None:
         parsed = urlparse(self.supabase_url)
@@ -109,6 +113,14 @@ def load_hosted_backend_config(
         "yes",
         "on",
     }
+    cors_allowed_origins = tuple(
+        origin.strip()
+        for origin in env_map.get(
+            "CORS_ALLOWED_ORIGINS",
+            "https://dev.sezzions.com,http://localhost:5173",
+        ).split(",")
+        if origin.strip()
+    )
 
     try:
         db_port = int(db_port_raw)
@@ -123,4 +135,5 @@ def load_hosted_backend_config(
         db_port=db_port,
         jwt_audience=jwt_audience,
         google_auth_enabled=google_auth_enabled,
+        cors_allowed_origins=cors_allowed_origins,
     )

--- a/docs/PROJECT_SPEC.md
+++ b/docs/PROJECT_SPEC.md
@@ -136,6 +136,7 @@ Hosted backend foundation (Issue #203):
 - The first protected hosted API endpoint is `GET /v1/session`.
 - `GET /v1/session` must require a bearer token, verify the Supabase access token against Supabase JWKS, and return the authenticated session identity summary.
 - After successful Google sign-in, the web shell should call `GET /v1/session` with the Supabase access token and reflect the protected API handshake status in the UI.
+- The hosted API must permit CORS preflight and authenticated browser requests from `https://dev.sezzions.com` and `http://localhost:5173` by default, with environment override support for additional origins.
 
 ### Application Update Infrastructure (Issue #171, MVP)
 

--- a/docs/status/CHANGELOG.md
+++ b/docs/status/CHANGELOG.md
@@ -12,6 +12,37 @@ Rules:
 ## 2026-03-28
 
 ```yaml
+id: 2026-03-28-07
+type: fix
+areas: [api, auth, deployment, docs, tests]
+issue: 203
+summary: "Allow staged web-to-Render auth requests through API CORS handling"
+details: >
+  Fixed the immediate production blocker for the protected API handshake after
+  Google sign-in. The browser app on `dev.sezzions.com` was failing with
+  "failed to fetch" because the Render-hosted FastAPI service rejected CORS
+  preflight requests. Added CORS middleware to the hosted API, introduced
+  configurable allowed origins, and added focused tests to verify that the
+  staged web origin can preflight `GET /v1/session` successfully.
+
+  Implemented:
+  - FastAPI CORS middleware for staged web + local Vite origins
+  - configurable `CORS_ALLOWED_ORIGINS` parsing in hosted config
+  - API preflight coverage for the protected session endpoint
+
+  Validation:
+  - PYTHONPATH=$PWD /usr/local/bin/python3 -m pytest -q tests/api/test_app.py tests/services/hosted/test_config.py
+files_changed:
+  - api/app.py
+  - api/config.py
+  - tests/api/test_app.py
+  - tests/services/hosted/test_config.py
+  - README.md
+  - docs/PROJECT_SPEC.md
+  - docs/status/CHANGELOG.md
+```
+
+```yaml
 id: 2026-03-28-06
 type: feat
 areas: [api, auth, frontend, docs, tests]

--- a/tests/api/test_app.py
+++ b/tests/api/test_app.py
@@ -49,3 +49,17 @@ def test_session_endpoint_returns_authenticated_session() -> None:
         "audience": "authenticated",
         "role": "authenticated",
     }
+
+
+def test_session_endpoint_allows_cors_preflight_from_dev_site() -> None:
+    response = client.options(
+        "/v1/session",
+        headers={
+            "Origin": "https://dev.sezzions.com",
+            "Access-Control-Request-Method": "GET",
+            "Access-Control-Request-Headers": "authorization",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.headers["access-control-allow-origin"] == "https://dev.sezzions.com"

--- a/tests/services/hosted/test_config.py
+++ b/tests/services/hosted/test_config.py
@@ -39,3 +39,24 @@ def test_load_hosted_backend_config_can_load_auth_only_settings() -> None:
     assert config.supabase_db_password is None
     assert config.supabase_issuer == "https://nztovvajnrokzsetliwz.supabase.co/auth/v1"
     assert config.supabase_jwks_url.endswith("/.well-known/jwks.json")
+    assert config.cors_allowed_origins == (
+        "https://dev.sezzions.com",
+        "http://localhost:5173",
+    )
+
+
+def test_load_hosted_backend_config_parses_cors_allowed_origins() -> None:
+    config = load_hosted_backend_config(
+        {
+            "SUPABASE_URL": "https://nztovvajnrokzsetliwz.supabase.co",
+            "CORS_ALLOWED_ORIGINS": "https://dev.sezzions.com, https://sezzions.com ,http://localhost:5173",
+        },
+        require_db_password=False,
+    )
+
+    assert config is not None
+    assert config.cors_allowed_origins == (
+        "https://dev.sezzions.com",
+        "https://sezzions.com",
+        "http://localhost:5173",
+    )


### PR DESCRIPTION
## Summary
- add API CORS handling for the staged web origin and local Vite origin
- parse configurable `CORS_ALLOWED_ORIGINS` in hosted config
- add preflight coverage for the protected `/v1/session` endpoint

## Validation
- PYTHONPATH=$PWD /usr/local/bin/python3 -m pytest -q tests/api/test_app.py tests/services/hosted/test_config.py
- simulated preflight from https://dev.sezzions.com now returns 200 with access-control-allow-origin

## Notes
- this fixes the browser-level `failed to fetch` error on the Google sign-in handshake path
- branch CI may still be blocked by the unrelated pre-existing updater UI failure in `tests/ui/test_update_ui.py`