### PR TITLE
Repair hosted bootstrap legacy schema

### DIFF
--- a/docs/PROJECT_SPEC.md
+++ b/docs/PROJECT_SPEC.md
@@ -146,6 +146,7 @@ Hosted backend foundation (Issue #203):
 - The initial hosted account lifecycle statuses are `active`, `disabled`, and `deleted`.
 - Hosted workspace bootstrap must create one default workspace per hosted account when none exists yet, using `<owner email> Workspace` as the initial display name.
 - The hosted API persists account/workspace bootstrap state through the configured Supabase PostgreSQL SQLAlchemy connection.
+- The hosted API must repair legacy hosted bootstrap tables in place when the initial account schema predates later account metadata columns required by the current bootstrap summary.
 - After the protected session handshake succeeds, the web shell should call `POST /v1/account/bootstrap` with the same Supabase access token and render the hosted account owner, auth provider, workspace name, and bootstrap status in the UI.
 - The hosted bootstrap summary must also expose the hosted account role and lifecycle status so future clients can render/administer the account correctly.
 - Sezzions-controlled administrator accounts are a platform layer above normal workspace ownership and exist to support future account-level operations such as disable, restore, delete/correct, and administrative review.

--- a/docs/status/CHANGELOG.md
+++ b/docs/status/CHANGELOG.md
@@ -12,6 +12,32 @@ Rules:
 ## 2026-03-29
 
 ```yaml
+id: 2026-03-29-13
+type: fix
+areas: [api, database, tests]
+issue: 225
+summary: "Repair legacy hosted bootstrap tables before account bootstrap runs"
+details: >
+  Hardened the hosted persistence bootstrap so older hosted databases created
+  before the account role/status columns existed are upgraded in place before
+  the account bootstrap service queries them. This prevents `/v1/account/bootstrap`
+  from failing with a raw 500 on long-lived hosted environments that still have
+  the original bootstrap-era schema.
+
+  Implemented:
+  - compatibility upgrade for legacy `hosted_accounts` bootstrap tables
+  - regression coverage for bootstrapping against a pre-role/pre-status schema
+
+  Validation:
+  - pytest -q tests/services/hosted/test_account_bootstrap_service.py tests/api/test_app.py
+files_changed:
+  - services/hosted/persistence.py
+  - tests/services/hosted/test_account_bootstrap_service.py
+  - docs/PROJECT_SPEC.md
+  - docs/status/CHANGELOG.md
+```
+
+```yaml
 id: 2026-03-29-12
 type: fix
 areas: [web, docs, tests]

--- a/services/hosted/persistence.py
+++ b/services/hosted/persistence.py
@@ -5,7 +5,18 @@ from __future__ import annotations
 from functools import lru_cache
 from uuid import uuid4
 
-from sqlalchemy import Boolean, Float, ForeignKey, Index, String, Text, UniqueConstraint, create_engine
+from sqlalchemy import (
+    Boolean,
+    Float,
+    ForeignKey,
+    Index,
+    String,
+    Text,
+    UniqueConstraint,
+    create_engine,
+    inspect,
+    text,
+)
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, sessionmaker
 
 
@@ -395,8 +406,35 @@ class HostedAccountAdjustmentRecord(HostedBase):
     deleted_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
 
 
+def _ensure_hosted_schema_compatibility(engine) -> None:
+    inspector = inspect(engine)
+
+    if "hosted_accounts" in inspector.get_table_names():
+        account_columns = {column["name"] for column in inspector.get_columns("hosted_accounts")}
+        statements: list[str] = []
+
+        if "auth_provider" not in account_columns:
+            statements.append(
+                "ALTER TABLE hosted_accounts ADD COLUMN auth_provider VARCHAR(32) NOT NULL DEFAULT 'google'"
+            )
+        if "role" not in account_columns:
+            statements.append(
+                "ALTER TABLE hosted_accounts ADD COLUMN role VARCHAR(32) NOT NULL DEFAULT 'owner'"
+            )
+        if "status" not in account_columns:
+            statements.append(
+                "ALTER TABLE hosted_accounts ADD COLUMN status VARCHAR(32) NOT NULL DEFAULT 'active'"
+            )
+
+        if statements:
+            with engine.begin() as connection:
+                for statement in statements:
+                    connection.execute(text(statement))
+
+
 @lru_cache(maxsize=4)
 def get_hosted_session_factory(sqlalchemy_url: str):
     engine = create_engine(sqlalchemy_url, future=True, pool_pre_ping=True)
     HostedBase.metadata.create_all(engine)
+    _ensure_hosted_schema_compatibility(engine)
     return sessionmaker(bind=engine, expire_on_commit=False)

--- a/tests/services/hosted/test_account_bootstrap_service.py
+++ b/tests/services/hosted/test_account_bootstrap_service.py
@@ -1,8 +1,11 @@
+from pathlib import Path
+
 from sqlalchemy import create_engine
+from sqlalchemy import text
 from sqlalchemy.orm import sessionmaker
 
 from services.hosted.account_bootstrap_service import HostedAccountBootstrapService
-from services.hosted.persistence import HostedBase
+from services.hosted.persistence import HostedBase, get_hosted_session_factory
 
 
 def _session_factory():
@@ -77,3 +80,73 @@ def test_bootstrap_updates_owner_email_without_changing_role_or_status() -> None
     assert second.account.owner_email == "updated@sezzions.com"
     assert second.account.role == "owner"
     assert second.account.status == "active"
+
+
+def test_bootstrap_upgrades_legacy_account_schema(tmp_path: Path) -> None:
+    db_path = tmp_path / "legacy_hosted.db"
+    sqlalchemy_url = f"sqlite+pysqlite:///{db_path}"
+
+    legacy_engine = create_engine(sqlalchemy_url, future=True)
+    try:
+        with legacy_engine.begin() as connection:
+            connection.execute(
+                text(
+                    """
+                    CREATE TABLE hosted_accounts (
+                        id VARCHAR(36) PRIMARY KEY,
+                        owner_email VARCHAR(255) NOT NULL,
+                        supabase_user_id VARCHAR(255) NOT NULL UNIQUE
+                    )
+                    """
+                )
+            )
+            connection.execute(
+                text(
+                    """
+                    CREATE TABLE hosted_workspaces (
+                        id VARCHAR(36) PRIMARY KEY,
+                        account_id VARCHAR(36) NOT NULL UNIQUE,
+                        name VARCHAR(255) NOT NULL,
+                        source_db_path VARCHAR(1024)
+                    )
+                    """
+                )
+            )
+            connection.execute(
+                text(
+                    """
+                    INSERT INTO hosted_accounts (id, owner_email, supabase_user_id)
+                    VALUES ('account-123', 'owner@sezzions.com', 'user-123')
+                    """
+                )
+            )
+            connection.execute(
+                text(
+                    """
+                    INSERT INTO hosted_workspaces (id, account_id, name, source_db_path)
+                    VALUES ('workspace-123', 'account-123', 'owner@sezzions.com Workspace', NULL)
+                    """
+                )
+            )
+    finally:
+        legacy_engine.dispose()
+
+    get_hosted_session_factory.cache_clear()
+    session_factory = get_hosted_session_factory(sqlalchemy_url)
+    service = HostedAccountBootstrapService(session_factory)
+
+    try:
+        summary = service.bootstrap_account_workspace(
+            supabase_user_id="user-123",
+            owner_email="owner@sezzions.com",
+        )
+    finally:
+        session_factory.kw["bind"].dispose()
+        get_hosted_session_factory.cache_clear()
+
+    assert summary.created_account is False
+    assert summary.created_workspace is False
+    assert summary.account.id == "account-123"
+    assert summary.account.role == "owner"
+    assert summary.account.status == "active"
+    assert summary.workspace.id == "workspace-123"


### PR DESCRIPTION
## Summary\nFix hosted account bootstrap against legacy Render/Supabase databases where the original hosted_accounts table was created before the role/status columns existed.\n\n## What changed\n- add hosted schema compatibility repair before bootstrap session use\n- upgrade legacy hosted_accounts tables in place for auth_provider, role, and status\n- add regression coverage for bootstrap against the legacy schema\n- update spec and changelog\n\n## Validation\n- pytest -q tests/services/hosted/test_account_bootstrap_service.py tests/api/test_app.py\n\n## Pitfalls / Follow-ups\n- This fixes bootstrap-time legacy drift for hosted_accounts only; if more hosted tables evolve before formal migrations exist, they should get the same explicit compatibility handling or a real migration system.