### PR TITLE
Preserve migration route through sign-in

### DIFF
--- a/docs/PROJECT_SPEC.md
+++ b/docs/PROJECT_SPEC.md
@@ -136,6 +136,7 @@ Hosted backend foundation (Issue #203):
 - The first protected hosted API endpoint is `GET /v1/session`.
 - `GET /v1/session` must require a bearer token, verify the Supabase access token against Supabase JWKS, and return the authenticated session identity summary.
 - After successful Google sign-in, the web shell should call `GET /v1/session` with the Supabase access token and reflect the protected API handshake status in the UI.
+- When Google sign-in is initiated from a staged hash-routed page such as `/#/migration`, the OAuth redirect target must preserve that current URL so the browser returns to the same page after authentication.
 - The first hosted persistence slice after auth is `POST /v1/account/bootstrap`.
 - `POST /v1/account/bootstrap` must require a bearer token and idempotently create or return the hosted account/workspace records for the authenticated Supabase user.
 - Hosted account identity is keyed by Supabase user id and tracks the owner email plus auth provider separately from the legacy SQLite business-domain `users` table.
@@ -154,6 +155,7 @@ Hosted backend foundation (Issue #203):
 - The upload-planning endpoint must write the uploaded file to a temporary location only long enough to inspect it, return a read-only inventory summary, and delete the temporary file afterward.
 - Invalid, empty, or unreadable uploads must fail safely with an actionable `400` response and must not create hosted business-domain records.
 - The staged web frontend may expose this as a temporary authenticated migration page, but on static hosting without SPA rewrites it should use a hash route such as `/#/migration` rather than relying on a direct server path.
+- Hash-routed staged pages must react to hash changes client-side rather than only reading the route once at initial page load.
 - The hosted API must permit CORS preflight and authenticated browser requests from `https://dev.sezzions.com` and `http://localhost:5173` by default, with environment override support for additional origins.
 - If direct local JWT decoding is not compatible with the live Supabase token format, the API may validate the bearer token through Supabase's `/auth/v1/user` endpoint before returning `401`.
 - The `/auth/v1/user` validation fallback must include a Supabase publishable/anon key, either from hosted backend configuration or from the web client's protected handshake request.

--- a/docs/status/CHANGELOG.md
+++ b/docs/status/CHANGELOG.md
@@ -12,6 +12,32 @@ Rules:
 ## 2026-03-29
 
 ```yaml
+id: 2026-03-29-07
+type: fix
+areas: [web, auth, docs, tests]
+issue: 216
+summary: "Preserve the migration hash route across navigation and sign-in"
+details: >
+  Fixed the staged migration upload page failing to stay visible during normal
+  navigation and after Google sign-in. The web shell now reacts to hash-route
+  changes client-side and preserves the full current URL as the Supabase OAuth
+  redirect target so `/#/migration` survives the auth round-trip.
+
+  Implemented:
+  - reactive hash-route page selection in the staged web shell
+  - Google OAuth redirect now preserves the full current URL
+  - focused web test updates for the route/auth behavior
+
+  Validation:
+  - cd web && npm test -- --run src/App.test.jsx
+files_changed:
+  - web/src/App.jsx
+  - web/src/App.test.jsx
+  - docs/PROJECT_SPEC.md
+  - docs/status/CHANGELOG.md
+```
+
+```yaml
 id: 2026-03-29-06
 type: fix
 areas: [web, docs, tests]

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -39,10 +39,14 @@ const launchPlan = [
   "Port feature areas incrementally without rewriting accounting rules twice."
 ];
 
-export default function App() {
+function readCurrentRoute() {
   const hashRoute = window.location.hash.replace(/^#/, "").replace(/\/+$/, "") || "";
   const pathRoute = window.location.pathname.replace(/\/+$/, "") || "/";
-  const currentRoute = hashRoute || pathRoute;
+  return hashRoute || pathRoute;
+}
+
+export default function App() {
+  const [currentRoute, setCurrentRoute] = useState(() => readCurrentRoute());
   const isMigrationPage = currentRoute === "/migration";
   const [sessionEmail, setSessionEmail] = useState(null);
   const [hostedSummary, setHostedSummary] = useState(null);
@@ -261,6 +265,20 @@ export default function App() {
   }
 
   useEffect(() => {
+    function syncRoute() {
+      setCurrentRoute(readCurrentRoute());
+    }
+
+    window.addEventListener("hashchange", syncRoute);
+    window.addEventListener("popstate", syncRoute);
+
+    return () => {
+      window.removeEventListener("hashchange", syncRoute);
+      window.removeEventListener("popstate", syncRoute);
+    };
+  }, []);
+
+  useEffect(() => {
     if (!supabase) {
       return undefined;
     }
@@ -315,7 +333,7 @@ export default function App() {
     const { error } = await supabase.auth.signInWithOAuth({
       provider: "google",
       options: {
-        redirectTo: window.location.origin
+        redirectTo: window.location.href
       }
     });
 

--- a/web/src/App.test.jsx
+++ b/web/src/App.test.jsx
@@ -127,7 +127,7 @@ describe("App", () => {
       expect(authMocks.signInWithOAuth).toHaveBeenCalledWith({
         provider: "google",
         options: {
-          redirectTo: window.location.origin
+          redirectTo: window.location.href
         }
       });
     });


### PR DESCRIPTION
## Summary
Fix the staged migration page so it reacts to hash-route navigation and returns to the same `/#/migration` page after Google sign-in.

## Changes
- make hash-route page selection reactive in the web shell
- preserve the full current URL as the Supabase OAuth redirect target
- document the hash-route auth behavior in the spec and changelog

## Validation
- `cd web && npm test -- --run src/App.test.jsx`
