### PR TITLE
Fallback live Supabase session validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Current authenticated backend slice:
 - it expects a Supabase bearer access token from the web client
 - the API verifies the token against Supabase JWKS before returning session identity details
 - the API must allow browser CORS requests from the staged web host and local Vite host
+- if direct JWT verification fails for a real Supabase session token, the API falls back to Supabase's `/auth/v1/user` validation endpoint before rejecting the request
 
 Important boundary:
 - the current SQLite `users` table is a business-domain entity, not the hosted auth/account model

--- a/api/auth.py
+++ b/api/auth.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from functools import lru_cache
 from typing import Any
 
+import httpx
 import jwt
 from fastapi import Depends, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
@@ -40,6 +41,18 @@ def decode_supabase_access_token(token: str, config: HostedBackendConfig) -> dic
     )
 
 
+def fetch_supabase_user(token: str, config: HostedBackendConfig) -> dict[str, Any]:
+    response = httpx.get(
+        f"{config.supabase_url.rstrip('/')}/auth/v1/user",
+        headers={
+            "Authorization": f"Bearer {token}",
+        },
+        timeout=10.0,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
 def _unauthorized(detail: str) -> HTTPException:
     return HTTPException(
         status_code=status.HTTP_401_UNAUTHORIZED,
@@ -61,10 +74,13 @@ def get_authenticated_session(
 
     try:
         claims = decode_supabase_access_token(credentials.credentials, config)
-    except jwt.InvalidTokenError as exc:
-        raise _unauthorized("Invalid bearer token.") from exc
+    except jwt.InvalidTokenError:
+        try:
+            claims = fetch_supabase_user(credentials.credentials, config)
+        except Exception as exc:
+            raise _unauthorized("Invalid bearer token.") from exc
 
-    user_id = str(claims.get("sub") or "")
+    user_id = str(claims.get("sub") or claims.get("id") or "")
     if not user_id:
         raise _unauthorized("Bearer token is missing subject.")
 

--- a/docs/PROJECT_SPEC.md
+++ b/docs/PROJECT_SPEC.md
@@ -137,6 +137,7 @@ Hosted backend foundation (Issue #203):
 - `GET /v1/session` must require a bearer token, verify the Supabase access token against Supabase JWKS, and return the authenticated session identity summary.
 - After successful Google sign-in, the web shell should call `GET /v1/session` with the Supabase access token and reflect the protected API handshake status in the UI.
 - The hosted API must permit CORS preflight and authenticated browser requests from `https://dev.sezzions.com` and `http://localhost:5173` by default, with environment override support for additional origins.
+- If direct local JWT decoding is not compatible with the live Supabase token format, the API may validate the bearer token through Supabase's `/auth/v1/user` endpoint before returning `401`.
 
 ### Application Update Infrastructure (Issue #171, MVP)
 

--- a/docs/status/CHANGELOG.md
+++ b/docs/status/CHANGELOG.md
@@ -12,6 +12,35 @@ Rules:
 ## 2026-03-28
 
 ```yaml
+id: 2026-03-28-08
+type: fix
+areas: [api, auth, docs, tests]
+issue: 203
+summary: "Fallback to Supabase user validation when direct JWT decoding rejects a live session"
+details: >
+  Fixed the staged Google sign-in handshake returning `401` after the CORS
+  issue was resolved. The browser was now reaching the Render API, but the API
+  was rejecting the live Supabase access token during direct JWT/JWKS decoding.
+  Added a fallback path that validates the bearer token through Supabase's
+  `/auth/v1/user` endpoint before rejecting the request. This keeps the direct
+  JWT path in place while making the live hosted session handshake compatible
+  with the current Supabase token behavior.
+
+  Implemented:
+  - Supabase `/auth/v1/user` fallback in the hosted auth layer
+  - focused auth tests covering successful fallback and unauthorized failure
+
+  Validation:
+  - PYTHONPATH=$PWD /usr/local/bin/python3 -m pytest -q tests/api/test_auth.py tests/api/test_app.py tests/services/hosted/test_config.py
+files_changed:
+  - api/auth.py
+  - tests/api/test_auth.py
+  - README.md
+  - docs/PROJECT_SPEC.md
+  - docs/status/CHANGELOG.md
+```
+
+```yaml
 id: 2026-03-28-07
 type: fix
 areas: [api, auth, deployment, docs, tests]

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -1,0 +1,63 @@
+import jwt
+import pytest
+
+from api.auth import get_authenticated_session
+
+
+def test_get_authenticated_session_falls_back_to_supabase_user_lookup(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "api.auth.load_hosted_backend_config",
+        lambda require_db_password=False: object(),
+    )
+    monkeypatch.setattr(
+        "api.auth.decode_supabase_access_token",
+        lambda token, config: (_ for _ in ()).throw(jwt.InvalidTokenError("bad token")),
+    )
+    monkeypatch.setattr(
+        "api.auth.fetch_supabase_user",
+        lambda token, config: {
+            "id": "user-123",
+            "email": "owner@sezzions.com",
+            "aud": "authenticated",
+            "role": "authenticated",
+        },
+    )
+
+    session = get_authenticated_session(
+        credentials=type(
+            "Creds",
+            (),
+            {"scheme": "Bearer", "credentials": "token-123"},
+        )()
+    )
+
+    assert session.user_id == "user-123"
+    assert session.email == "owner@sezzions.com"
+    assert session.audience == "authenticated"
+    assert session.role == "authenticated"
+
+
+def test_get_authenticated_session_raises_unauthorized_when_fallback_fails(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "api.auth.load_hosted_backend_config",
+        lambda require_db_password=False: object(),
+    )
+    monkeypatch.setattr(
+        "api.auth.decode_supabase_access_token",
+        lambda token, config: (_ for _ in ()).throw(jwt.InvalidTokenError("bad token")),
+    )
+    monkeypatch.setattr(
+        "api.auth.fetch_supabase_user",
+        lambda token, config: (_ for _ in ()).throw(RuntimeError("no user")),
+    )
+
+    with pytest.raises(Exception) as exc_info:
+        get_authenticated_session(
+            credentials=type(
+                "Creds",
+                (),
+                {"scheme": "Bearer", "credentials": "token-123"},
+            )()
+        )
+
+    assert getattr(exc_info.value, "status_code", None) == 401


### PR DESCRIPTION
## Summary
- fall back to Supabase /auth/v1/user when direct JWT decoding rejects a live session token
- keep the protected /v1/session handshake working for staged Google sign-in
- add focused auth tests and record the behavior in the spec/changelog

## Validation
- PYTHONPATH=/Users/elliot/Documents/My Documents/Business/Carolina Edge Gaming/Session App/Claude Version/V28 - multi session testing 2 /usr/local/bin/python3 -m pytest -q tests/api/test_auth.py tests/api/test_app.py tests/services/hosted/test_config.py

## Issue
- Closes #203