### PR TITLE
Add hosted account/workspace bootstrap after auth

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
-from fastapi import Depends, FastAPI
+from fastapi import Depends, FastAPI, HTTPException, status
 from fastapi.middleware.cors import CORSMiddleware
 
 from api.auth import AuthenticatedSession, get_authenticated_session
-from api.config import load_hosted_backend_config
+from api.config import HostedConfigurationError, load_hosted_backend_config
+from services.hosted.account_bootstrap_service import HostedAccountBootstrapService
+from services.hosted.persistence import get_hosted_session_factory
 
 
 app = FastAPI(title="Sezzions Hosted API", version="0.1.0")
@@ -19,9 +21,19 @@ app.add_middleware(
         "http://localhost:5173",
     ],
     allow_credentials=True,
-    allow_methods=["GET", "OPTIONS"],
+    allow_methods=["GET", "POST", "OPTIONS"],
     allow_headers=["*"],
 )
+
+
+def get_hosted_account_bootstrap_service() -> HostedAccountBootstrapService:
+    try:
+        config = load_hosted_backend_config(require_db_password=True)
+    except HostedConfigurationError as exc:
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(exc)) from exc
+
+    session_factory = get_hosted_session_factory(config.sqlalchemy_url)
+    return HostedAccountBootstrapService(session_factory)
 
 
 @app.get("/healthz")
@@ -52,3 +64,15 @@ def session_summary(
         "audience": session.audience,
         "role": session.role,
     }
+
+
+@app.post("/v1/account/bootstrap")
+def account_bootstrap(
+    session: AuthenticatedSession = Depends(get_authenticated_session),
+    service: HostedAccountBootstrapService = Depends(get_hosted_account_bootstrap_service),
+) -> dict[str, object]:
+    summary = service.bootstrap_account_workspace(
+        supabase_user_id=session.user_id,
+        owner_email=session.email,
+    )
+    return summary.as_dict() if hasattr(summary, "as_dict") else summary

--- a/docs/PROJECT_SPEC.md
+++ b/docs/PROJECT_SPEC.md
@@ -136,6 +136,12 @@ Hosted backend foundation (Issue #203):
 - The first protected hosted API endpoint is `GET /v1/session`.
 - `GET /v1/session` must require a bearer token, verify the Supabase access token against Supabase JWKS, and return the authenticated session identity summary.
 - After successful Google sign-in, the web shell should call `GET /v1/session` with the Supabase access token and reflect the protected API handshake status in the UI.
+- The first hosted persistence slice after auth is `POST /v1/account/bootstrap`.
+- `POST /v1/account/bootstrap` must require a bearer token and idempotently create or return the hosted account/workspace records for the authenticated Supabase user.
+- Hosted account identity is keyed by Supabase user id and tracks the owner email plus auth provider separately from the legacy SQLite business-domain `users` table.
+- Hosted workspace bootstrap must create one default workspace per hosted account when none exists yet, using `<owner email> Workspace` as the initial display name.
+- The hosted API persists account/workspace bootstrap state through the configured Supabase PostgreSQL SQLAlchemy connection.
+- After the protected session handshake succeeds, the web shell should call `POST /v1/account/bootstrap` with the same Supabase access token and render the hosted account owner, auth provider, workspace name, and bootstrap status in the UI.
 - The hosted API must permit CORS preflight and authenticated browser requests from `https://dev.sezzions.com` and `http://localhost:5173` by default, with environment override support for additional origins.
 - If direct local JWT decoding is not compatible with the live Supabase token format, the API may validate the bearer token through Supabase's `/auth/v1/user` endpoint before returning `401`.
 - The `/auth/v1/user` validation fallback must include a Supabase publishable/anon key, either from hosted backend configuration or from the web client's protected handshake request.

--- a/docs/status/CHANGELOG.md
+++ b/docs/status/CHANGELOG.md
@@ -9,6 +9,46 @@ Rules:
 
 ---
 
+## 2026-03-29
+
+```yaml
+id: 2026-03-29-01
+type: feat
+areas: [api, auth, database, web, docs, tests]
+issue: 210
+summary: "Bootstrap a hosted account and workspace after authenticated sign-in"
+details: >
+  Added the first persisted hosted product state after the protected Supabase
+  session handshake. The hosted API now exposes `POST /v1/account/bootstrap`,
+  which idempotently creates or returns the hosted account/workspace for the
+  authenticated Supabase user. The web shell now calls that endpoint after the
+  protected session handshake succeeds and renders the hosted owner/workspace
+  summary in the UI.
+
+  Implemented:
+  - SQLAlchemy-backed hosted account/workspace persistence records
+  - idempotent hosted account bootstrap service and protected API endpoint
+  - web-shell bootstrap request and hosted summary rendering after sign-in
+  - focused service, API, and web tests for the new authenticated slice
+
+  Validation:
+  - PYTHONPATH=$PWD /usr/local/bin/python3 -m pytest -q tests/services/hosted/test_account_bootstrap_service.py tests/api/test_app.py
+  - cd web && npm test -- --run App.test.jsx
+files_changed:
+  - api/app.py
+  - repositories/hosted_account_repository.py
+  - repositories/hosted_workspace_repository.py
+  - services/hosted/__init__.py
+  - services/hosted/account_bootstrap_service.py
+  - services/hosted/persistence.py
+  - web/src/App.jsx
+  - web/src/App.test.jsx
+  - tests/api/test_app.py
+  - tests/services/hosted/test_account_bootstrap_service.py
+  - docs/PROJECT_SPEC.md
+  - docs/status/CHANGELOG.md
+```
+
 ## 2026-03-28
 
 ```yaml

--- a/repositories/hosted_account_repository.py
+++ b/repositories/hosted_account_repository.py
@@ -1,0 +1,61 @@
+"""Persistence helpers for hosted product accounts."""
+
+from __future__ import annotations
+
+from sqlalchemy import select
+
+from services.hosted.models import HostedAccount
+from services.hosted.persistence import HostedAccountRecord
+
+
+class HostedAccountRepository:
+    def get_by_supabase_user_id(self, session, supabase_user_id: str) -> HostedAccount | None:
+        record = session.scalar(
+            select(HostedAccountRecord).where(HostedAccountRecord.supabase_user_id == supabase_user_id)
+        )
+        if record is None:
+            return None
+        return HostedAccount(
+            id=record.id,
+            owner_email=record.owner_email,
+            auth_provider=record.auth_provider,
+            supabase_user_id=record.supabase_user_id,
+        )
+
+    def create(
+        self,
+        session,
+        *,
+        owner_email: str,
+        supabase_user_id: str,
+        auth_provider: str = "google",
+    ) -> HostedAccount:
+        record = HostedAccountRecord(
+            owner_email=owner_email,
+            auth_provider=auth_provider,
+            supabase_user_id=supabase_user_id,
+        )
+        session.add(record)
+        session.flush()
+        return HostedAccount(
+            id=record.id,
+            owner_email=record.owner_email,
+            auth_provider=record.auth_provider,
+            supabase_user_id=record.supabase_user_id,
+        )
+
+    def update_owner_email(self, session, *, supabase_user_id: str, owner_email: str) -> HostedAccount | None:
+        record = session.scalar(
+            select(HostedAccountRecord).where(HostedAccountRecord.supabase_user_id == supabase_user_id)
+        )
+        if record is None:
+            return None
+
+        record.owner_email = owner_email
+        session.flush()
+        return HostedAccount(
+            id=record.id,
+            owner_email=record.owner_email,
+            auth_provider=record.auth_provider,
+            supabase_user_id=record.supabase_user_id,
+        )

--- a/repositories/hosted_workspace_repository.py
+++ b/repositories/hosted_workspace_repository.py
@@ -1,0 +1,45 @@
+"""Persistence helpers for hosted product workspaces."""
+
+from __future__ import annotations
+
+from sqlalchemy import select
+
+from services.hosted.models import HostedWorkspace
+from services.hosted.persistence import HostedWorkspaceRecord
+
+
+class HostedWorkspaceRepository:
+    def get_by_account_id(self, session, account_id: str) -> HostedWorkspace | None:
+        record = session.scalar(
+            select(HostedWorkspaceRecord).where(HostedWorkspaceRecord.account_id == account_id)
+        )
+        if record is None:
+            return None
+        return HostedWorkspace(
+            id=record.id,
+            account_id=record.account_id,
+            name=record.name,
+            source_db_path=record.source_db_path,
+        )
+
+    def create(
+        self,
+        session,
+        *,
+        account_id: str,
+        name: str,
+        source_db_path: str | None = None,
+    ) -> HostedWorkspace:
+        record = HostedWorkspaceRecord(
+            account_id=account_id,
+            name=name,
+            source_db_path=source_db_path,
+        )
+        session.add(record)
+        session.flush()
+        return HostedWorkspace(
+            id=record.id,
+            account_id=record.account_id,
+            name=record.name,
+            source_db_path=record.source_db_path,
+        )

--- a/services/hosted/__init__.py
+++ b/services/hosted/__init__.py
@@ -1,1 +1,8 @@
 """Hosted backend and migration helpers."""
+
+from services.hosted.account_bootstrap_service import (
+	HostedAccountBootstrapService,
+	HostedBootstrapSummary,
+)
+
+__all__ = ["HostedAccountBootstrapService", "HostedBootstrapSummary"]

--- a/services/hosted/account_bootstrap_service.py
+++ b/services/hosted/account_bootstrap_service.py
@@ -1,0 +1,93 @@
+"""Hosted account/workspace bootstrap flow for authenticated users."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from repositories.hosted_account_repository import HostedAccountRepository
+from repositories.hosted_workspace_repository import HostedWorkspaceRepository
+from services.hosted.models import HostedAccount, HostedWorkspace
+
+
+@dataclass(frozen=True)
+class HostedBootstrapSummary:
+    account: HostedAccount
+    workspace: HostedWorkspace
+    created_account: bool
+    created_workspace: bool
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "created_account": self.created_account,
+            "created_workspace": self.created_workspace,
+            "account": {
+                "id": self.account.id,
+                "owner_email": self.account.owner_email,
+                "auth_provider": self.account.auth_provider,
+                "supabase_user_id": self.account.supabase_user_id,
+            },
+            "workspace": {
+                "id": self.workspace.id,
+                "account_id": self.workspace.account_id,
+                "name": self.workspace.name,
+                "source_db_path": self.workspace.source_db_path,
+            },
+        }
+
+
+class HostedAccountBootstrapService:
+    def __init__(self, session_factory) -> None:
+        self.session_factory = session_factory
+        self.account_repository = HostedAccountRepository()
+        self.workspace_repository = HostedWorkspaceRepository()
+
+    def bootstrap_account_workspace(
+        self,
+        *,
+        supabase_user_id: str,
+        owner_email: str | None,
+    ) -> HostedBootstrapSummary:
+        normalized_email = self._normalized_owner_email(owner_email, supabase_user_id)
+
+        with self.session_factory() as session:
+            created_account = False
+            created_workspace = False
+
+            account = self.account_repository.get_by_supabase_user_id(session, supabase_user_id)
+            if account is None:
+                account = self.account_repository.create(
+                    session,
+                    owner_email=normalized_email,
+                    supabase_user_id=supabase_user_id,
+                )
+                created_account = True
+            elif account.owner_email != normalized_email:
+                account = self.account_repository.update_owner_email(
+                    session,
+                    supabase_user_id=supabase_user_id,
+                    owner_email=normalized_email,
+                )
+
+            workspace = self.workspace_repository.get_by_account_id(session, account.id)
+            if workspace is None:
+                workspace = self.workspace_repository.create(
+                    session,
+                    account_id=account.id,
+                    name=f"{account.owner_email} Workspace",
+                )
+                created_workspace = True
+
+            session.commit()
+
+        return HostedBootstrapSummary(
+            account=account,
+            workspace=workspace,
+            created_account=created_account,
+            created_workspace=created_workspace,
+        )
+
+    @staticmethod
+    def _normalized_owner_email(owner_email: str | None, supabase_user_id: str) -> str:
+        if owner_email and owner_email.strip():
+            return owner_email.strip().lower()
+        return f"{supabase_user_id}@users.sezzions.local"

--- a/services/hosted/persistence.py
+++ b/services/hosted/persistence.py
@@ -1,0 +1,43 @@
+"""Hosted persistence primitives for account/workspace bootstrap."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from uuid import uuid4
+
+from sqlalchemy import ForeignKey, String, create_engine
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, sessionmaker
+
+
+class HostedBase(DeclarativeBase):
+    """Base metadata for hosted persistence models."""
+
+
+class HostedAccountRecord(HostedBase):
+    __tablename__ = "hosted_accounts"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid4()))
+    owner_email: Mapped[str] = mapped_column(String(255), nullable=False)
+    auth_provider: Mapped[str] = mapped_column(String(32), nullable=False, default="google")
+    supabase_user_id: Mapped[str] = mapped_column(String(255), nullable=False, unique=True, index=True)
+
+
+class HostedWorkspaceRecord(HostedBase):
+    __tablename__ = "hosted_workspaces"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid4()))
+    account_id: Mapped[str] = mapped_column(
+        ForeignKey("hosted_accounts.id"),
+        nullable=False,
+        unique=True,
+        index=True,
+    )
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    source_db_path: Mapped[str | None] = mapped_column(String(1024), nullable=True)
+
+
+@lru_cache(maxsize=4)
+def get_hosted_session_factory(sqlalchemy_url: str):
+    engine = create_engine(sqlalchemy_url, future=True, pool_pre_ping=True)
+    HostedBase.metadata.create_all(engine)
+    return sessionmaker(bind=engine, expire_on_commit=False)

--- a/tests/api/test_app.py
+++ b/tests/api/test_app.py
@@ -1,7 +1,7 @@
 from fastapi.testclient import TestClient
 
 from api.auth import AuthenticatedSession, get_authenticated_session
-from api.app import app
+from api.app import app, get_hosted_account_bootstrap_service
 
 
 client = TestClient(app)
@@ -63,3 +63,67 @@ def test_session_endpoint_allows_cors_preflight_from_dev_site() -> None:
 
     assert response.status_code == 200
     assert response.headers["access-control-allow-origin"] == "https://dev.sezzions.com"
+
+
+def test_account_bootstrap_endpoint_returns_hosted_summary() -> None:
+    class StubBootstrapService:
+        def bootstrap_account_workspace(self, *, supabase_user_id: str, owner_email: str | None):
+            return type(
+                "Summary",
+                (),
+                {
+                    "as_dict": lambda self: {
+                        "created_account": True,
+                        "created_workspace": True,
+                        "account": {
+                            "id": "account-123",
+                            "supabase_user_id": supabase_user_id,
+                            "owner_email": owner_email,
+                            "auth_provider": "google",
+                        },
+                        "workspace": {
+                            "id": "workspace-123",
+                            "account_id": "account-123",
+                            "name": "owner@sezzions.com Workspace",
+                            "source_db_path": None,
+                        },
+                    }
+                },
+            )()
+
+    app.dependency_overrides[get_authenticated_session] = lambda: AuthenticatedSession(
+        user_id="user-123",
+        email="owner@sezzions.com",
+        audience="authenticated",
+        role="authenticated",
+    )
+    app.dependency_overrides[get_hosted_account_bootstrap_service] = lambda: StubBootstrapService()
+
+    try:
+        response = client.post("/v1/account/bootstrap")
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "created_account": True,
+        "created_workspace": True,
+        "account": {
+            "id": "account-123",
+            "supabase_user_id": "user-123",
+            "owner_email": "owner@sezzions.com",
+            "auth_provider": "google",
+        },
+        "workspace": {
+            "id": "workspace-123",
+            "account_id": "account-123",
+            "name": "owner@sezzions.com Workspace",
+            "source_db_path": None,
+        },
+    }
+
+
+def test_account_bootstrap_endpoint_requires_bearer_auth() -> None:
+    response = client.post("/v1/account/bootstrap")
+
+    assert response.status_code == 401

--- a/tests/services/hosted/test_account_bootstrap_service.py
+++ b/tests/services/hosted/test_account_bootstrap_service.py
@@ -1,0 +1,53 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from services.hosted.account_bootstrap_service import HostedAccountBootstrapService
+from services.hosted.persistence import HostedBase
+
+
+def _session_factory():
+    engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+    HostedBase.metadata.create_all(engine)
+    return engine, sessionmaker(bind=engine, expire_on_commit=False)
+
+
+def test_bootstrap_creates_account_and_workspace_for_first_time_user() -> None:
+    engine, session_factory = _session_factory()
+    service = HostedAccountBootstrapService(session_factory)
+
+    try:
+        summary = service.bootstrap_account_workspace(
+            supabase_user_id="user-123",
+            owner_email="owner@sezzions.com",
+        )
+    finally:
+        engine.dispose()
+
+    assert summary.created_account is True
+    assert summary.created_workspace is True
+    assert summary.account.supabase_user_id == "user-123"
+    assert summary.account.owner_email == "owner@sezzions.com"
+    assert summary.workspace.account_id == summary.account.id
+    assert summary.workspace.name == "owner@sezzions.com Workspace"
+
+
+def test_bootstrap_is_idempotent_for_existing_user() -> None:
+    engine, session_factory = _session_factory()
+    service = HostedAccountBootstrapService(session_factory)
+
+    try:
+        first = service.bootstrap_account_workspace(
+            supabase_user_id="user-123",
+            owner_email="owner@sezzions.com",
+        )
+        second = service.bootstrap_account_workspace(
+            supabase_user_id="user-123",
+            owner_email="owner@sezzions.com",
+        )
+    finally:
+        engine.dispose()
+
+    assert second.created_account is False
+    assert second.created_workspace is False
+    assert second.account.id == first.account.id
+    assert second.workspace.id == first.workspace.id

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -41,23 +41,74 @@ const launchPlan = [
 
 export default function App() {
   const [sessionEmail, setSessionEmail] = useState(null);
+  const [hostedSummary, setHostedSummary] = useState(null);
   const [authMessage, setAuthMessage] = useState(
     supabaseConfigured ? "Sign in with Google to activate the hosted web shell." : supabaseConfigError
   );
   const [apiStatus, setApiStatus] = useState(
     "Protected API handshake will run after Google sign-in."
   );
+  const [hostedStatus, setHostedStatus] = useState(
+    "Hosted account bootstrap will run after the protected API handshake."
+  );
   const apiBaseUrl = import.meta.env.VITE_API_BASE_URL?.trim() || null;
   const supabaseApiKey = import.meta.env.VITE_SUPABASE_ANON_KEY?.trim() || null;
+
+  async function syncHostedBootstrap(nextSession) {
+    if (!nextSession?.access_token) {
+      setHostedSummary(null);
+      setHostedStatus("Hosted account bootstrap will run after the protected API handshake.");
+      return;
+    }
+
+    if (!apiBaseUrl) {
+      setHostedSummary(null);
+      setHostedStatus("Set VITE_API_BASE_URL to enable hosted account bootstrap.");
+      return;
+    }
+
+    setHostedStatus("Bootstrapping the hosted Sezzions account workspace...");
+
+    try {
+      const response = await fetch(`${apiBaseUrl}/v1/account/bootstrap`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${nextSession.access_token}`,
+          ...(supabaseApiKey ? { apikey: supabaseApiKey } : {})
+        }
+      });
+
+      if (!response.ok) {
+        setHostedSummary(null);
+        setHostedStatus(`Hosted account bootstrap failed (${response.status}).`);
+        return;
+      }
+
+      const data = await response.json();
+      setHostedSummary(data);
+      setHostedStatus(
+        data.created_account || data.created_workspace
+          ? "Hosted account workspace created and ready."
+          : "Hosted account workspace ready."
+      );
+    } catch (error) {
+      setHostedSummary(null);
+      setHostedStatus(error instanceof Error ? error.message : "Hosted account bootstrap failed.");
+    }
+  }
 
   async function syncProtectedApi(nextSession) {
     if (!nextSession?.access_token) {
       setApiStatus("Protected API handshake will run after Google sign-in.");
+      setHostedSummary(null);
+      setHostedStatus("Hosted account bootstrap will run after the protected API handshake.");
       return;
     }
 
     if (!apiBaseUrl) {
       setApiStatus("Set VITE_API_BASE_URL to enable the protected API handshake.");
+      setHostedSummary(null);
+      setHostedStatus("Set VITE_API_BASE_URL to enable hosted account bootstrap.");
       return;
     }
 
@@ -80,7 +131,10 @@ export default function App() {
       setApiStatus(
         `Protected API handshake ready for ${data.email || data.user_id}.`
       );
+      await syncHostedBootstrap(nextSession);
     } catch (error) {
+      setHostedSummary(null);
+      setHostedStatus("Hosted account bootstrap will run after the protected API handshake.");
       setApiStatus(error instanceof Error ? error.message : "Protected API handshake failed.");
     }
   }
@@ -161,8 +215,10 @@ export default function App() {
     }
 
     setSessionEmail(null);
+    setHostedSummary(null);
     setAuthMessage("Signed out. Sign in with Google to reactivate the hosted web shell.");
     setApiStatus("Protected API handshake will run after Google sign-in.");
+    setHostedStatus("Hosted account bootstrap will run after the protected API handshake.");
   }
 
   return (
@@ -207,6 +263,10 @@ export default function App() {
             <div>
               <dt>API handshake</dt>
               <dd>{apiStatus}</dd>
+            </div>
+            <div>
+              <dt>Hosted bootstrap</dt>
+              <dd>{hostedStatus}</dd>
             </div>
           </dl>
           {sessionEmail ? (
@@ -262,6 +322,35 @@ export default function App() {
             After Google sign-in is live, the next slice is a protected call into the Render API
             and then the first controlled import of desktop data from the local SQLite source.
           </p>
+        </section>
+
+        <section className="panel launch-panel">
+          <div className="panel-head">
+            <p className="panel-kicker">Hosted account</p>
+            <h2>Authenticated workspace bootstrap</h2>
+          </div>
+          {hostedSummary ? (
+            <dl className="aside-meta">
+              <div>
+                <dt>Hosted account owner</dt>
+                <dd>{hostedSummary.account.owner_email}</dd>
+              </div>
+              <div>
+                <dt>Auth provider</dt>
+                <dd>{hostedSummary.account.auth_provider}</dd>
+              </div>
+              <div>
+                <dt>Workspace</dt>
+                <dd>{hostedSummary.workspace.name}</dd>
+              </div>
+              <div>
+                <dt>Bootstrap result</dt>
+                <dd>{hostedStatus}</dd>
+              </div>
+            </dl>
+          ) : (
+            <p className="launch-note">{hostedStatus}</p>
+          )}
         </section>
       </main>
     </div>

--- a/web/src/App.test.jsx
+++ b/web/src/App.test.jsx
@@ -1,5 +1,5 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import App from "./App";
 
@@ -25,6 +25,11 @@ vi.mock("./lib/supabaseClient", () => ({
 }));
 
 describe("App", () => {
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllEnvs();
+  });
+
   beforeEach(() => {
     vi.stubEnv("VITE_API_BASE_URL", "https://api.sezzions.test");
     authMocks.getSession.mockReset();
@@ -43,15 +48,39 @@ describe("App", () => {
     });
     authMocks.signInWithOAuth.mockResolvedValue({ error: null });
     authMocks.signOut.mockResolvedValue({ error: null });
-    global.fetch = vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        authenticated: true,
-        user_id: "user-123",
-        email: "owner@sezzions.com",
-        audience: "authenticated",
-        role: "authenticated"
-      })
+    global.fetch = vi.fn().mockImplementation(async (url) => {
+      if (url === "https://api.sezzions.test/v1/account/bootstrap") {
+        return {
+          ok: true,
+          json: async () => ({
+            created_account: true,
+            created_workspace: true,
+            account: {
+              id: "account-123",
+              supabase_user_id: "user-123",
+              owner_email: "owner@sezzions.com",
+              auth_provider: "google"
+            },
+            workspace: {
+              id: "workspace-123",
+              account_id: "account-123",
+              name: "owner@sezzions.com Workspace",
+              source_db_path: null
+            }
+          })
+        };
+      }
+
+      return {
+        ok: true,
+        json: async () => ({
+          authenticated: true,
+          user_id: "user-123",
+          email: "owner@sezzions.com",
+          audience: "authenticated",
+          role: "authenticated"
+        })
+      };
     });
   });
 
@@ -113,5 +142,75 @@ describe("App", () => {
     expect(
       screen.getByText(/protected api handshake ready for owner@sezzions.com/i)
     ).toBeInTheDocument();
+  });
+
+  it("renders the hosted account workspace summary after bootstrap", async () => {
+    authMocks.getSession.mockResolvedValue({
+      data: {
+        session: {
+          access_token: "access-token-123",
+          user: {
+            email: "owner@sezzions.com"
+          }
+        }
+      },
+      error: null
+    });
+
+    global.fetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          authenticated: true,
+          user_id: "user-123",
+          email: "owner@sezzions.com",
+          audience: "authenticated",
+          role: "authenticated"
+        })
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          created_account: true,
+          created_workspace: true,
+          account: {
+            id: "account-123",
+            supabase_user_id: "user-123",
+            owner_email: "owner@sezzions.com",
+            auth_provider: "google"
+          },
+          workspace: {
+            id: "workspace-123",
+            account_id: "account-123",
+            name: "owner@sezzions.com Workspace",
+            source_db_path: null
+          }
+        })
+      });
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenNthCalledWith(
+        2,
+        "https://api.sezzions.test/v1/account/bootstrap",
+        {
+          method: "POST",
+          headers: {
+            Authorization: "Bearer access-token-123"
+          }
+        }
+      );
+    });
+
+    const hostedHeading = await screen.findByRole("heading", {
+      name: /authenticated workspace bootstrap/i
+    });
+    const hostedSection = hostedHeading.closest("section");
+
+    expect(hostedSection).not.toBeNull();
+    expect(within(hostedSection).getByText(/hosted account owner/i)).toBeInTheDocument();
+    expect(within(hostedSection).getByText("owner@sezzions.com Workspace")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- add SQLAlchemy-backed hosted account and workspace persistence for authenticated users
- add protected POST /v1/account/bootstrap to idempotently create or return the hosted account/workspace summary
- update the web shell to bootstrap and render hosted account/workspace details after the protected session handshake
- document the new hosted bootstrap slice in the project spec and changelog

## Testing
- PYTHONPATH=$PWD /usr/local/bin/python3 -m pytest -q tests/services/hosted/test_account_bootstrap_service.py tests/api/test_app.py
- cd web && npm test -- --run App.test.jsx
- pytest -q

## Notes
- The focused hosted bootstrap Python/API tests passed.
- The focused web test passed.
- Full pytest still has one unrelated existing failure: tests/ui/test_expenses_autocomplete.py::test_expense_dialog_vendor_and_notes_inline_prediction_with_tab_accept

## Pitfalls / Follow-ups
- This slice persists the first hosted account/workspace records but does not yet import desktop SQLite business data into the hosted workspace.
- Hosted workspace naming is intentionally simple for now and may need a later rename/edit flow once real multi-workspace UX exists.
