### PR TITLE
Add hosted workspace import planning

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -9,6 +9,9 @@ from api.auth import AuthenticatedSession, get_authenticated_session
 from api.config import HostedConfigurationError, load_hosted_backend_config
 from services.hosted.account_bootstrap_service import HostedAccountBootstrapService
 from services.hosted.persistence import get_hosted_session_factory
+from services.hosted.workspace_import_planning_service import (
+    HostedWorkspaceImportPlanningService,
+)
 
 
 app = FastAPI(title="Sezzions Hosted API", version="0.1.0")
@@ -34,6 +37,16 @@ def get_hosted_account_bootstrap_service() -> HostedAccountBootstrapService:
 
     session_factory = get_hosted_session_factory(config.sqlalchemy_url)
     return HostedAccountBootstrapService(session_factory)
+
+
+def get_hosted_workspace_import_planning_service() -> HostedWorkspaceImportPlanningService:
+    try:
+        config = load_hosted_backend_config(require_db_password=True)
+    except HostedConfigurationError as exc:
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(exc)) from exc
+
+    session_factory = get_hosted_session_factory(config.sqlalchemy_url)
+    return HostedWorkspaceImportPlanningService(session_factory)
 
 
 @app.get("/healthz")
@@ -75,4 +88,17 @@ def account_bootstrap(
         supabase_user_id=session.user_id,
         owner_email=session.email,
     )
+    return summary.as_dict() if hasattr(summary, "as_dict") else summary
+
+
+@app.get("/v1/workspace/import-plan")
+def workspace_import_plan(
+    session: AuthenticatedSession = Depends(get_authenticated_session),
+    service: HostedWorkspaceImportPlanningService = Depends(get_hosted_workspace_import_planning_service),
+) -> dict[str, object]:
+    try:
+        summary = service.plan_import(supabase_user_id=session.user_id)
+    except LookupError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+
     return summary.as_dict() if hasattr(summary, "as_dict") else summary

--- a/docs/PROJECT_SPEC.md
+++ b/docs/PROJECT_SPEC.md
@@ -142,6 +142,13 @@ Hosted backend foundation (Issue #203):
 - Hosted workspace bootstrap must create one default workspace per hosted account when none exists yet, using `<owner email> Workspace` as the initial display name.
 - The hosted API persists account/workspace bootstrap state through the configured Supabase PostgreSQL SQLAlchemy connection.
 - After the protected session handshake succeeds, the web shell should call `POST /v1/account/bootstrap` with the same Supabase access token and render the hosted account owner, auth provider, workspace name, and bootstrap status in the UI.
+- The next hosted planning slice after bootstrap is `GET /v1/workspace/import-plan`.
+- `GET /v1/workspace/import-plan` must require a bearer token and return a read-only import-planning summary for the authenticated user's hosted workspace.
+- The import-planning summary must include workspace identity, whether a source SQLite path is recorded, whether that path is accessible to the API process, a human-readable planning detail message, and any read-only SQLite inventory data that can be inspected safely.
+- If the hosted workspace has no recorded `source_db_path`, the endpoint must return a safe actionable status instead of failing.
+- If the hosted workspace records a SQLite path that is not accessible to the API deployment, the endpoint must return a safe actionable status instead of failing.
+- The hosted API must never claim that a browser-only hosted flow can directly inspect an end user's local SQLite file unless that file has been made accessible to the API process by a later desktop-assisted or upload-based bridge.
+- After hosted bootstrap succeeds, the web shell should call `GET /v1/workspace/import-plan` and render the resulting import-planning status and any available inventory summary.
 - The hosted API must permit CORS preflight and authenticated browser requests from `https://dev.sezzions.com` and `http://localhost:5173` by default, with environment override support for additional origins.
 - If direct local JWT decoding is not compatible with the live Supabase token format, the API may validate the bearer token through Supabase's `/auth/v1/user` endpoint before returning `401`.
 - The `/auth/v1/user` validation fallback must include a Supabase publishable/anon key, either from hosted backend configuration or from the web client's protected handshake request.

--- a/docs/archive/2026-03-29-issue-hosted-import-planning.md
+++ b/docs/archive/2026-03-29-issue-hosted-import-planning.md
@@ -1,0 +1,59 @@
+## Summary
+Add the next hosted product slice after account/workspace bootstrap: an authenticated workspace import-planning flow that inspects the user’s local Sezzions SQLite database and shows a hosted inventory summary before any real data migration occurs.
+
+## Problem
+Hosted auth and workspace bootstrap now work, but the hosted product still has no bridge from an existing desktop user’s local `sezzions.db` into the hosted account/workspace. We already have a read-only CLI inventory tool for SQLite inspection, but there is no hosted API or web UI flow that makes that planning information part of the staged hosted product.
+
+## Proposal
+Implement an authenticated hosted import-planning slice that:
+- records or confirms the source database path for the hosted workspace
+- exposes a protected API endpoint that returns a read-only inventory summary for that source SQLite database
+- renders the import-planning summary in the web shell after hosted bootstrap
+- does not perform any data writes into hosted business tables yet
+
+## Scope
+In scope:
+- protected hosted API endpoint for workspace import planning
+- service-layer orchestration that reuses the existing SQLite inventory logic
+- web-shell UI for showing import-planning readiness and inventory results
+- focused tests for happy path, edge cases, and a failure case
+- docs/changelog updates for the new hosted slice
+
+Out of scope:
+- actual record migration from SQLite to Supabase Postgres
+- bidirectional sync
+- background jobs / resumable imports
+- hosted CRUD for business entities
+
+## Acceptance Criteria
+- authenticated users with a bootstrapped hosted workspace can request a read-only import inventory summary
+- the API response includes enough planning data to judge migration readiness, including table counts and basic metadata already available from the existing inventory tool
+- the web shell displays the inventory summary clearly after auth/bootstrap succeeds
+- missing or invalid source DB paths fail safely with an actionable error, without changing hosted state
+- no business-domain rows are imported yet
+
+## Test Matrix
+Happy path:
+- authenticated request returns inventory summary for a valid source SQLite file
+
+Edge cases:
+- workspace has no source DB path yet
+- source DB path exists in workspace state but the file is missing on disk
+
+Failure injection:
+- SQLite inspection raises an error mid-read and the API returns a safe failure without mutating hosted records
+
+Invariants:
+- hosted account/workspace identity remains unchanged
+- no hosted business-domain data is created
+- request still requires bearer auth
+
+## Manual Verification
+- sign in on staged web
+- confirm hosted bootstrap succeeds
+- request/import-planning summary and confirm the UI shows read-only inventory data or a clear actionable error
+
+## Labels
+- feature
+- status:ready
+- type:feature

--- a/docs/status/CHANGELOG.md
+++ b/docs/status/CHANGELOG.md
@@ -12,6 +12,42 @@ Rules:
 ## 2026-03-29
 
 ```yaml
+id: 2026-03-29-04
+type: feat
+areas: [api, web, docs, tests]
+issue: 214
+summary: "Add authenticated hosted workspace import planning"
+details: >
+  Added the next hosted product slice after workspace bootstrap: a protected
+  read-only import-planning endpoint and staged web UI that report whether the
+  hosted workspace has an inspectable SQLite migration source. The implemented
+  contract reflects the real deployment boundary: the hosted API can only
+  inspect a source SQLite path when that path is actually accessible to the API
+  process.
+
+  Implemented:
+  - `GET /v1/workspace/import-plan` protected hosted planning endpoint
+  - hosted planning service with safe statuses for missing paths, inaccessible
+    paths, and inspection failures
+  - staged web-shell import planning status/inventory rendering after bootstrap
+  - focused service, API, and web tests for the new hosted slice
+
+  Validation:
+  - PYTHONPATH=$PWD /usr/local/bin/python3 -m pytest -q tests/services/hosted/test_workspace_import_planning_service.py tests/api/test_workspace_import_plan.py
+  - cd web && npm test -- --run src/App.test.jsx
+files_changed:
+  - api/app.py
+  - services/hosted/workspace_import_planning_service.py
+  - services/hosted/__init__.py
+  - web/src/App.jsx
+  - web/src/App.test.jsx
+  - tests/services/hosted/test_workspace_import_planning_service.py
+  - tests/api/test_workspace_import_plan.py
+  - docs/PROJECT_SPEC.md
+  - docs/status/CHANGELOG.md
+```
+
+```yaml
 id: 2026-03-29-03
 type: fix
 areas: [api, database, docs, tests]

--- a/services/hosted/__init__.py
+++ b/services/hosted/__init__.py
@@ -1,8 +1,32 @@
 """Hosted backend and migration helpers."""
 
-from services.hosted.account_bootstrap_service import (
-	HostedAccountBootstrapService,
-	HostedBootstrapSummary,
-)
+__all__ = [
+	"HostedAccountBootstrapService",
+	"HostedBootstrapSummary",
+	"HostedWorkspaceImportPlanningService",
+	"HostedWorkspaceImportPlanningSummary",
+]
 
-__all__ = ["HostedAccountBootstrapService", "HostedBootstrapSummary"]
+
+def __getattr__(name: str):
+	if name in {"HostedAccountBootstrapService", "HostedBootstrapSummary"}:
+		from services.hosted.account_bootstrap_service import (
+			HostedAccountBootstrapService,
+			HostedBootstrapSummary,
+		)
+
+		return {
+			"HostedAccountBootstrapService": HostedAccountBootstrapService,
+			"HostedBootstrapSummary": HostedBootstrapSummary,
+		}[name]
+	if name in {"HostedWorkspaceImportPlanningService", "HostedWorkspaceImportPlanningSummary"}:
+		from services.hosted.workspace_import_planning_service import (
+			HostedWorkspaceImportPlanningService,
+			HostedWorkspaceImportPlanningSummary,
+		)
+
+		return {
+			"HostedWorkspaceImportPlanningService": HostedWorkspaceImportPlanningService,
+			"HostedWorkspaceImportPlanningSummary": HostedWorkspaceImportPlanningSummary,
+		}[name]
+	raise AttributeError(name)

--- a/services/hosted/workspace_import_planning_service.py
+++ b/services/hosted/workspace_import_planning_service.py
@@ -1,0 +1,97 @@
+"""Hosted workspace import-planning flow for authenticated users."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from repositories.hosted_account_repository import HostedAccountRepository
+from repositories.hosted_workspace_repository import HostedWorkspaceRepository
+from services.hosted.models import HostedWorkspace
+from services.hosted.sqlite_migration_inventory_service import (
+    SQLiteMigrationInventory,
+    SQLiteMigrationInventoryService,
+)
+
+
+@dataclass(frozen=True)
+class HostedWorkspaceImportPlanningSummary:
+    workspace: HostedWorkspace
+    status: str
+    detail: str
+    source_db_configured: bool
+    source_db_accessible: bool
+    inventory: SQLiteMigrationInventory | None
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "status": self.status,
+            "detail": self.detail,
+            "source_db_configured": self.source_db_configured,
+            "source_db_accessible": self.source_db_accessible,
+            "workspace": {
+                "id": self.workspace.id,
+                "account_id": self.workspace.account_id,
+                "name": self.workspace.name,
+                "source_db_path": self.workspace.source_db_path,
+            },
+            "inventory": self.inventory.to_dict() if self.inventory else None,
+        }
+
+
+class HostedWorkspaceImportPlanningService:
+    def __init__(self, session_factory, *, inventory_service: SQLiteMigrationInventoryService | None = None) -> None:
+        self.session_factory = session_factory
+        self.account_repository = HostedAccountRepository()
+        self.workspace_repository = HostedWorkspaceRepository()
+        self.inventory_service = inventory_service or SQLiteMigrationInventoryService()
+
+    def plan_import(self, *, supabase_user_id: str) -> HostedWorkspaceImportPlanningSummary:
+        with self.session_factory() as session:
+            account = self.account_repository.get_by_supabase_user_id(session, supabase_user_id)
+            if account is None:
+                raise LookupError("Hosted workspace bootstrap must complete before import planning.")
+
+            workspace = self.workspace_repository.get_by_account_id(session, account.id)
+            if workspace is None:
+                raise LookupError("Hosted workspace bootstrap must complete before import planning.")
+
+        source_db_path = (workspace.source_db_path or "").strip() if workspace.source_db_path else ""
+        if not source_db_path:
+            return HostedWorkspaceImportPlanningSummary(
+                workspace=workspace,
+                status="source-db-path-missing",
+                detail="No source SQLite database path is recorded for this hosted workspace yet.",
+                source_db_configured=False,
+                source_db_accessible=False,
+                inventory=None,
+            )
+
+        try:
+            inventory = self.inventory_service.inspect_database(source_db_path)
+        except FileNotFoundError:
+            return HostedWorkspaceImportPlanningSummary(
+                workspace=workspace,
+                status="source-db-not-found",
+                detail="The recorded source SQLite database path is not accessible to this API deployment.",
+                source_db_configured=True,
+                source_db_accessible=False,
+                inventory=None,
+            )
+        except Exception:
+            return HostedWorkspaceImportPlanningSummary(
+                workspace=workspace,
+                status="inspection-failed",
+                detail="SQLite import planning failed during inspection. Hosted state was not changed.",
+                source_db_configured=True,
+                source_db_accessible=False,
+                inventory=None,
+            )
+
+        return HostedWorkspaceImportPlanningSummary(
+            workspace=workspace,
+            status="ready",
+            detail="Workspace import planning inventory is ready.",
+            source_db_configured=True,
+            source_db_accessible=True,
+            inventory=inventory,
+        )

--- a/tests/api/test_workspace_import_plan.py
+++ b/tests/api/test_workspace_import_plan.py
@@ -1,0 +1,81 @@
+from fastapi.testclient import TestClient
+
+from api.app import app, get_hosted_workspace_import_planning_service
+from api.auth import AuthenticatedSession, get_authenticated_session
+
+
+client = TestClient(app)
+
+
+def test_workspace_import_plan_endpoint_returns_readiness_summary() -> None:
+    class StubPlanningService:
+        def plan_import(self, *, supabase_user_id: str):
+            return {
+                "status": "ready",
+                "detail": "Workspace import planning inventory is ready.",
+                "source_db_configured": True,
+                "source_db_accessible": True,
+                "workspace": {
+                    "id": "workspace-123",
+                    "account_id": "account-123",
+                    "name": "owner@sezzions.com Workspace",
+                    "source_db_path": "/tmp/sezzions.db",
+                },
+                "inventory": {
+                    "db_path": "/tmp/sezzions.db",
+                    "db_size_bytes": 1024,
+                    "schema_version_count": 1,
+                    "tables": [{"table_name": "users", "row_count": 4}],
+                    "active_user_names": ["Elliot"],
+                    "site_names": ["Stake"],
+                },
+            }
+
+    app.dependency_overrides[get_authenticated_session] = lambda: AuthenticatedSession(
+        user_id="user-123",
+        email="owner@sezzions.com",
+        audience="authenticated",
+        role="authenticated",
+    )
+    app.dependency_overrides[get_hosted_workspace_import_planning_service] = (
+        lambda: StubPlanningService()
+    )
+
+    try:
+        response = client.get("/v1/workspace/import-plan")
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "ready"
+    assert response.json()["inventory"]["active_user_names"] == ["Elliot"]
+
+
+def test_workspace_import_plan_endpoint_requires_bearer_auth() -> None:
+    response = client.get("/v1/workspace/import-plan")
+
+    assert response.status_code == 401
+
+
+def test_workspace_import_plan_endpoint_requires_existing_workspace() -> None:
+    class MissingWorkspacePlanningService:
+        def plan_import(self, *, supabase_user_id: str):
+            raise LookupError("Hosted workspace bootstrap must complete before import planning.")
+
+    app.dependency_overrides[get_authenticated_session] = lambda: AuthenticatedSession(
+        user_id="user-123",
+        email="owner@sezzions.com",
+        audience="authenticated",
+        role="authenticated",
+    )
+    app.dependency_overrides[get_hosted_workspace_import_planning_service] = (
+        lambda: MissingWorkspacePlanningService()
+    )
+
+    try:
+        response = client.get("/v1/workspace/import-plan")
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "Hosted workspace bootstrap must complete before import planning."

--- a/tests/services/hosted/test_workspace_import_planning_service.py
+++ b/tests/services/hosted/test_workspace_import_planning_service.py
@@ -1,0 +1,176 @@
+import sqlite3
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from repositories.hosted_account_repository import HostedAccountRepository
+from repositories.hosted_workspace_repository import HostedWorkspaceRepository
+from services.hosted.persistence import HostedBase
+from services.hosted.workspace_import_planning_service import (
+    HostedWorkspaceImportPlanningService,
+)
+
+
+def _session_factory():
+    engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+    HostedBase.metadata.create_all(engine)
+    return engine, sessionmaker(bind=engine, expire_on_commit=False)
+
+
+def _create_inventory_db(db_path: Path) -> None:
+    connection = sqlite3.connect(db_path)
+    try:
+        connection.execute("CREATE TABLE schema_version (version INTEGER PRIMARY KEY)")
+        connection.execute("INSERT INTO schema_version (version) VALUES (1)")
+        connection.execute(
+            "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL, is_active INTEGER DEFAULT 1)"
+        )
+        connection.execute(
+            "CREATE TABLE sites (id INTEGER PRIMARY KEY, name TEXT NOT NULL, is_active INTEGER DEFAULT 1)"
+        )
+        connection.execute("INSERT INTO users (name, is_active) VALUES ('Elliot', 1)")
+        connection.execute("INSERT INTO sites (name, is_active) VALUES ('Stake', 1)")
+        connection.commit()
+    finally:
+        connection.close()
+
+
+def test_plan_import_returns_inventory_for_accessible_source_db(tmp_path: Path) -> None:
+    db_path = tmp_path / "seed.db"
+    _create_inventory_db(db_path)
+
+    engine, session_factory = _session_factory()
+    try:
+        with session_factory() as session:
+            account = HostedAccountRepository().create(
+                session,
+                owner_email="owner@sezzions.com",
+                supabase_user_id="user-123",
+            )
+            HostedWorkspaceRepository().create(
+                session,
+                account_id=account.id,
+                name="owner@sezzions.com Workspace",
+                source_db_path=str(db_path),
+            )
+            session.commit()
+
+        summary = HostedWorkspaceImportPlanningService(session_factory).plan_import(
+            supabase_user_id="user-123"
+        )
+    finally:
+        engine.dispose()
+
+    assert summary.status == "ready"
+    assert summary.source_db_configured is True
+    assert summary.source_db_accessible is True
+    assert summary.inventory is not None
+    assert summary.inventory.active_user_names == ["Elliot"]
+    assert summary.inventory.site_names == ["Stake"]
+
+
+def test_plan_import_reports_missing_source_db_path() -> None:
+    engine, session_factory = _session_factory()
+    try:
+        with session_factory() as session:
+            account = HostedAccountRepository().create(
+                session,
+                owner_email="owner@sezzions.com",
+                supabase_user_id="user-123",
+            )
+            HostedWorkspaceRepository().create(
+                session,
+                account_id=account.id,
+                name="owner@sezzions.com Workspace",
+            )
+            session.commit()
+
+        summary = HostedWorkspaceImportPlanningService(session_factory).plan_import(
+            supabase_user_id="user-123"
+        )
+    finally:
+        engine.dispose()
+
+    assert summary.status == "source-db-path-missing"
+    assert summary.source_db_configured is False
+    assert summary.source_db_accessible is False
+    assert summary.inventory is None
+
+
+def test_plan_import_reports_missing_source_file(tmp_path: Path) -> None:
+    missing_path = tmp_path / "missing.db"
+    engine, session_factory = _session_factory()
+    try:
+        with session_factory() as session:
+            account = HostedAccountRepository().create(
+                session,
+                owner_email="owner@sezzions.com",
+                supabase_user_id="user-123",
+            )
+            HostedWorkspaceRepository().create(
+                session,
+                account_id=account.id,
+                name="owner@sezzions.com Workspace",
+                source_db_path=str(missing_path),
+            )
+            session.commit()
+
+        summary = HostedWorkspaceImportPlanningService(session_factory).plan_import(
+            supabase_user_id="user-123"
+        )
+    finally:
+        engine.dispose()
+
+    assert summary.status == "source-db-not-found"
+    assert summary.source_db_configured is True
+    assert summary.source_db_accessible is False
+    assert summary.inventory is None
+
+
+def test_plan_import_reports_safe_failure_when_inventory_inspection_breaks(tmp_path: Path) -> None:
+    db_path = tmp_path / "seed.db"
+    _create_inventory_db(db_path)
+
+    class ExplodingInventoryService:
+        def inspect_database(self, db_path: str):
+            raise RuntimeError("boom")
+
+    engine, session_factory = _session_factory()
+    try:
+        with session_factory() as session:
+            account = HostedAccountRepository().create(
+                session,
+                owner_email="owner@sezzions.com",
+                supabase_user_id="user-123",
+            )
+            HostedWorkspaceRepository().create(
+                session,
+                account_id=account.id,
+                name="owner@sezzions.com Workspace",
+                source_db_path=str(db_path),
+            )
+            session.commit()
+
+        summary = HostedWorkspaceImportPlanningService(
+            session_factory,
+            inventory_service=ExplodingInventoryService(),
+        ).plan_import(supabase_user_id="user-123")
+    finally:
+        engine.dispose()
+
+    assert summary.status == "inspection-failed"
+    assert summary.source_db_configured is True
+    assert summary.source_db_accessible is False
+    assert summary.inventory is None
+
+
+def test_plan_import_requires_existing_bootstrapped_workspace() -> None:
+    engine, session_factory = _session_factory()
+    try:
+        service = HostedWorkspaceImportPlanningService(session_factory)
+        with pytest.raises(LookupError):
+            service.plan_import(supabase_user_id="user-123")
+    finally:
+        engine.dispose()

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -42,6 +42,7 @@ const launchPlan = [
 export default function App() {
   const [sessionEmail, setSessionEmail] = useState(null);
   const [hostedSummary, setHostedSummary] = useState(null);
+  const [importPlanSummary, setImportPlanSummary] = useState(null);
   const [authMessage, setAuthMessage] = useState(
     supabaseConfigured ? "Sign in with Google to activate the hosted web shell." : supabaseConfigError
   );
@@ -51,19 +52,64 @@ export default function App() {
   const [hostedStatus, setHostedStatus] = useState(
     "Hosted account bootstrap will run after the protected API handshake."
   );
+  const [importPlanStatus, setImportPlanStatus] = useState(
+    "Hosted import planning will run after workspace bootstrap."
+  );
   const apiBaseUrl = import.meta.env.VITE_API_BASE_URL?.trim() || null;
   const supabaseApiKey = import.meta.env.VITE_SUPABASE_ANON_KEY?.trim() || null;
+
+  async function syncWorkspaceImportPlan(nextSession) {
+    if (!nextSession?.access_token) {
+      setImportPlanSummary(null);
+      setImportPlanStatus("Hosted import planning will run after workspace bootstrap.");
+      return;
+    }
+
+    if (!apiBaseUrl) {
+      setImportPlanSummary(null);
+      setImportPlanStatus("Set VITE_API_BASE_URL to enable hosted import planning.");
+      return;
+    }
+
+    setImportPlanStatus("Loading hosted workspace import planning status...");
+
+    try {
+      const response = await fetch(`${apiBaseUrl}/v1/workspace/import-plan`, {
+        headers: {
+          Authorization: `Bearer ${nextSession.access_token}`,
+          ...(supabaseApiKey ? { apikey: supabaseApiKey } : {})
+        }
+      });
+
+      if (!response.ok) {
+        setImportPlanSummary(null);
+        setImportPlanStatus(`Hosted import planning failed (${response.status}).`);
+        return;
+      }
+
+      const data = await response.json();
+      setImportPlanSummary(data);
+      setImportPlanStatus(data.detail || "Hosted import planning is ready.");
+    } catch (error) {
+      setImportPlanSummary(null);
+      setImportPlanStatus(error instanceof Error ? error.message : "Hosted import planning failed.");
+    }
+  }
 
   async function syncHostedBootstrap(nextSession) {
     if (!nextSession?.access_token) {
       setHostedSummary(null);
       setHostedStatus("Hosted account bootstrap will run after the protected API handshake.");
+      setImportPlanSummary(null);
+      setImportPlanStatus("Hosted import planning will run after workspace bootstrap.");
       return;
     }
 
     if (!apiBaseUrl) {
       setHostedSummary(null);
       setHostedStatus("Set VITE_API_BASE_URL to enable hosted account bootstrap.");
+      setImportPlanSummary(null);
+      setImportPlanStatus("Set VITE_API_BASE_URL to enable hosted import planning.");
       return;
     }
 
@@ -80,6 +126,8 @@ export default function App() {
 
       if (!response.ok) {
         setHostedSummary(null);
+        setImportPlanSummary(null);
+        setImportPlanStatus("Hosted import planning will run after workspace bootstrap.");
         setHostedStatus(`Hosted account bootstrap failed (${response.status}).`);
         return;
       }
@@ -91,8 +139,11 @@ export default function App() {
           ? "Hosted account workspace created and ready."
           : "Hosted account workspace ready."
       );
+      await syncWorkspaceImportPlan(nextSession);
     } catch (error) {
       setHostedSummary(null);
+      setImportPlanSummary(null);
+      setImportPlanStatus("Hosted import planning will run after workspace bootstrap.");
       setHostedStatus(error instanceof Error ? error.message : "Hosted account bootstrap failed.");
     }
   }
@@ -102,6 +153,8 @@ export default function App() {
       setApiStatus("Protected API handshake will run after Google sign-in.");
       setHostedSummary(null);
       setHostedStatus("Hosted account bootstrap will run after the protected API handshake.");
+      setImportPlanSummary(null);
+      setImportPlanStatus("Hosted import planning will run after workspace bootstrap.");
       return;
     }
 
@@ -109,6 +162,8 @@ export default function App() {
       setApiStatus("Set VITE_API_BASE_URL to enable the protected API handshake.");
       setHostedSummary(null);
       setHostedStatus("Set VITE_API_BASE_URL to enable hosted account bootstrap.");
+      setImportPlanSummary(null);
+      setImportPlanStatus("Set VITE_API_BASE_URL to enable hosted import planning.");
       return;
     }
 
@@ -135,6 +190,8 @@ export default function App() {
     } catch (error) {
       setHostedSummary(null);
       setHostedStatus("Hosted account bootstrap will run after the protected API handshake.");
+      setImportPlanSummary(null);
+      setImportPlanStatus("Hosted import planning will run after workspace bootstrap.");
       setApiStatus(error instanceof Error ? error.message : "Protected API handshake failed.");
     }
   }
@@ -216,9 +273,11 @@ export default function App() {
 
     setSessionEmail(null);
     setHostedSummary(null);
+    setImportPlanSummary(null);
     setAuthMessage("Signed out. Sign in with Google to reactivate the hosted web shell.");
     setApiStatus("Protected API handshake will run after Google sign-in.");
     setHostedStatus("Hosted account bootstrap will run after the protected API handshake.");
+    setImportPlanStatus("Hosted import planning will run after workspace bootstrap.");
   }
 
   return (
@@ -267,6 +326,10 @@ export default function App() {
             <div>
               <dt>Hosted bootstrap</dt>
               <dd>{hostedStatus}</dd>
+            </div>
+            <div>
+              <dt>Import planning</dt>
+              <dd>{importPlanStatus}</dd>
             </div>
           </dl>
           {sessionEmail ? (
@@ -319,8 +382,8 @@ export default function App() {
             ))}
           </ol>
           <p className="launch-note">
-            After Google sign-in is live, the next slice is a protected call into the Render API
-            and then the first controlled import of desktop data from the local SQLite source.
+            After Google sign-in is live, the next slice is a protected import-planning pass that
+            reports whether this hosted workspace has an inspectable SQLite migration source.
           </p>
         </section>
 
@@ -350,6 +413,39 @@ export default function App() {
             </dl>
           ) : (
             <p className="launch-note">{hostedStatus}</p>
+          )}
+        </section>
+
+        <section className="panel launch-panel">
+          <div className="panel-head">
+            <p className="panel-kicker">Import planning</p>
+            <h2>Hosted workspace import readiness</h2>
+          </div>
+          {importPlanSummary ? (
+            <dl className="aside-meta">
+              <div>
+                <dt>Planning status</dt>
+                <dd>{importPlanSummary.status}</dd>
+              </div>
+              <div>
+                <dt>Planning detail</dt>
+                <dd>{importPlanSummary.detail}</dd>
+              </div>
+              <div>
+                <dt>Source DB path</dt>
+                <dd>{importPlanSummary.workspace?.source_db_path || "Not recorded"}</dd>
+              </div>
+              <div>
+                <dt>Active users discovered</dt>
+                <dd>{importPlanSummary.inventory?.active_user_names?.join(", ") || "None"}</dd>
+              </div>
+              <div>
+                <dt>Sites discovered</dt>
+                <dd>{importPlanSummary.inventory?.site_names?.join(", ") || "None"}</dd>
+              </div>
+            </dl>
+          ) : (
+            <p className="launch-note">{importPlanStatus}</p>
           )}
         </section>
       </main>

--- a/web/src/App.test.jsx
+++ b/web/src/App.test.jsx
@@ -49,6 +49,25 @@ describe("App", () => {
     authMocks.signInWithOAuth.mockResolvedValue({ error: null });
     authMocks.signOut.mockResolvedValue({ error: null });
     global.fetch = vi.fn().mockImplementation(async (url) => {
+      if (url === "https://api.sezzions.test/v1/workspace/import-plan") {
+        return {
+          ok: true,
+          json: async () => ({
+            status: "source-db-path-missing",
+            detail: "No source SQLite database path is recorded for this hosted workspace yet.",
+            source_db_configured: false,
+            source_db_accessible: false,
+            workspace: {
+              id: "workspace-123",
+              account_id: "account-123",
+              name: "owner@sezzions.com Workspace",
+              source_db_path: null
+            },
+            inventory: null
+          })
+        };
+      }
+
       if (url === "https://api.sezzions.test/v1/account/bootstrap") {
         return {
           ok: true,
@@ -187,6 +206,22 @@ describe("App", () => {
             source_db_path: null
           }
         })
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          status: "source-db-path-missing",
+          detail: "No source SQLite database path is recorded for this hosted workspace yet.",
+          source_db_configured: false,
+          source_db_accessible: false,
+          workspace: {
+            id: "workspace-123",
+            account_id: "account-123",
+            name: "owner@sezzions.com Workspace",
+            source_db_path: null
+          },
+          inventory: null
+        })
       });
 
     render(<App />);
@@ -208,9 +243,26 @@ describe("App", () => {
       name: /authenticated workspace bootstrap/i
     });
     const hostedSection = hostedHeading.closest("section");
+    const importHeading = await screen.findByRole("heading", {
+      name: /hosted workspace import readiness/i
+    });
+    const importSection = importHeading.closest("section");
 
     expect(hostedSection).not.toBeNull();
+    expect(importSection).not.toBeNull();
     expect(within(hostedSection).getByText(/hosted account owner/i)).toBeInTheDocument();
     expect(within(hostedSection).getByText("owner@sezzions.com Workspace")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenNthCalledWith(
+        3,
+        "https://api.sezzions.test/v1/workspace/import-plan",
+        {
+          headers: {
+            Authorization: "Bearer access-token-123"
+          }
+        }
+      );
+    });
+    expect(within(importSection).getByText(/no source sqlite database path is recorded/i)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
Implement issue #214 by adding the next hosted product slice after workspace bootstrap: protected import-planning status and read-only SQLite inventory reporting when the source path is accessible to the API process.

## Changes
- add `GET /v1/workspace/import-plan`
- add hosted workspace import-planning service and tests
- render import planning status and inventory in the staged web shell after bootstrap
- update the spec and changelog with the real API accessibility constraint

## Validation
- `PYTHONPATH=$PWD /usr/local/bin/python3 -m pytest -q tests/services/hosted/test_workspace_import_planning_service.py tests/api/test_workspace_import_plan.py`
- `cd web && npm test -- --run src/App.test.jsx`

## Pitfalls / Follow-ups
- a deployed browser flow still cannot directly inspect a user local SQLite file without a later desktop-assisted bridge or upload flow
- this slice reports readiness safely but does not perform any hosted business-data import yet
