### PR TITLE
Allow hosted database URL overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,11 +168,15 @@ Important boundary:
 Environment variables expected by the hosted foundation:
 - `SUPABASE_URL`
 - `SUPABASE_DB_PASSWORD`
+- `SUPABASE_SQLALCHEMY_URL` or `DATABASE_URL` (optional override for hosted deployments; preferred when your platform needs a pooler or IPv4-safe connection string)
 - `SUPABASE_DB_USER` (optional, defaults to `postgres`)
 - `SUPABASE_DB_NAME` (optional, defaults to `postgres`)
 - `SUPABASE_DB_PORT` (optional, defaults to `5432`)
+- `SUPABASE_DB_SSLMODE` (optional, defaults to `require`)
 - `SUPABASE_JWT_AUDIENCE` (optional, defaults to `authenticated`)
 - `SUPABASE_GOOGLE_AUTH_ENABLED` (optional, `true`/`false`)
+
+If `SUPABASE_SQLALCHEMY_URL` or `DATABASE_URL` is set, the API uses that value directly for hosted Postgres access instead of constructing a URL from the individual `SUPABASE_DB_*` parts. This is the safer option on platforms that cannot reach Supabase's direct IPv6 database host and need the Supabase pooler connection string instead.
 
 Example values are provided in `api/.env.example`.
 

--- a/api/config.py
+++ b/api/config.py
@@ -18,6 +18,7 @@ class HostedBackendConfig:
 
     supabase_url: str
     supabase_db_password: Optional[str] = None
+    sqlalchemy_url_override: Optional[str] = None
     supabase_publishable_key: Optional[str] = None
     db_user: str = "postgres"
     db_name: str = "postgres"
@@ -60,6 +61,8 @@ class HostedBackendConfig:
 
     @property
     def sqlalchemy_url(self) -> str:
+        if self.sqlalchemy_url_override:
+            return self.sqlalchemy_url_override
         if not self.supabase_db_password:
             raise HostedConfigurationError(
                 "SUPABASE_DB_PASSWORD is required for hosted database access."
@@ -82,9 +85,11 @@ def load_hosted_backend_config(
 
     Required environment variables:
     - SUPABASE_URL
-    - SUPABASE_DB_PASSWORD
+    - SUPABASE_DB_PASSWORD or SUPABASE_SQLALCHEMY_URL / DATABASE_URL
 
     Optional:
+    - SUPABASE_SQLALCHEMY_URL
+    - DATABASE_URL
     - SUPABASE_DB_USER
     - SUPABASE_DB_NAME
     - SUPABASE_DB_PORT
@@ -98,14 +103,19 @@ def load_hosted_backend_config(
     env_map = env or os.environ
     supabase_url = env_map.get("SUPABASE_URL", "").strip()
     db_password = env_map.get("SUPABASE_DB_PASSWORD", "").strip()
+    sqlalchemy_url_override = (
+        env_map.get("SUPABASE_SQLALCHEMY_URL", "").strip()
+        or env_map.get("DATABASE_URL", "").strip()
+        or None
+    )
 
-    if not supabase_url and not db_password and not required:
+    if not supabase_url and not db_password and not sqlalchemy_url_override and not required:
         return None
 
-    if not supabase_url or (require_db_password and not db_password):
+    if not supabase_url or (require_db_password and not db_password and not sqlalchemy_url_override):
         if required:
             raise HostedConfigurationError(
-                "SUPABASE_URL and SUPABASE_DB_PASSWORD must both be set."
+                "SUPABASE_URL and either SUPABASE_DB_PASSWORD or SUPABASE_SQLALCHEMY_URL / DATABASE_URL must be set."
             )
         return None
 
@@ -143,6 +153,7 @@ def load_hosted_backend_config(
     return HostedBackendConfig(
         supabase_url=supabase_url,
         supabase_db_password=db_password or None,
+        sqlalchemy_url_override=sqlalchemy_url_override,
         supabase_publishable_key=supabase_publishable_key,
         db_user=db_user,
         db_name=db_name,

--- a/docs/status/CHANGELOG.md
+++ b/docs/status/CHANGELOG.md
@@ -12,6 +12,33 @@ Rules:
 ## 2026-03-29
 
 ```yaml
+id: 2026-03-29-03
+type: fix
+areas: [api, database, docs, tests]
+issue: 210
+summary: "Allow hosted Postgres URL overrides for IPv4-safe deployments"
+details: >
+  Followed up on the staged hosted bootstrap 500 after Render logs showed the
+  API was attempting to reach the direct Supabase database host over IPv6,
+  which was unreachable from the deployed service. The hosted backend now
+  accepts `SUPABASE_SQLALCHEMY_URL` or `DATABASE_URL` so deployments can use a
+  Supabase pooler or other platform-safe Postgres connection string directly.
+
+  Implemented:
+  - direct SQLAlchemy URL override support for hosted database access
+  - focused config coverage for the override path
+  - README guidance for using a pooler/IPv4-safe connection string on hosted platforms
+
+  Validation:
+  - pending deploy verification on Render using a Supabase pooler URL override
+files_changed:
+  - api/config.py
+  - tests/services/hosted/test_config.py
+  - README.md
+  - docs/status/CHANGELOG.md
+```
+
+```yaml
 id: 2026-03-29-02
 type: fix
 areas: [api, database, docs, tests]

--- a/tests/services/hosted/test_config.py
+++ b/tests/services/hosted/test_config.py
@@ -32,6 +32,21 @@ def test_load_hosted_backend_config_allows_sslmode_override() -> None:
     assert config.sqlalchemy_url.endswith("?sslmode=verify-full")
 
 
+def test_load_hosted_backend_config_allows_sqlalchemy_url_override() -> None:
+    config = load_hosted_backend_config(
+        {
+            "SUPABASE_URL": "https://nztovvajnrokzsetliwz.supabase.co",
+            "DATABASE_URL": "postgresql+psycopg2://postgres.nztovvajnrokzsetliwz:secret@aws-0-us-east-1.pooler.supabase.com:6543/postgres?sslmode=require",
+        }
+    )
+
+    assert config.sqlalchemy_url_override is not None
+    assert config.sqlalchemy_url == (
+        "postgresql+psycopg2://postgres.nztovvajnrokzsetliwz:secret@"
+        "aws-0-us-east-1.pooler.supabase.com:6543/postgres?sslmode=require"
+    )
+
+
 def test_load_hosted_backend_config_can_skip_when_not_required() -> None:
     config = load_hosted_backend_config({}, required=False)
 


### PR DESCRIPTION
## Summary
Allow the hosted API to use an explicit SQLAlchemy/Postgres URL override for deployed environments that cannot reach the direct Supabase host.

## Changes
- support `SUPABASE_SQLALCHEMY_URL` and `DATABASE_URL`
- keep the existing constructed Supabase URL path as the fallback
- document the override for Render/pooler usage

## Why
Render is failing to reach the direct Supabase host over IPv6 during `/v1/account/bootstrap`.
