### PR TITLE
Prefer request apikey in staged auth fallback

### DIFF
--- a/api/auth.py
+++ b/api/auth.py
@@ -16,6 +16,12 @@ from api.config import HostedBackendConfig, HostedConfigurationError, load_hoste
 
 bearer_scheme = HTTPBearer(auto_error=False)
 
+JWT_FALLBACK_ERRORS = [jwt.InvalidTokenError]
+for _jwt_error_name in ("PyJWKClientError", "PyJWKClientConnectionError"):
+    _jwt_error = getattr(jwt, _jwt_error_name, None)
+    if _jwt_error is not None:
+        JWT_FALLBACK_ERRORS.append(_jwt_error)
+
 
 @dataclass(frozen=True)
 class AuthenticatedSession:
@@ -70,6 +76,22 @@ def _unauthorized(detail: str) -> HTTPException:
     )
 
 
+def _fallback_api_keys(request: Request, config: HostedBackendConfig) -> tuple[str | None, ...]:
+    candidates = (
+        request.headers.get("apikey"),
+        request.headers.get("x-supabase-apikey"),
+        getattr(config, "supabase_publishable_key", None),
+        None,
+    )
+
+    ordered_keys: list[str | None] = []
+    for candidate in candidates:
+        if candidate not in ordered_keys:
+            ordered_keys.append(candidate)
+
+    return tuple(ordered_keys)
+
+
 def get_authenticated_session(
     request: Request,
     credentials: HTTPAuthorizationCredentials | None = Depends(bearer_scheme),
@@ -84,20 +106,20 @@ def get_authenticated_session(
 
     try:
         claims = decode_supabase_access_token(credentials.credentials, config)
-    except jwt.InvalidTokenError:
-        fallback_api_key = (
-            getattr(config, "supabase_publishable_key", None)
-            or request.headers.get("apikey")
-            or request.headers.get("x-supabase-apikey")
-        )
-        try:
-            claims = fetch_supabase_user(
-                credentials.credentials,
-                config,
-                api_key=fallback_api_key,
-            )
-        except Exception as exc:
-            raise _unauthorized("Invalid bearer token.") from exc
+    except tuple(JWT_FALLBACK_ERRORS):
+        last_error: Exception | None = None
+        for fallback_api_key in _fallback_api_keys(request, config):
+            try:
+                claims = fetch_supabase_user(
+                    credentials.credentials,
+                    config,
+                    api_key=fallback_api_key,
+                )
+                break
+            except Exception as exc:
+                last_error = exc
+        else:
+            raise _unauthorized("Invalid bearer token.") from last_error
 
     user_id = str(claims.get("sub") or claims.get("id") or "")
     if not user_id:

--- a/docs/status/CHANGELOG.md
+++ b/docs/status/CHANGELOG.md
@@ -12,6 +12,34 @@ Rules:
 ## 2026-03-28
 
 ```yaml
+id: 2026-03-28-10
+type: fix
+areas: [api, auth, tests]
+issue: 203
+summary: "Prefer the browser apikey during staged Supabase user fallback"
+details: >
+  Followed up on the still-live staged `401` after confirming the current web
+  bundle was deployed. The hosted auth fallback was still preferring any
+  backend-configured Supabase publishable key over the fresh `apikey` already
+  being sent by the browser, which left room for stale Render env values to
+  keep breaking `/auth/v1/user` validation.
+
+  Implemented:
+  - auth fallback now tries request-supplied Supabase API keys before backend
+    config values
+  - fallback now retries available key candidates in order instead of failing on
+    the first rejected key
+  - focused auth tests covering request-key precedence and ordered retries
+
+  Validation:
+  - /usr/local/bin/python3 -m pytest tests/api/test_auth.py -q
+files_changed:
+  - api/auth.py
+  - tests/api/test_auth.py
+  - docs/status/CHANGELOG.md
+```
+
+```yaml
 id: 2026-03-28-09
 type: fix
 areas: [api, auth, web, docs, tests]

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -78,7 +78,7 @@ def test_get_authenticated_session_uses_request_apikey_for_fallback(monkeypatch)
         lambda require_db_password=False: type(
             "Config",
             (),
-            {"supabase_publishable_key": None},
+            {"supabase_publishable_key": "stale-render-key"},
         )(),
     )
     monkeypatch.setattr(
@@ -112,6 +112,55 @@ def test_get_authenticated_session_uses_request_apikey_for_fallback(monkeypatch)
 
     assert session.user_id == "user-123"
     assert captured["api_key"] == "publishable-key-123"
+
+
+def test_get_authenticated_session_retries_fallback_keys_in_order(monkeypatch) -> None:
+    attempted_keys = []
+
+    monkeypatch.setattr(
+        "api.auth.load_hosted_backend_config",
+        lambda require_db_password=False: type(
+            "Config",
+            (),
+            {"supabase_publishable_key": "render-config-key"},
+        )(),
+    )
+    monkeypatch.setattr(
+        "api.auth.decode_supabase_access_token",
+        lambda token, config: (_ for _ in ()).throw(jwt.InvalidTokenError("bad token")),
+    )
+
+    def fake_fetch(token, config, *, api_key=None):
+        attempted_keys.append(api_key)
+        if api_key == "request-key":
+            raise RuntimeError("request key rejected")
+        return {
+            "id": "user-123",
+            "email": "owner@sezzions.com",
+            "aud": "authenticated",
+            "role": "authenticated",
+        }
+
+    monkeypatch.setattr("api.auth.fetch_supabase_user", fake_fetch)
+
+    session = get_authenticated_session(
+        credentials=type(
+            "Creds",
+            (),
+            {"scheme": "Bearer", "credentials": "token-123"},
+        )(),
+        request=type(
+            "Request",
+            (),
+            {"headers": {"apikey": "request-key", "x-supabase-apikey": "secondary-request-key"}},
+        )(),
+    )
+
+    assert session.user_id == "user-123"
+    assert attempted_keys == [
+        "request-key",
+        "secondary-request-key",
+    ]
 
 
 def test_fetch_supabase_user_sends_apikey_header(monkeypatch) -> None:


### PR DESCRIPTION
## What

- Prefer request-supplied Supabase API keys during the `/auth/v1/user` fallback path.
- Retry available fallback API keys in order instead of failing after the first rejected key.
- Add focused regression tests for request-key precedence and ordered retries.
- Record the fix in the changelog.

## Why

- The staged frontend was confirmed current, but the live protected handshake could still return `401` if Render had a stale Supabase publishable key configured.
- The browser already forwards a fresh `apikey`, so the API should try that first before trusting backend config.

## How

- Added fallback-key ordering logic in `api/auth.py`.
- Expanded the fallback exception set to include JWKS client failures that should still reach the Supabase user lookup path.
- Added focused tests in `tests/api/test_auth.py`.
- Added a changelog entry in `docs/status/CHANGELOG.md`.

## Linked Issue

- Refs #203

## Target Branch

- [x] This PR targets `develop` for normal work, or `main` only for an approved release/hotfix.

## Checklist

- [x] Tests pass locally (`pytest -q`)
- [x] Updated/added tests for intended semantics (esp. accounting rules)
- [ ] Updated `docs/PROJECT_SPEC.md` if behavior/architecture/workflows changed
- [x] Added/updated `docs/status/CHANGELOG.md` for noteworthy changes
- [x] No documentation sprawl (no new random markdown files)
- [ ] UI change: included screenshots / short notes (if applicable)

## Validation Notes

Steps to validate:
1. `/usr/local/bin/python3 -m pytest tests/api/test_auth.py tests/api/test_app.py tests/services/hosted/test_config.py -q`
2. Sign in on `dev.sezzions.com` and confirm the protected `/v1/session` call no longer fails because of backend key precedence.
3. Verify the UI advances from `Protected API handshake failed (401).` to the ready state after Render redeploys.

## Pitfalls / Follow-ups

- If staging still returns `401` after this deploy, inspect the live Render env values and the exact `/v1/session` response body before changing the auth flow again.
- Full repository CI may still show the unrelated updater UI failure seen on earlier PRs; that is not addressed by this change.
