### PR TITLE
Use hash route for migration page

### DIFF
--- a/docs/PROJECT_SPEC.md
+++ b/docs/PROJECT_SPEC.md
@@ -153,7 +153,7 @@ Hosted backend foundation (Issue #203):
 - `POST /v1/workspace/import-upload-plan` must require a bearer token and accept a browser-uploaded SQLite file as multipart form data for read-only inspection.
 - The upload-planning endpoint must write the uploaded file to a temporary location only long enough to inspect it, return a read-only inventory summary, and delete the temporary file afterward.
 - Invalid, empty, or unreadable uploads must fail safely with an actionable `400` response and must not create hosted business-domain records.
-- The staged web frontend may expose this as a temporary authenticated migration page at `/migration` rather than productizing it as a permanent customer-facing workflow.
+- The staged web frontend may expose this as a temporary authenticated migration page, but on static hosting without SPA rewrites it should use a hash route such as `/#/migration` rather than relying on a direct server path.
 - The hosted API must permit CORS preflight and authenticated browser requests from `https://dev.sezzions.com` and `http://localhost:5173` by default, with environment override support for additional origins.
 - If direct local JWT decoding is not compatible with the live Supabase token format, the API may validate the bearer token through Supabase's `/auth/v1/user` endpoint before returning `401`.
 - The `/auth/v1/user` validation fallback must include a Supabase publishable/anon key, either from hosted backend configuration or from the web client's protected handshake request.

--- a/docs/status/CHANGELOG.md
+++ b/docs/status/CHANGELOG.md
@@ -12,6 +12,32 @@ Rules:
 ## 2026-03-29
 
 ```yaml
+id: 2026-03-29-06
+type: fix
+areas: [web, docs, tests]
+issue: 216
+summary: "Use a hash route for the temporary migration page on static hosting"
+details: >
+  Fixed the staged migration upload page returning a server-side 404 on the
+  cPanel static host. The temporary migration surface now uses a hash route
+  instead of a direct `/migration` path so the server only has to serve the
+  root web bundle and React can select the migration view client-side.
+
+  Implemented:
+  - switched migration links/page detection to `/#/migration`
+  - updated the web tests for hash-based routing
+  - clarified the static-host routing constraint in the project spec
+
+  Validation:
+  - cd web && npm test -- --run src/App.test.jsx
+files_changed:
+  - web/src/App.jsx
+  - web/src/App.test.jsx
+  - docs/PROJECT_SPEC.md
+  - docs/status/CHANGELOG.md
+```
+
+```yaml
 id: 2026-03-29-05
 type: feat
 areas: [api, web, docs, tests]

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -40,8 +40,10 @@ const launchPlan = [
 ];
 
 export default function App() {
-  const currentPath = window.location.pathname.replace(/\/+$/, "") || "/";
-  const isMigrationPage = currentPath === "/migration";
+  const hashRoute = window.location.hash.replace(/^#/, "").replace(/\/+$/, "") || "";
+  const pathRoute = window.location.pathname.replace(/\/+$/, "") || "/";
+  const currentRoute = hashRoute || pathRoute;
+  const isMigrationPage = currentRoute === "/migration";
   const [sessionEmail, setSessionEmail] = useState(null);
   const [hostedSummary, setHostedSummary] = useState(null);
   const [importPlanSummary, setImportPlanSummary] = useState(null);
@@ -360,7 +362,7 @@ export default function App() {
               read-only hosted migration planning. This is an operator bridge, not a permanent sync surface.
             </p>
             <div className="hero-actions">
-              <a className="primary-link action-button" href="/">Back To Control Tower</a>
+              <a className="primary-link action-button" href="/#/">Back To Control Tower</a>
               <span className="status-pill">
                 {sessionEmail ? "Google session live" : "Awaiting Google sign-in"}
               </span>
@@ -465,7 +467,7 @@ export default function App() {
             <button className="primary-link action-button" type="button" onClick={handleGoogleSignIn}>
               Continue With Google
             </button>
-            <a className="secondary-button" href="/migration">Open Migration Upload</a>
+            <a className="secondary-button" href="/#/migration">Open Migration Upload</a>
             <span className="status-pill">
               {sessionEmail ? "Google session live" : "Awaiting Google sign-in"}
             </span>

--- a/web/src/App.test.jsx
+++ b/web/src/App.test.jsx
@@ -31,7 +31,7 @@ describe("App", () => {
   });
 
   beforeEach(() => {
-    window.history.pushState({}, "", "/");
+    window.history.pushState({}, "", "/#/");
     vi.stubEnv("VITE_API_BASE_URL", "https://api.sezzions.test");
     authMocks.getSession.mockReset();
     authMocks.onAuthStateChange.mockReset();
@@ -268,7 +268,7 @@ describe("App", () => {
   });
 
   it("uploads a sqlite file from the migration page and renders the inventory summary", async () => {
-    window.history.pushState({}, "", "/migration");
+    window.history.pushState({}, "", "/#/migration");
     authMocks.getSession.mockResolvedValue({
       data: {
         session: {


### PR DESCRIPTION
## Summary
Fix the temporary migration page returning a static-host 404 by switching it from a direct path to a hash route.

## Changes
- use `/#/migration` instead of `/migration` for the temporary upload page
- update page detection and test routing to match the hash route
- document the static-host constraint in the spec and changelog

## Validation
- `cd web && npm test -- --run src/App.test.jsx`
