### PR TITLE
Require SSL for hosted Supabase Postgres

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -22,6 +22,7 @@ class HostedBackendConfig:
     db_user: str = "postgres"
     db_name: str = "postgres"
     db_port: int = 5432
+    db_sslmode: str = "require"
     jwt_audience: str = "authenticated"
     google_auth_enabled: bool = False
     cors_allowed_origins: tuple[str, ...] = (
@@ -67,6 +68,7 @@ class HostedBackendConfig:
         return (
             "postgresql+psycopg2://"
             f"{self.db_user}:{encoded_password}@{self.db_host}:{self.db_port}/{self.db_name}"
+            f"?sslmode={quote_plus(self.db_sslmode)}"
         )
 
 
@@ -86,6 +88,7 @@ def load_hosted_backend_config(
     - SUPABASE_DB_USER
     - SUPABASE_DB_NAME
     - SUPABASE_DB_PORT
+    - SUPABASE_DB_SSLMODE
     - SUPABASE_PUBLISHABLE_KEY
     - SUPABASE_ANON_KEY
     - SUPABASE_JWT_AUDIENCE
@@ -109,6 +112,7 @@ def load_hosted_backend_config(
     db_user = env_map.get("SUPABASE_DB_USER", "postgres").strip() or "postgres"
     db_name = env_map.get("SUPABASE_DB_NAME", "postgres").strip() or "postgres"
     db_port_raw = env_map.get("SUPABASE_DB_PORT", "5432").strip() or "5432"
+    db_sslmode = env_map.get("SUPABASE_DB_SSLMODE", "require").strip() or "require"
     supabase_publishable_key = (
         env_map.get("SUPABASE_PUBLISHABLE_KEY", "").strip()
         or env_map.get("SUPABASE_ANON_KEY", "").strip()
@@ -143,6 +147,7 @@ def load_hosted_backend_config(
         db_user=db_user,
         db_name=db_name,
         db_port=db_port,
+        db_sslmode=db_sslmode,
         jwt_audience=jwt_audience,
         google_auth_enabled=google_auth_enabled,
         cors_allowed_origins=cors_allowed_origins,

--- a/docs/status/CHANGELOG.md
+++ b/docs/status/CHANGELOG.md
@@ -12,6 +12,32 @@ Rules:
 ## 2026-03-29
 
 ```yaml
+id: 2026-03-29-02
+type: fix
+areas: [api, database, docs, tests]
+issue: 210
+summary: "Require SSL on hosted Supabase Postgres connections"
+details: >
+  Fixed a live staged regression where authenticated hosted account bootstrap
+  reached the backend but failed with a server-side error while opening the
+  hosted Supabase Postgres connection. The hosted SQLAlchemy URL now includes
+  `sslmode=require` by default, with an env override for deployments that need
+  a different libpq SSL mode.
+
+  Implemented:
+  - default Supabase SQLAlchemy URLs now append `?sslmode=require`
+  - optional `SUPABASE_DB_SSLMODE` override for hosted deployments
+  - focused config tests covering the default and override cases
+
+  Validation:
+  - PYTHONPATH=$PWD /usr/local/bin/python3 -m pytest -q tests/services/hosted/test_config.py tests/api/test_app.py
+files_changed:
+  - api/config.py
+  - tests/services/hosted/test_config.py
+  - docs/status/CHANGELOG.md
+```
+
+```yaml
 id: 2026-03-29-01
 type: feat
 areas: [api, auth, database, web, docs, tests]

--- a/tests/services/hosted/test_config.py
+++ b/tests/services/hosted/test_config.py
@@ -16,6 +16,20 @@ def test_load_hosted_backend_config_builds_supabase_db_connection_values() -> No
     assert config.db_host == "db.nztovvajnrokzsetliwz.supabase.co"
     assert config.google_auth_enabled is True
     assert "secret+with+spaces" in config.sqlalchemy_url
+    assert config.sqlalchemy_url.endswith("?sslmode=require")
+
+
+def test_load_hosted_backend_config_allows_sslmode_override() -> None:
+    config = load_hosted_backend_config(
+        {
+            "SUPABASE_URL": "https://nztovvajnrokzsetliwz.supabase.co",
+            "SUPABASE_DB_PASSWORD": "secret",
+            "SUPABASE_DB_SSLMODE": "verify-full",
+        }
+    )
+
+    assert config.db_sslmode == "verify-full"
+    assert config.sqlalchemy_url.endswith("?sslmode=verify-full")
 
 
 def test_load_hosted_backend_config_can_skip_when_not_required() -> None:


### PR DESCRIPTION
## Summary
Fix the hosted bootstrap staging regression by appending `sslmode=require` to the Supabase SQLAlchemy connection URL by default.

## Changes
- add default hosted DB SSL mode support in backend config
- allow `SUPABASE_DB_SSLMODE` override when needed
- add focused config coverage for the default and override cases

## Notes
This unblocks the live `/v1/account/bootstrap` 500 seen after auth on staging.
