### PR TITLE
Add temporary hosted SQLite upload planning

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
-from fastapi import Depends, FastAPI, HTTPException, status
+from fastapi import Depends, FastAPI, File, HTTPException, UploadFile, status
 from fastapi.middleware.cors import CORSMiddleware
 
 from api.auth import AuthenticatedSession, get_authenticated_session
 from api.config import HostedConfigurationError, load_hosted_backend_config
 from services.hosted.account_bootstrap_service import HostedAccountBootstrapService
 from services.hosted.persistence import get_hosted_session_factory
+from services.hosted.uploaded_sqlite_inspection_service import (
+    HostedUploadedSQLiteInspectionService,
+)
 from services.hosted.workspace_import_planning_service import (
     HostedWorkspaceImportPlanningService,
 )
@@ -47,6 +50,10 @@ def get_hosted_workspace_import_planning_service() -> HostedWorkspaceImportPlann
 
     session_factory = get_hosted_session_factory(config.sqlalchemy_url)
     return HostedWorkspaceImportPlanningService(session_factory)
+
+
+def get_hosted_uploaded_sqlite_inspection_service() -> HostedUploadedSQLiteInspectionService:
+    return HostedUploadedSQLiteInspectionService()
 
 
 @app.get("/healthz")
@@ -100,5 +107,25 @@ def workspace_import_plan(
         summary = service.plan_import(supabase_user_id=session.user_id)
     except LookupError as exc:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+
+    return summary.as_dict() if hasattr(summary, "as_dict") else summary
+
+
+@app.post("/v1/workspace/import-upload-plan")
+async def workspace_import_upload_plan(
+    session: AuthenticatedSession = Depends(get_authenticated_session),
+    sqlite_db: UploadFile = File(...),
+    service: HostedUploadedSQLiteInspectionService = Depends(get_hosted_uploaded_sqlite_inspection_service),
+) -> dict[str, object]:
+    del session
+    try:
+        summary = service.inspect_upload(
+            filename=sqlite_db.filename or "uploaded.sqlite",
+            fileobj=sqlite_db.file,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    finally:
+        await sqlite_db.close()
 
     return summary.as_dict() if hasattr(summary, "as_dict") else summary

--- a/docs/PROJECT_SPEC.md
+++ b/docs/PROJECT_SPEC.md
@@ -149,6 +149,11 @@ Hosted backend foundation (Issue #203):
 - If the hosted workspace records a SQLite path that is not accessible to the API deployment, the endpoint must return a safe actionable status instead of failing.
 - The hosted API must never claim that a browser-only hosted flow can directly inspect an end user's local SQLite file unless that file has been made accessible to the API process by a later desktop-assisted or upload-based bridge.
 - After hosted bootstrap succeeds, the web shell should call `GET /v1/workspace/import-plan` and render the resulting import-planning status and any available inventory summary.
+- The temporary operator-only bridge after hosted import planning is `POST /v1/workspace/import-upload-plan`.
+- `POST /v1/workspace/import-upload-plan` must require a bearer token and accept a browser-uploaded SQLite file as multipart form data for read-only inspection.
+- The upload-planning endpoint must write the uploaded file to a temporary location only long enough to inspect it, return a read-only inventory summary, and delete the temporary file afterward.
+- Invalid, empty, or unreadable uploads must fail safely with an actionable `400` response and must not create hosted business-domain records.
+- The staged web frontend may expose this as a temporary authenticated migration page at `/migration` rather than productizing it as a permanent customer-facing workflow.
 - The hosted API must permit CORS preflight and authenticated browser requests from `https://dev.sezzions.com` and `http://localhost:5173` by default, with environment override support for additional origins.
 - If direct local JWT decoding is not compatible with the live Supabase token format, the API may validate the bearer token through Supabase's `/auth/v1/user` endpoint before returning `401`.
 - The `/auth/v1/user` validation fallback must include a Supabase publishable/anon key, either from hosted backend configuration or from the web client's protected handshake request.

--- a/docs/archive/2026-03-29-issue-hosted-sqlite-upload-planning.md
+++ b/docs/archive/2026-03-29-issue-hosted-sqlite-upload-planning.md
@@ -1,0 +1,62 @@
+## Summary
+Add a temporary authenticated web migration page that lets the current operator upload a local Sezzions SQLite database to the hosted API for read-only inspection and migration planning.
+
+## Problem
+The current hosted import-planning endpoint can only inspect a `source_db_path` that is accessible to the API process. That is correct for a deployed backend, but it does not solve the actual one-user migration bridge needed right now: getting the local desktop SQLite database into the hosted flow without productizing a permanent desktop sync feature.
+
+## Proposal
+Implement a temporary hosted migration surface that:
+- adds a separate authenticated migration page in the web app
+- accepts a SQLite `.db` file upload from the browser
+- sends the uploaded file to the hosted API for read-only inspection
+- returns the same planning/inventory summary the existing SQLite inventory service already knows how to produce
+- does not perform the hosted business-data import yet
+
+## Scope
+In scope:
+- protected upload-based API endpoint for read-only SQLite inspection
+- temporary file handling in the hosted API for inspection only
+- separate migration/upload page or route in the web app
+- focused tests for valid upload, invalid file, and failure handling
+- docs/changelog updates
+
+Out of scope:
+- actual record import into hosted business tables
+- background jobs or resumable upload processing
+- multi-user polished admin tooling
+- long-term desktop sync architecture
+
+## Acceptance Criteria
+- an authenticated user can open a dedicated migration/upload page in the web app
+- the page accepts a SQLite database file and sends it to the hosted API
+- the API inspects the uploaded file read-only and returns planning inventory data
+- invalid or unreadable uploads fail safely with an actionable message
+- temporary files are not treated as persistent hosted state
+- no business-domain rows are imported yet
+
+## Test Matrix
+Happy path:
+- authenticated upload of a valid SQLite file returns inventory summary
+
+Edge cases:
+- uploaded file is not a SQLite database
+- uploaded file is empty or unreadable
+
+Failure injection:
+- inspection fails after temporary file creation and the API returns a safe error without persisting hosted business data
+
+Invariants:
+- request still requires bearer auth
+- hosted account/workspace identity remains unchanged
+- no hosted business-domain rows are created
+
+## Manual Verification
+- sign in on staged web
+- navigate to the migration/upload page
+- upload a real Sezzions SQLite file
+- confirm the UI shows read-only planning inventory or a safe actionable error
+
+## Labels
+- feature
+- status:ready
+- type:feature

--- a/docs/status/CHANGELOG.md
+++ b/docs/status/CHANGELOG.md
@@ -12,6 +12,40 @@ Rules:
 ## 2026-03-29
 
 ```yaml
+id: 2026-03-29-05
+type: feat
+areas: [api, web, docs, tests]
+issue: 216
+summary: "Add a temporary hosted SQLite upload planning page"
+details: >
+  Added a pragmatic one-user migration bridge for the hosted rollout: an
+  authenticated web migration page and protected API endpoint that accept a
+  SQLite upload, inspect it read-only through the existing inventory service,
+  and return planning data without performing any hosted business-data import.
+
+  Implemented:
+  - `POST /v1/workspace/import-upload-plan` multipart upload inspection endpoint
+  - temporary uploaded-SQLite inspection service with temp-file cleanup
+  - staged `/migration` page for authenticated SQLite upload planning
+  - focused service, API, and web tests for the upload bridge
+
+  Validation:
+  - PYTHONPATH=$PWD /usr/local/bin/python3 -m pytest -q tests/services/hosted/test_uploaded_sqlite_inspection_service.py tests/api/test_workspace_import_upload.py
+  - cd web && npm test -- --run src/App.test.jsx
+files_changed:
+  - api/app.py
+  - services/hosted/uploaded_sqlite_inspection_service.py
+  - services/hosted/__init__.py
+  - requirements.txt
+  - web/src/App.jsx
+  - web/src/App.test.jsx
+  - tests/services/hosted/test_uploaded_sqlite_inspection_service.py
+  - tests/api/test_workspace_import_upload.py
+  - docs/PROJECT_SPEC.md
+  - docs/status/CHANGELOG.md
+```
+
+```yaml
 id: 2026-03-29-04
 type: feat
 areas: [api, web, docs, tests]

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ pydantic>=2.5.0
 fastapi>=0.115.0
 uvicorn>=0.30.0
 httpx>=0.27.0
+python-multipart>=0.0.9
 PyJWT[crypto]>=2.10.0
 
 # Testing

--- a/services/hosted/__init__.py
+++ b/services/hosted/__init__.py
@@ -3,6 +3,8 @@
 __all__ = [
 	"HostedAccountBootstrapService",
 	"HostedBootstrapSummary",
+	"HostedUploadedSQLiteInspectionService",
+	"HostedUploadedSQLiteInspectionSummary",
 	"HostedWorkspaceImportPlanningService",
 	"HostedWorkspaceImportPlanningSummary",
 ]
@@ -18,6 +20,16 @@ def __getattr__(name: str):
 		return {
 			"HostedAccountBootstrapService": HostedAccountBootstrapService,
 			"HostedBootstrapSummary": HostedBootstrapSummary,
+		}[name]
+	if name in {"HostedUploadedSQLiteInspectionService", "HostedUploadedSQLiteInspectionSummary"}:
+		from services.hosted.uploaded_sqlite_inspection_service import (
+			HostedUploadedSQLiteInspectionService,
+			HostedUploadedSQLiteInspectionSummary,
+		)
+
+		return {
+			"HostedUploadedSQLiteInspectionService": HostedUploadedSQLiteInspectionService,
+			"HostedUploadedSQLiteInspectionSummary": HostedUploadedSQLiteInspectionSummary,
 		}[name]
 	if name in {"HostedWorkspaceImportPlanningService", "HostedWorkspaceImportPlanningSummary"}:
 		from services.hosted.workspace_import_planning_service import (

--- a/services/hosted/uploaded_sqlite_inspection_service.py
+++ b/services/hosted/uploaded_sqlite_inspection_service.py
@@ -1,0 +1,67 @@
+"""Read-only inspection of uploaded SQLite files for hosted migration planning."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+
+from services.hosted.sqlite_migration_inventory_service import (
+    SQLiteMigrationInventory,
+    SQLiteMigrationInventoryService,
+)
+
+
+@dataclass(frozen=True)
+class HostedUploadedSQLiteInspectionSummary:
+    status: str
+    detail: str
+    uploaded_filename: str
+    inventory: SQLiteMigrationInventory | None
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "status": self.status,
+            "detail": self.detail,
+            "uploaded_filename": self.uploaded_filename,
+            "inventory": self.inventory.to_dict() if self.inventory else None,
+        }
+
+
+class HostedUploadedSQLiteInspectionService:
+    def __init__(self, *, inventory_service: SQLiteMigrationInventoryService | None = None) -> None:
+        self.inventory_service = inventory_service or SQLiteMigrationInventoryService()
+
+    def inspect_upload(self, *, filename: str, fileobj) -> HostedUploadedSQLiteInspectionSummary:
+        uploaded_filename = (filename or "uploaded.sqlite").strip() or "uploaded.sqlite"
+
+        with NamedTemporaryFile(prefix="sezzions-upload-", suffix=".db", delete=False) as temp_file:
+            temp_path = Path(temp_file.name)
+            while True:
+                chunk = fileobj.read(1024 * 1024)
+                if not chunk:
+                    break
+                temp_file.write(chunk)
+
+        try:
+            if temp_path.stat().st_size == 0:
+                raise ValueError("Uploaded SQLite file is empty.")
+
+            try:
+                inventory = self.inventory_service.inspect_database(str(temp_path))
+            except ValueError:
+                raise
+            except Exception as exc:
+                message = str(exc).lower()
+                if "file is not a database" in message or "database disk image is malformed" in message:
+                    raise ValueError("Uploaded file is not a readable SQLite database.") from exc
+                raise ValueError("Uploaded SQLite inspection failed.") from exc
+
+            return HostedUploadedSQLiteInspectionSummary(
+                status="ready",
+                detail="Uploaded SQLite inventory is ready.",
+                uploaded_filename=uploaded_filename,
+                inventory=inventory,
+            )
+        finally:
+            temp_path.unlink(missing_ok=True)

--- a/tests/api/test_workspace_import_upload.py
+++ b/tests/api/test_workspace_import_upload.py
@@ -1,0 +1,79 @@
+from fastapi.testclient import TestClient
+
+from api.app import app, get_hosted_uploaded_sqlite_inspection_service
+from api.auth import AuthenticatedSession, get_authenticated_session
+
+
+client = TestClient(app)
+
+
+def test_workspace_import_upload_endpoint_returns_inventory_summary() -> None:
+    class StubUploadService:
+        def inspect_upload(self, *, filename: str, fileobj):
+            return {
+                "status": "ready",
+                "detail": "Uploaded SQLite inventory is ready.",
+                "uploaded_filename": filename,
+                "inventory": {
+                    "db_path": "/tmp/upload.db",
+                    "db_size_bytes": 1024,
+                    "schema_version_count": 1,
+                    "tables": [{"table_name": "users", "row_count": 1}],
+                    "active_user_names": ["Elliot"],
+                    "site_names": ["Stake"],
+                },
+            }
+
+    app.dependency_overrides[get_authenticated_session] = lambda: AuthenticatedSession(
+        user_id="user-123",
+        email="owner@sezzions.com",
+        audience="authenticated",
+        role="authenticated",
+    )
+    app.dependency_overrides[get_hosted_uploaded_sqlite_inspection_service] = lambda: StubUploadService()
+
+    try:
+        response = client.post(
+            "/v1/workspace/import-upload-plan",
+            files={"sqlite_db": ("sezzions.db", b"sqlite-bytes", "application/octet-stream")},
+        )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "ready"
+    assert response.json()["uploaded_filename"] == "sezzions.db"
+
+
+def test_workspace_import_upload_endpoint_requires_bearer_auth() -> None:
+    response = client.post(
+        "/v1/workspace/import-upload-plan",
+        files={"sqlite_db": ("sezzions.db", b"sqlite-bytes", "application/octet-stream")},
+    )
+
+    assert response.status_code == 401
+
+
+def test_workspace_import_upload_endpoint_returns_400_for_invalid_upload() -> None:
+    class RejectingUploadService:
+        def inspect_upload(self, *, filename: str, fileobj):
+            raise ValueError("Uploaded file is not a readable SQLite database.")
+
+    app.dependency_overrides[get_authenticated_session] = lambda: AuthenticatedSession(
+        user_id="user-123",
+        email="owner@sezzions.com",
+        audience="authenticated",
+        role="authenticated",
+    )
+    app.dependency_overrides[get_hosted_uploaded_sqlite_inspection_service] = lambda: RejectingUploadService()
+
+    try:
+        response = client.post(
+            "/v1/workspace/import-upload-plan",
+            files={"sqlite_db": ("bad.db", b"bad-bytes", "application/octet-stream")},
+        )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Uploaded file is not a readable SQLite database."

--- a/tests/services/hosted/test_uploaded_sqlite_inspection_service.py
+++ b/tests/services/hosted/test_uploaded_sqlite_inspection_service.py
@@ -1,0 +1,86 @@
+import io
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from services.hosted.uploaded_sqlite_inspection_service import (
+    HostedUploadedSQLiteInspectionService,
+)
+
+
+def _build_sqlite_bytes(tmp_path: Path) -> bytes:
+    db_path = tmp_path / "upload.db"
+    connection = sqlite3.connect(db_path)
+    try:
+        connection.execute("CREATE TABLE schema_version (version INTEGER PRIMARY KEY)")
+        connection.execute("INSERT INTO schema_version (version) VALUES (1)")
+        connection.execute(
+            "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL, is_active INTEGER DEFAULT 1)"
+        )
+        connection.execute(
+            "CREATE TABLE sites (id INTEGER PRIMARY KEY, name TEXT NOT NULL, is_active INTEGER DEFAULT 1)"
+        )
+        connection.execute("INSERT INTO users (name, is_active) VALUES ('Elliot', 1)")
+        connection.execute("INSERT INTO sites (name, is_active) VALUES ('Stake', 1)")
+        connection.commit()
+    finally:
+        connection.close()
+    return db_path.read_bytes()
+
+
+def test_inspect_upload_returns_inventory_and_cleans_up_temp_file(tmp_path: Path) -> None:
+    sqlite_bytes = _build_sqlite_bytes(tmp_path)
+    seen_paths: list[str] = []
+
+    class TrackingInventoryService:
+        def inspect_database(self, db_path: str):
+            seen_paths.append(db_path)
+            from services.hosted.sqlite_migration_inventory_service import SQLiteMigrationInventoryService
+
+            return SQLiteMigrationInventoryService().inspect_database(db_path)
+
+    summary = HostedUploadedSQLiteInspectionService(
+        inventory_service=TrackingInventoryService()
+    ).inspect_upload(filename="sezzions.db", fileobj=io.BytesIO(sqlite_bytes))
+
+    assert summary.status == "ready"
+    assert summary.uploaded_filename == "sezzions.db"
+    assert summary.inventory is not None
+    assert summary.inventory.active_user_names == ["Elliot"]
+    assert seen_paths
+    assert Path(seen_paths[0]).exists() is False
+
+
+def test_inspect_upload_rejects_empty_upload() -> None:
+    service = HostedUploadedSQLiteInspectionService()
+
+    with pytest.raises(ValueError, match="Uploaded SQLite file is empty"):
+        service.inspect_upload(filename="empty.db", fileobj=io.BytesIO(b""))
+
+
+def test_inspect_upload_raises_safe_error_for_invalid_sqlite_bytes() -> None:
+    service = HostedUploadedSQLiteInspectionService()
+
+    with pytest.raises(ValueError, match="Uploaded file is not a readable SQLite database"):
+        service.inspect_upload(filename="bad.db", fileobj=io.BytesIO(b"not-a-sqlite-db"))
+
+
+def test_inspect_upload_cleans_up_temp_file_when_inspection_fails(tmp_path: Path) -> None:
+    sqlite_bytes = _build_sqlite_bytes(tmp_path)
+    seen_paths: list[str] = []
+
+    class ExplodingInventoryService:
+        def inspect_database(self, db_path: str):
+            seen_paths.append(db_path)
+            raise RuntimeError("boom")
+
+    service = HostedUploadedSQLiteInspectionService(
+        inventory_service=ExplodingInventoryService()
+    )
+
+    with pytest.raises(ValueError, match="Uploaded SQLite inspection failed"):
+        service.inspect_upload(filename="sezzions.db", fileobj=io.BytesIO(sqlite_bytes))
+
+    assert seen_paths
+    assert Path(seen_paths[0]).exists() is False

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -40,9 +40,16 @@ const launchPlan = [
 ];
 
 export default function App() {
+  const currentPath = window.location.pathname.replace(/\/+$/, "") || "/";
+  const isMigrationPage = currentPath === "/migration";
   const [sessionEmail, setSessionEmail] = useState(null);
   const [hostedSummary, setHostedSummary] = useState(null);
   const [importPlanSummary, setImportPlanSummary] = useState(null);
+  const [uploadSummary, setUploadSummary] = useState(null);
+  const [uploadStatus, setUploadStatus] = useState(
+    "Upload a SQLite database to inspect it for hosted migration planning."
+  );
+  const [selectedUploadFile, setSelectedUploadFile] = useState(null);
   const [authMessage, setAuthMessage] = useState(
     supabaseConfigured ? "Sign in with Google to activate the hosted web shell." : supabaseConfigError
   );
@@ -57,6 +64,61 @@ export default function App() {
   );
   const apiBaseUrl = import.meta.env.VITE_API_BASE_URL?.trim() || null;
   const supabaseApiKey = import.meta.env.VITE_SUPABASE_ANON_KEY?.trim() || null;
+
+  async function handleMigrationUpload() {
+    if (!selectedUploadFile) {
+      setUploadSummary(null);
+      setUploadStatus("Choose a SQLite database file before uploading.");
+      return;
+    }
+
+    if (!apiBaseUrl) {
+      setUploadSummary(null);
+      setUploadStatus("Set VITE_API_BASE_URL to enable SQLite upload planning.");
+      return;
+    }
+
+    if (!supabase?.auth) {
+      setUploadSummary(null);
+      setUploadStatus("Google sign-in is required before uploading a SQLite file.");
+      return;
+    }
+
+    const { data, error } = await supabase.auth.getSession();
+    if (error || !data.session?.access_token) {
+      setUploadSummary(null);
+      setUploadStatus(error?.message || "Google sign-in is required before uploading a SQLite file.");
+      return;
+    }
+
+    setUploadStatus("Uploading SQLite file for hosted migration planning...");
+    const formData = new FormData();
+    formData.append("sqlite_db", selectedUploadFile);
+
+    try {
+      const response = await fetch(`${apiBaseUrl}/v1/workspace/import-upload-plan`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${data.session.access_token}`,
+          ...(supabaseApiKey ? { apikey: supabaseApiKey } : {})
+        },
+        body: formData
+      });
+
+      const payload = await response.json();
+      if (!response.ok) {
+        setUploadSummary(null);
+        setUploadStatus(payload.detail || `SQLite upload planning failed (${response.status}).`);
+        return;
+      }
+
+      setUploadSummary(payload);
+      setUploadStatus(payload.detail || "Uploaded SQLite inventory is ready.");
+    } catch (error) {
+      setUploadSummary(null);
+      setUploadStatus(error instanceof Error ? error.message : "SQLite upload planning failed.");
+    }
+  }
 
   async function syncWorkspaceImportPlan(nextSession) {
     if (!nextSession?.access_token) {
@@ -274,10 +336,115 @@ export default function App() {
     setSessionEmail(null);
     setHostedSummary(null);
     setImportPlanSummary(null);
+    setUploadSummary(null);
+    setSelectedUploadFile(null);
     setAuthMessage("Signed out. Sign in with Google to reactivate the hosted web shell.");
     setApiStatus("Protected API handshake will run after Google sign-in.");
     setHostedStatus("Hosted account bootstrap will run after the protected API handshake.");
     setImportPlanStatus("Hosted import planning will run after workspace bootstrap.");
+    setUploadStatus("Upload a SQLite database to inspect it for hosted migration planning.");
+  }
+
+  if (isMigrationPage) {
+    return (
+      <div className="shell">
+        <div className="ambient ambient-left" aria-hidden="true" />
+        <div className="ambient ambient-right" aria-hidden="true" />
+
+        <header className="hero">
+          <div className="hero-copy">
+            <p className="eyebrow">Sezzions Migration</p>
+            <h1>Temporary SQLite Upload Planning</h1>
+            <p className="lede">
+              Use this temporary authenticated page to upload a local Sezzions SQLite database for
+              read-only hosted migration planning. This is an operator bridge, not a permanent sync surface.
+            </p>
+            <div className="hero-actions">
+              <a className="primary-link action-button" href="/">Back To Control Tower</a>
+              <span className="status-pill">
+                {sessionEmail ? "Google session live" : "Awaiting Google sign-in"}
+              </span>
+            </div>
+          </div>
+
+          <aside className="hero-aside">
+            <p className="aside-label">Auth state</p>
+            <strong>{sessionEmail || "Not signed in"}</strong>
+            <p>{authMessage}</p>
+            <dl className="aside-meta">
+              <div>
+                <dt>API host</dt>
+                <dd>{apiBaseUrl || "Set VITE_API_BASE_URL"}</dd>
+              </div>
+              <div>
+                <dt>Upload status</dt>
+                <dd>{uploadStatus}</dd>
+              </div>
+            </dl>
+            {sessionEmail ? (
+              <button className="secondary-button" type="button" onClick={handleSignOut}>
+                Sign Out
+              </button>
+            ) : (
+              <button className="secondary-button" type="button" onClick={handleGoogleSignIn}>
+                Continue With Google
+              </button>
+            )}
+          </aside>
+        </header>
+
+        <main className="content-grid">
+          <section className="panel launch-panel">
+            <div className="panel-head">
+              <p className="panel-kicker">Upload bridge</p>
+              <h2>Inspect a local SQLite database</h2>
+            </div>
+            <label htmlFor="sqlite-upload-input">SQLite database file</label>
+            <input
+              id="sqlite-upload-input"
+              type="file"
+              accept=".db,.sqlite,.sqlite3,application/octet-stream"
+              onChange={(event) => setSelectedUploadFile(event.target.files?.[0] || null)}
+            />
+            <div className="hero-actions">
+              <button className="primary-link action-button" type="button" onClick={handleMigrationUpload}>
+                Upload SQLite For Planning
+              </button>
+            </div>
+            <p className="launch-note">{uploadStatus}</p>
+          </section>
+
+          <section className="panel launch-panel">
+            <div className="panel-head">
+              <p className="panel-kicker">Inventory</p>
+              <h2>Uploaded SQLite inspection</h2>
+            </div>
+            {uploadSummary ? (
+              <dl className="aside-meta">
+                <div>
+                  <dt>Uploaded file</dt>
+                  <dd>{uploadSummary.uploaded_filename}</dd>
+                </div>
+                <div>
+                  <dt>Status</dt>
+                  <dd>{uploadSummary.status}</dd>
+                </div>
+                <div>
+                  <dt>Active users discovered</dt>
+                  <dd>{uploadSummary.inventory?.active_user_names?.join(", ") || "None"}</dd>
+                </div>
+                <div>
+                  <dt>Sites discovered</dt>
+                  <dd>{uploadSummary.inventory?.site_names?.join(", ") || "None"}</dd>
+                </div>
+              </dl>
+            ) : (
+              <p className="launch-note">Upload a SQLite file to inspect it here.</p>
+            )}
+          </section>
+        </main>
+      </div>
+    );
   }
 
   return (
@@ -298,6 +465,7 @@ export default function App() {
             <button className="primary-link action-button" type="button" onClick={handleGoogleSignIn}>
               Continue With Google
             </button>
+            <a className="secondary-button" href="/migration">Open Migration Upload</a>
             <span className="status-pill">
               {sessionEmail ? "Google session live" : "Awaiting Google sign-in"}
             </span>

--- a/web/src/App.test.jsx
+++ b/web/src/App.test.jsx
@@ -31,6 +31,7 @@ describe("App", () => {
   });
 
   beforeEach(() => {
+    window.history.pushState({}, "", "/");
     vi.stubEnv("VITE_API_BASE_URL", "https://api.sezzions.test");
     authMocks.getSession.mockReset();
     authMocks.onAuthStateChange.mockReset();
@@ -264,5 +265,114 @@ describe("App", () => {
       );
     });
     expect(within(importSection).getByText(/no source sqlite database path is recorded/i)).toBeInTheDocument();
+  });
+
+  it("uploads a sqlite file from the migration page and renders the inventory summary", async () => {
+    window.history.pushState({}, "", "/migration");
+    authMocks.getSession.mockResolvedValue({
+      data: {
+        session: {
+          access_token: "access-token-123",
+          user: {
+            email: "owner@sezzions.com"
+          }
+        }
+      },
+      error: null
+    });
+
+    global.fetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          authenticated: true,
+          user_id: "user-123",
+          email: "owner@sezzions.com",
+          audience: "authenticated",
+          role: "authenticated"
+        })
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          created_account: true,
+          created_workspace: true,
+          account: {
+            id: "account-123",
+            supabase_user_id: "user-123",
+            owner_email: "owner@sezzions.com",
+            auth_provider: "google"
+          },
+          workspace: {
+            id: "workspace-123",
+            account_id: "account-123",
+            name: "owner@sezzions.com Workspace",
+            source_db_path: null
+          }
+        })
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          status: "source-db-path-missing",
+          detail: "No source SQLite database path is recorded for this hosted workspace yet.",
+          source_db_configured: false,
+          source_db_accessible: false,
+          workspace: {
+            id: "workspace-123",
+            account_id: "account-123",
+            name: "owner@sezzions.com Workspace",
+            source_db_path: null
+          },
+          inventory: null
+        })
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          status: "ready",
+          detail: "Uploaded SQLite inventory is ready.",
+          uploaded_filename: "sezzions.db",
+          inventory: {
+            db_path: "/tmp/upload.db",
+            db_size_bytes: 1024,
+            schema_version_count: 1,
+            tables: [{ table_name: "users", row_count: 1 }],
+            active_user_names: ["Elliot"],
+            site_names: ["Stake"]
+          }
+        })
+      });
+
+    render(<App />);
+
+    const uploadInput = await screen.findByLabelText(/sqlite database file/i);
+    const file = new File(["sqlite"], "sezzions.db", { type: "application/octet-stream" });
+    fireEvent.change(uploadInput, { target: { files: [file] } });
+    fireEvent.click(screen.getByRole("button", { name: /upload sqlite for planning/i }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenNthCalledWith(
+        4,
+        "https://api.sezzions.test/v1/workspace/import-upload-plan",
+        expect.objectContaining({
+          method: "POST",
+          headers: {
+            Authorization: "Bearer access-token-123"
+          }
+        })
+      );
+    });
+
+    const inventoryHeading = await screen.findByRole("heading", {
+      name: /uploaded sqlite inspection/i
+    });
+    const inventorySection = inventoryHeading.closest("section");
+
+    expect(inventorySection).not.toBeNull();
+    expect(within(inventorySection).getByText(/uploaded file/i)).toBeInTheDocument();
+    expect(within(inventorySection).getByText("sezzions.db")).toBeInTheDocument();
+    expect(within(inventorySection).getByText(/elliot/i)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
Implement issue #216 by adding a temporary authenticated migration page and protected upload inspection endpoint for one-user SQLite-to-hosted planning.

## Changes
- add `POST /v1/workspace/import-upload-plan` multipart upload inspection endpoint
- add uploaded SQLite inspection service with temp-file cleanup
- add temporary `/migration` page in the web app for authenticated SQLite upload planning
- update requirements, spec, and changelog for the upload bridge

## Validation
- `PYTHONPATH=$PWD /usr/local/bin/python3 -m pytest -q tests/services/hosted/test_uploaded_sqlite_inspection_service.py tests/api/test_workspace_import_upload.py`
- `cd web && npm test -- --run src/App.test.jsx`

## Pitfalls / Follow-ups
- this is intentionally a temporary operator bridge, not a permanent customer sync workflow
- the upload path only inspects and reports inventory; it still does not perform hosted business-data import
