### PR TITLE
Forward Supabase public key on protected auth handshake

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Current authenticated backend slice:
 - the API verifies the token against Supabase JWKS before returning session identity details
 - the API must allow browser CORS requests from the staged web host and local Vite host
 - if direct JWT verification fails for a real Supabase session token, the API falls back to Supabase's `/auth/v1/user` validation endpoint before rejecting the request
+- the `/auth/v1/user` fallback must include a Supabase publishable/anon key, sourced from backend env or forwarded by the web client during the protected handshake
 
 Important boundary:
 - the current SQLite `users` table is a business-domain entity, not the hosted auth/account model

--- a/api/auth.py
+++ b/api/auth.py
@@ -8,7 +8,7 @@ from typing import Any
 
 import httpx
 import jwt
-from fastapi import Depends, HTTPException, status
+from fastapi import Depends, HTTPException, Request, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
 from api.config import HostedBackendConfig, HostedConfigurationError, load_hosted_backend_config
@@ -41,12 +41,21 @@ def decode_supabase_access_token(token: str, config: HostedBackendConfig) -> dic
     )
 
 
-def fetch_supabase_user(token: str, config: HostedBackendConfig) -> dict[str, Any]:
+def fetch_supabase_user(
+    token: str,
+    config: HostedBackendConfig,
+    *,
+    api_key: str | None = None,
+) -> dict[str, Any]:
+    headers = {
+        "Authorization": f"Bearer {token}",
+    }
+    if api_key or config.supabase_publishable_key:
+        headers["apikey"] = api_key or config.supabase_publishable_key
+
     response = httpx.get(
         f"{config.supabase_url.rstrip('/')}/auth/v1/user",
-        headers={
-            "Authorization": f"Bearer {token}",
-        },
+        headers=headers,
         timeout=10.0,
     )
     response.raise_for_status()
@@ -62,6 +71,7 @@ def _unauthorized(detail: str) -> HTTPException:
 
 
 def get_authenticated_session(
+    request: Request,
     credentials: HTTPAuthorizationCredentials | None = Depends(bearer_scheme),
 ) -> AuthenticatedSession:
     if not credentials or credentials.scheme.lower() != "bearer":
@@ -75,8 +85,17 @@ def get_authenticated_session(
     try:
         claims = decode_supabase_access_token(credentials.credentials, config)
     except jwt.InvalidTokenError:
+        fallback_api_key = (
+            getattr(config, "supabase_publishable_key", None)
+            or request.headers.get("apikey")
+            or request.headers.get("x-supabase-apikey")
+        )
         try:
-            claims = fetch_supabase_user(credentials.credentials, config)
+            claims = fetch_supabase_user(
+                credentials.credentials,
+                config,
+                api_key=fallback_api_key,
+            )
         except Exception as exc:
             raise _unauthorized("Invalid bearer token.") from exc
 

--- a/api/config.py
+++ b/api/config.py
@@ -18,6 +18,7 @@ class HostedBackendConfig:
 
     supabase_url: str
     supabase_db_password: Optional[str] = None
+    supabase_publishable_key: Optional[str] = None
     db_user: str = "postgres"
     db_name: str = "postgres"
     db_port: int = 5432
@@ -85,6 +86,8 @@ def load_hosted_backend_config(
     - SUPABASE_DB_USER
     - SUPABASE_DB_NAME
     - SUPABASE_DB_PORT
+    - SUPABASE_PUBLISHABLE_KEY
+    - SUPABASE_ANON_KEY
     - SUPABASE_JWT_AUDIENCE
     - SUPABASE_GOOGLE_AUTH_ENABLED
     """
@@ -106,6 +109,12 @@ def load_hosted_backend_config(
     db_user = env_map.get("SUPABASE_DB_USER", "postgres").strip() or "postgres"
     db_name = env_map.get("SUPABASE_DB_NAME", "postgres").strip() or "postgres"
     db_port_raw = env_map.get("SUPABASE_DB_PORT", "5432").strip() or "5432"
+    supabase_publishable_key = (
+        env_map.get("SUPABASE_PUBLISHABLE_KEY", "").strip()
+        or env_map.get("SUPABASE_ANON_KEY", "").strip()
+        or env_map.get("VITE_SUPABASE_ANON_KEY", "").strip()
+        or None
+    )
     jwt_audience = env_map.get("SUPABASE_JWT_AUDIENCE", "authenticated").strip() or "authenticated"
     google_auth_enabled = env_map.get("SUPABASE_GOOGLE_AUTH_ENABLED", "false").strip().lower() in {
         "1",
@@ -130,6 +139,7 @@ def load_hosted_backend_config(
     return HostedBackendConfig(
         supabase_url=supabase_url,
         supabase_db_password=db_password or None,
+        supabase_publishable_key=supabase_publishable_key,
         db_user=db_user,
         db_name=db_name,
         db_port=db_port,

--- a/docs/PROJECT_SPEC.md
+++ b/docs/PROJECT_SPEC.md
@@ -138,6 +138,7 @@ Hosted backend foundation (Issue #203):
 - After successful Google sign-in, the web shell should call `GET /v1/session` with the Supabase access token and reflect the protected API handshake status in the UI.
 - The hosted API must permit CORS preflight and authenticated browser requests from `https://dev.sezzions.com` and `http://localhost:5173` by default, with environment override support for additional origins.
 - If direct local JWT decoding is not compatible with the live Supabase token format, the API may validate the bearer token through Supabase's `/auth/v1/user` endpoint before returning `401`.
+- The `/auth/v1/user` validation fallback must include a Supabase publishable/anon key, either from hosted backend configuration or from the web client's protected handshake request.
 
 ### Application Update Infrastructure (Issue #171, MVP)
 

--- a/docs/status/CHANGELOG.md
+++ b/docs/status/CHANGELOG.md
@@ -12,6 +12,38 @@ Rules:
 ## 2026-03-28
 
 ```yaml
+id: 2026-03-28-09
+type: fix
+areas: [api, auth, web, docs, tests]
+issue: 203
+summary: "Provide the Supabase public key on the protected session fallback path"
+details: >
+  Followed up on the staged `401` issue after adding the `/auth/v1/user`
+  fallback. Supabase's server-side user validation path requires both the bearer
+  token and a publishable/anon API key. Added support for the hosted API to read
+  that public key from backend configuration or from the web client's protected
+  handshake request, and updated the web shell to forward the key alongside the
+  bearer token.
+
+  Implemented:
+  - hosted config support for `SUPABASE_PUBLISHABLE_KEY` or `SUPABASE_ANON_KEY`
+  - `apikey` forwarding on the protected web handshake
+  - auth tests covering the forwarded-key fallback path
+
+  Validation:
+  - PYTHONPATH=$PWD /usr/local/bin/python3 -m pytest -q tests/api/test_auth.py tests/api/test_app.py tests/services/hosted/test_config.py
+files_changed:
+  - api/config.py
+  - api/auth.py
+  - web/src/App.jsx
+  - tests/api/test_auth.py
+  - tests/services/hosted/test_config.py
+  - README.md
+  - docs/PROJECT_SPEC.md
+  - docs/status/CHANGELOG.md
+```
+
+```yaml
 id: 2026-03-28-08
 type: fix
 areas: [api, auth, docs, tests]

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -1,7 +1,12 @@
 import jwt
 import pytest
 
-from api.auth import get_authenticated_session
+from api.auth import fetch_supabase_user, get_authenticated_session
+from api.config import HostedBackendConfig
+
+
+def _request(headers: dict[str, str] | None = None):
+    return type("Request", (), {"headers": headers or {}})()
 
 
 def test_get_authenticated_session_falls_back_to_supabase_user_lookup(monkeypatch) -> None:
@@ -15,7 +20,7 @@ def test_get_authenticated_session_falls_back_to_supabase_user_lookup(monkeypatc
     )
     monkeypatch.setattr(
         "api.auth.fetch_supabase_user",
-        lambda token, config: {
+        lambda token, config, *, api_key=None: {
             "id": "user-123",
             "email": "owner@sezzions.com",
             "aud": "authenticated",
@@ -28,7 +33,8 @@ def test_get_authenticated_session_falls_back_to_supabase_user_lookup(monkeypatc
             "Creds",
             (),
             {"scheme": "Bearer", "credentials": "token-123"},
-        )()
+        )(),
+        request=_request(),
     )
 
     assert session.user_id == "user-123"
@@ -48,7 +54,7 @@ def test_get_authenticated_session_raises_unauthorized_when_fallback_fails(monke
     )
     monkeypatch.setattr(
         "api.auth.fetch_supabase_user",
-        lambda token, config: (_ for _ in ()).throw(RuntimeError("no user")),
+        lambda token, config, *, api_key=None: (_ for _ in ()).throw(RuntimeError("no user")),
     )
 
     with pytest.raises(Exception) as exc_info:
@@ -57,7 +63,86 @@ def test_get_authenticated_session_raises_unauthorized_when_fallback_fails(monke
                 "Creds",
                 (),
                 {"scheme": "Bearer", "credentials": "token-123"},
-            )()
+            )(),
+            request=_request(),
         )
 
     assert getattr(exc_info.value, "status_code", None) == 401
+
+
+def test_get_authenticated_session_uses_request_apikey_for_fallback(monkeypatch) -> None:
+    captured = {}
+
+    monkeypatch.setattr(
+        "api.auth.load_hosted_backend_config",
+        lambda require_db_password=False: type(
+            "Config",
+            (),
+            {"supabase_publishable_key": None},
+        )(),
+    )
+    monkeypatch.setattr(
+        "api.auth.decode_supabase_access_token",
+        lambda token, config: (_ for _ in ()).throw(jwt.InvalidTokenError("bad token")),
+    )
+
+    def fake_fetch(token, config, *, api_key=None):
+        captured["api_key"] = api_key
+        return {
+            "id": "user-123",
+            "email": "owner@sezzions.com",
+            "aud": "authenticated",
+            "role": "authenticated",
+        }
+
+    monkeypatch.setattr("api.auth.fetch_supabase_user", fake_fetch)
+
+    session = get_authenticated_session(
+        credentials=type(
+            "Creds",
+            (),
+            {"scheme": "Bearer", "credentials": "token-123"},
+        )(),
+        request=type(
+            "Request",
+            (),
+            {"headers": {"apikey": "publishable-key-123"}},
+        )(),
+    )
+
+    assert session.user_id == "user-123"
+    assert captured["api_key"] == "publishable-key-123"
+
+
+def test_fetch_supabase_user_sends_apikey_header(monkeypatch) -> None:
+    captured = {}
+
+    class Response:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, str]:
+            return {"id": "user-123"}
+
+    def fake_get(url: str, *, headers: dict[str, str], timeout: float) -> Response:
+        captured["url"] = url
+        captured["headers"] = headers
+        captured["timeout"] = timeout
+        return Response()
+
+    monkeypatch.setattr("api.auth.httpx.get", fake_get)
+
+    config = HostedBackendConfig(
+        supabase_url="https://example.supabase.co",
+        supabase_publishable_key="publishable-key-123",
+    )
+
+    user = fetch_supabase_user("token-123", config)
+
+    assert user == {"id": "user-123"}
+    assert captured["url"] == "https://example.supabase.co/auth/v1/user"
+    assert captured["headers"] == {
+        "Authorization": "Bearer token-123",
+        "apikey": "publishable-key-123",
+    }
+    assert captured["timeout"] == 10.0

--- a/tests/services/hosted/test_config.py
+++ b/tests/services/hosted/test_config.py
@@ -60,3 +60,27 @@ def test_load_hosted_backend_config_parses_cors_allowed_origins() -> None:
         "https://sezzions.com",
         "http://localhost:5173",
     )
+
+
+def test_load_hosted_backend_config_reads_publishable_key_variants() -> None:
+    config = load_hosted_backend_config(
+        {
+            "SUPABASE_URL": "https://nztovvajnrokzsetliwz.supabase.co",
+            "SUPABASE_PUBLISHABLE_KEY": "publishable-key-123",
+        },
+        require_db_password=False,
+    )
+
+    assert config is not None
+    assert config.supabase_publishable_key == "publishable-key-123"
+
+    fallback_config = load_hosted_backend_config(
+        {
+            "SUPABASE_URL": "https://nztovvajnrokzsetliwz.supabase.co",
+            "SUPABASE_ANON_KEY": "anon-key-123",
+        },
+        require_db_password=False,
+    )
+
+    assert fallback_config is not None
+    assert fallback_config.supabase_publishable_key == "anon-key-123"

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -48,6 +48,7 @@ export default function App() {
     "Protected API handshake will run after Google sign-in."
   );
   const apiBaseUrl = import.meta.env.VITE_API_BASE_URL?.trim() || null;
+  const supabaseApiKey = import.meta.env.VITE_SUPABASE_ANON_KEY?.trim() || null;
 
   async function syncProtectedApi(nextSession) {
     if (!nextSession?.access_token) {
@@ -65,7 +66,8 @@ export default function App() {
     try {
       const response = await fetch(`${apiBaseUrl}/v1/session`, {
         headers: {
-          Authorization: `Bearer ${nextSession.access_token}`
+          Authorization: `Bearer ${nextSession.access_token}`,
+          ...(supabaseApiKey ? { apikey: supabaseApiKey } : {})
         }
       });
 


### PR DESCRIPTION
## Summary
- forward the Supabase public key from the web shell on the protected /v1/session handshake
- allow the hosted API fallback to use a backend-configured or forwarded publishable/anon key when calling /auth/v1/user
- add focused auth/config tests and update the spec/changelog

## Validation
- PYTHONPATH=/Users/elliot/Documents/My Documents/Business/Carolina Edge Gaming/Session App/Claude Version/V28 - multi session testing 2 /usr/local/bin/python3 -m pytest -q tests/api/test_auth.py tests/api/test_app.py tests/services/hosted/test_config.py
- cd web && npm test -- --run

## Issue
- Closes #203