### PR TITLE
Hosted Users tab UX redesign + FK cascade unification

### DIFF
--- a/docs/archive/2026-03-29-hosted-header-fidelity-issue-body.md
+++ b/docs/archive/2026-03-29-hosted-header-fidelity-issue-body.md
@@ -1,0 +1,95 @@
+## Problem / motivation
+The current hosted web header is still too large and web-shell-like compared with the desktop app. The large “Hosted Workspace” banner, the full “Signed in as” panel, and the expanded hosted status affordance consume too much vertical and horizontal space. This weakens fidelity with the desktop app, which uses a compact title area and utility-style header icons such as the notification bell and settings gear.
+
+## Proposed solution
+What:
+- Shrink the hosted header dramatically and replace the large hero-like title with the product name: `Sezzions - Sweepstakes Session Tracker`.
+- Replace the current full-width signed-in account summary with compact header utility icons.
+- Introduce desktop-inspired utility controls in the hosted header: notifications bell, settings gear, account entry point, and compact status entry point.
+- Keep detailed account and hosted-status information available behind compact controls instead of always-visible header blocks.
+
+Why:
+- Improves parity with the desktop app’s structure and visual density.
+- Frees space for the actual workflow content.
+- Creates a more scalable pattern for future hosted features without reintroducing a bulky SaaS-style top shell.
+
+Notes:
+- A reasonable first pass is to keep Account details in the existing Account section while using a compact account icon in the header as the entry point.
+- Hosted status should remain available but not visually dominant.
+
+## Scope
+In-scope:
+- Reduce the signed-in header height and simplify the title treatment.
+- Replace the current signed-in identity block with an icon-based account entry point.
+- Make the hosted status affordance more compact.
+- Add desktop-inspired header utility icons/patterns.
+- Update frontend tests for the new header behavior.
+
+Out-of-scope:
+- Full notification-center backend functionality.
+- Full settings/workspace-preferences feature set.
+- New hosted business workflows beyond header navigation and presentation.
+
+## UX / fields / checkboxes
+Screen/Tab:
+- Hosted signed-in web shell header
+- Setup primary shell
+- Account access entry point
+- Hosted status entry point
+
+Fields:
+- Product title text: `Sezzions - Sweepstakes Session Tracker`
+- Account summary fields remain available behind account entry instead of in the main header
+- Hosted status details remain available behind compact status access
+
+Checkboxes/toggles:
+- None required for first pass
+
+Buttons/actions:
+- Notifications bell
+- Settings gear
+- Account icon/button
+- Status icon/button
+- Existing Account/Status details remain reachable from those compact controls
+
+Warnings/confirmations:
+- None expected beyond existing destructive confirmations such as user delete
+
+## Implementation notes / strategy
+Approach:
+- Rework the hosted topbar into a compact desktop-inspired utility row.
+- Reuse the existing Account primary tab or a dedicated modal as the detail surface for account information.
+- Reuse the existing hosted status modal but reduce the header button footprint.
+- Add a lightweight notifications surface if needed for parity, even if it initially reports no notifications.
+
+Data model / migrations (if any):
+- None
+
+Risk areas:
+- Header utility icons should remain accessible and understandable on smaller screens.
+- The refactor should not regress sign-out, status access, or account discoverability.
+
+## Acceptance criteria
+- Given a signed-in hosted user, when the shell loads, then the header shows a compact product title rather than a large banner-style workspace header.
+- Given a signed-in hosted user, when viewing the shell, then account identity is no longer shown as a large always-visible summary block in the header.
+- Given a signed-in hosted user, when viewing the shell, then a compact account entry point is available in the header.
+- Given a signed-in hosted user, when viewing the shell, then hosted status is still accessible from the header through a compact control.
+- Given a signed-in hosted user, when using the header, then the layout more closely matches the desktop utility-icon pattern by including notifications/settings/account-oriented controls.
+- Given a signed-in hosted user, when using the header controls, then existing account/status information remains reachable without breaking current workflows.
+
+## Test plan
+Automated tests:
+- Update frontend tests for the compact header layout and utility controls.
+- Verify account/status access still works from the new compact controls.
+
+Manual verification:
+- Launch the hosted web app locally with Vite.
+- Confirm the new compact header leaves more room for Setup content.
+- Confirm account and status information remain easy to reach.
+- Confirm the layout still works at narrower widths.
+
+## Area
+UI
+
+## Notes
+- This change likely requires updating `docs/PROJECT_SPEC.md`.

--- a/docs/archive/2026-03-29-hosted-users-ui-pr-body.md
+++ b/docs/archive/2026-03-29-hosted-users-ui-pr-body.md
@@ -1,0 +1,31 @@
+## Summary
+
+- compact the hosted signed-in header into desktop-style utility controls
+- add desktop-style hosted Users sorting, filtering, multi-select, and dialog behavior
+- add paged hosted users API support plus batch delete support
+- harden the web client against incorrect paging metadata from the deployed Render backend
+
+## What changed
+
+- replaced the oversized hosted header with compact notifications, account, settings, and status utilities
+- added desktop-style column sorting and filter popups for hosted Users
+- added multi-row selection, batch delete, and related confirmation flows
+- added paged hosted users API parameters and response metadata
+- added repository/service/API support for hosted users batch delete
+- added client-side resilience for bad `total_count` and repeated-page responses from the currently deployed backend
+- simplified the Users summary chips so the UI only shows trustworthy totals
+
+## Validation
+
+- `/usr/local/bin/python3 -m pytest tests/api/test_workspace_users.py tests/services/hosted/test_workspace_user_service.py -q`
+- `cd web && npm test`
+
+## Known issue / follow-up
+
+- the local backend code in this branch computes `total_count` correctly, but the deployed Render API currently used by `web/.env.local` is still returning inconsistent paging metadata and may repeat page 1 for later offsets
+- the frontend now works around that deployed behavior, but the clean fix is to update/redeploy the hosted backend so `/v1/workspace/users` returns correct paging data consistently
+
+## Manual verification
+
+- exercised the hosted Users screen in the local Vite app while iterating on paging and batch delete behavior
+- verified that initial render stays capped to one page and that additional rows can be loaded afterward

--- a/docs/status/CHANGELOG.md
+++ b/docs/status/CHANGELOG.md
@@ -12,6 +12,86 @@ Rules:
 ## 2026-03-29
 
 ```yaml
+id: 2026-03-29-18
+type: feat
+areas: [web, docs, tests]
+issue: none
+summary: "Lock hosted Users controls while table rows scroll"
+details: >
+  Finalized the hosted Users panel around a fixed-controls data-grid pattern.
+  Action buttons, search, summary chips, and footer stats now stay outside the
+  scrollable row viewport so the interface behaves more like a desktop table.
+  Infinite loading is driven by the table viewport rather than the page, which
+  keeps the controls stable while the row area scrolls independently.
+
+  Implemented:
+  - internal scrolling viewport for hosted Users rows
+  - opaque sticky table headers inside the row viewport
+  - fixed top controls and top/bottom summary rails outside the row scroll area
+  - updated frontend tests for viewport-based paging behavior
+
+  Validation:
+  - cd web && npm test
+files_changed:
+  - web/src/App.jsx
+  - web/src/App.test.jsx
+  - web/src/styles.css
+  - docs/status/CHANGELOG.md
+```
+
+```yaml
+id: 2026-03-29-17
+type: feat
+areas: [web, docs]
+issue: none
+summary: "Add sticky Users controls and bottom stats rail"
+details: >
+  Continued the hosted Users UI polish by turning the actions and search area
+  into a sticky control block and moving the summary chips into dedicated top
+  and bottom rails. The framed internal-scroll table experiment was then backed
+  out in favor of preserving the original page-scroll loading behavior while
+  keeping the sticky bottom stats treatment.
+
+  Implemented:
+  - sticky hosted Users action/search control block
+  - top and bottom summary rails for shown, total, selection, and filtered-state chips
+  - search input switched to a plain text control and corrected left padding so the custom search icon no longer collides with the text
+  - restored page-scroll-based auto loading instead of an internal table scroll frame
+
+  Validation:
+  - cd web && npm test
+files_changed:
+  - web/src/App.jsx
+  - web/src/styles.css
+  - docs/status/CHANGELOG.md
+```
+
+```yaml
+id: 2026-03-29-16
+type: fix
+areas: [web, docs]
+issue: none
+summary: "Polish hosted Users search spacing and viewport fit"
+details: >
+  Tightened the hosted Users page after live validation. The search field now
+  clears the browser-native search decoration so the custom magnifying-glass
+  icon no longer overlaps the placeholder text, and the Users page/table shell
+  no longer impose oversized viewport-based minimum heights when only a small
+  number of rows are present.
+
+  Implemented:
+  - removed native WebKit search adornments from the hosted Users search field
+  - increased the left text inset so the custom search icon has clear spacing
+  - removed hard minimum heights that forced the Users table below the visible window when few rows exist
+
+  Validation:
+  - cd web && npm test
+files_changed:
+  - web/src/styles.css
+  - docs/status/CHANGELOG.md
+```
+
+```yaml
 id: 2026-03-29-15
 type: feat
 areas: [web, docs, tests]

--- a/docs/status/CHANGELOG.md
+++ b/docs/status/CHANGELOG.md
@@ -12,6 +12,37 @@ Rules:
 ## 2026-03-29
 
 ```yaml
+id: 2026-03-29-19
+type: feat
+areas: [web, docs, tests]
+issue: none
+summary: "Reframe hosted Users into a contained scrolling data grid"
+details: >
+  Reworked the hosted Users experience into a single framed data-grid surface.
+  The Setup/Users intro now lives inside the framed surface so it scrolls away
+  under the rounded top edge before the action/search controls pin in place.
+  The row area then continues beneath sticky table headers, and the bottom
+  stats rail acts as an integrated opaque footer without extra nested chrome
+  or translucent corners.
+
+  Implemented:
+  - contained hosted Users frame with rounded outer borders
+  - scoped scroll viewport that lets the Setup/Users intro scroll away first
+  - internal row viewport with sticky hosted Users headers
+  - simplified integrated footer rail with shown/total/selected stats and load-more action
+  - removed the extra footer status copy from the hosted Users surface
+  - updated frontend tests for viewport-based paging and the single summary rail
+
+  Validation:
+  - cd web && npm test -- --run
+files_changed:
+  - web/src/App.jsx
+  - web/src/App.test.jsx
+  - web/src/styles.css
+  - docs/status/CHANGELOG.md
+```
+
+```yaml
 id: 2026-03-29-18
 type: feat
 areas: [web, docs, tests]

--- a/repositories/database.py
+++ b/repositories/database.py
@@ -127,7 +127,7 @@ class DatabaseManager:
                 notes TEXT,
                 created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                 updated_at TIMESTAMP,
-                FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL
+                FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
             )
         ''')
         self._migrate_redemption_methods_table()
@@ -351,7 +351,7 @@ class DatabaseManager:
                 notes TEXT,
                 created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                 FOREIGN KEY (site_id) REFERENCES sites(id) ON DELETE RESTRICT,
-                FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE RESTRICT,
+                FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
                 FOREIGN KEY (redemption_id) REFERENCES redemptions(id) ON DELETE CASCADE
             )
         ''')
@@ -376,7 +376,7 @@ class DatabaseManager:
                 expense_entry_time_zone TEXT,
                 created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                 updated_at TIMESTAMP,
-                FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL
+                FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
             )
         ''')
 
@@ -393,7 +393,7 @@ class DatabaseManager:
                 num_other_income_items INTEGER DEFAULT 0,
                 notes TEXT,
                 PRIMARY KEY (session_date, user_id),
-                FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE RESTRICT
+                FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
             )
         ''')
 
@@ -572,6 +572,9 @@ class DatabaseManager:
         cursor.execute('CREATE INDEX IF NOT EXISTS idx_cards_active ON cards(is_active)')
         
         self._connection.commit()
+
+        # Migrate FK rules: RESTRICT/SET NULL → CASCADE on user_id for 4 tables
+        self._migrate_user_fk_cascade()
 
         # Data normalization (idempotent): ensure missing times are treated as 00:00:00
         self._normalize_time_fields()
@@ -1034,6 +1037,102 @@ class DatabaseManager:
                     cursor.execute(f"ALTER TABLE audit_log ADD COLUMN {column_name} {column_def}")
                 except Exception:
                     pass
+
+    def _migrate_user_fk_cascade(self):
+        """Migrate user_id FK rules to CASCADE for: redemption_methods, realized_transactions, expenses, daily_sessions."""
+        cursor = self._connection.cursor()
+
+        # Each entry: (table_name, old_fk_fragment, new_create_sql, columns, has_autoincrement_id)
+        migrations = [
+            (
+                'redemption_methods',
+                "ON DELETE SET NULL",
+                '''CREATE TABLE redemption_methods_new (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    name TEXT NOT NULL,
+                    method_type TEXT,
+                    user_id INTEGER,
+                    is_active INTEGER DEFAULT 1,
+                    notes TEXT,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    updated_at TIMESTAMP,
+                    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+                )''',
+                'id, name, method_type, user_id, is_active, notes, created_at, updated_at',
+            ),
+            (
+                'realized_transactions',
+                "users(id) ON DELETE RESTRICT",
+                '''CREATE TABLE realized_transactions_new (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    redemption_date TEXT NOT NULL,
+                    site_id INTEGER NOT NULL,
+                    user_id INTEGER NOT NULL,
+                    redemption_id INTEGER NOT NULL,
+                    cost_basis TEXT NOT NULL,
+                    payout TEXT NOT NULL,
+                    net_pl TEXT NOT NULL,
+                    notes TEXT,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    FOREIGN KEY (site_id) REFERENCES sites(id) ON DELETE RESTRICT,
+                    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+                    FOREIGN KEY (redemption_id) REFERENCES redemptions(id) ON DELETE CASCADE
+                )''',
+                'id, redemption_date, site_id, user_id, redemption_id, cost_basis, payout, net_pl, notes, created_at',
+            ),
+            (
+                'expenses',
+                "ON DELETE SET NULL",
+                '''CREATE TABLE expenses_new (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    expense_date TEXT NOT NULL,
+                    expense_time TEXT,
+                    amount TEXT NOT NULL,
+                    vendor TEXT NOT NULL,
+                    description TEXT,
+                    category TEXT,
+                    user_id INTEGER,
+                    expense_entry_time_zone TEXT,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    updated_at TIMESTAMP,
+                    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+                )''',
+                'id, expense_date, expense_time, amount, vendor, description, category, user_id, expense_entry_time_zone, created_at, updated_at',
+            ),
+            (
+                'daily_sessions',
+                "ON DELETE RESTRICT",
+                '''CREATE TABLE daily_sessions_new (
+                    session_date TEXT NOT NULL,
+                    user_id INTEGER NOT NULL,
+                    total_other_income REAL DEFAULT 0.0,
+                    total_session_pnl REAL DEFAULT 0.0,
+                    net_daily_pnl REAL DEFAULT 0.0,
+                    status TEXT,
+                    num_game_sessions INTEGER DEFAULT 0,
+                    num_other_income_items INTEGER DEFAULT 0,
+                    notes TEXT,
+                    PRIMARY KEY (session_date, user_id),
+                    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+                )''',
+                'session_date, user_id, total_other_income, total_session_pnl, net_daily_pnl, status, num_game_sessions, num_other_income_items, notes',
+            ),
+        ]
+
+        for table, old_fragment, create_sql, columns in migrations:
+            try:
+                cursor.execute(f"SELECT sql FROM sqlite_master WHERE type='table' AND name='{table}'")
+                row = cursor.fetchone()
+                if not row or old_fragment not in row[0]:
+                    continue  # Already migrated or table doesn't exist
+
+                cursor.execute(create_sql)
+                cursor.execute(f'INSERT INTO {table}_new ({columns}) SELECT {columns} FROM {table}')
+                cursor.execute(f'DROP TABLE {table}')
+                cursor.execute(f'ALTER TABLE {table}_new RENAME TO {table}')
+                self._connection.commit()
+            except Exception:
+                self._connection.rollback()
 
     def _normalize_time_fields(self):
         """Backfill NULL/blank time strings to '00:00:00' (safe to rerun)."""

--- a/services/hosted/persistence.py
+++ b/services/hosted/persistence.py
@@ -40,7 +40,7 @@ class HostedWorkspaceRecord(HostedBase):
 
     id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid4()))
     account_id: Mapped[str] = mapped_column(
-        ForeignKey("hosted_accounts.id"),
+        ForeignKey("hosted_accounts.id", ondelete="CASCADE"),
         nullable=False,
         unique=True,
         index=True,
@@ -55,7 +55,7 @@ class HostedUserRecord(HostedBase):
 
     id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid4()))
     workspace_id: Mapped[str] = mapped_column(
-        ForeignKey("hosted_workspaces.id"),
+        ForeignKey("hosted_workspaces.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
     )
@@ -70,7 +70,7 @@ class HostedSiteRecord(HostedBase):
     __table_args__ = (UniqueConstraint("workspace_id", "name"),)
 
     id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid4()))
-    workspace_id: Mapped[str] = mapped_column(ForeignKey("hosted_workspaces.id"), nullable=False, index=True)
+    workspace_id: Mapped[str] = mapped_column(ForeignKey("hosted_workspaces.id", ondelete="CASCADE"), nullable=False, index=True)
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     url: Mapped[str | None] = mapped_column(String(1024), nullable=True)
     sc_rate: Mapped[float] = mapped_column(Float, nullable=False, default=1.0)
@@ -84,8 +84,8 @@ class HostedCardRecord(HostedBase):
     __table_args__ = (Index("idx_hosted_cards_workspace_user", "workspace_id", "user_id"),)
 
     id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid4()))
-    workspace_id: Mapped[str] = mapped_column(ForeignKey("hosted_workspaces.id"), nullable=False, index=True)
-    user_id: Mapped[str] = mapped_column(ForeignKey("hosted_users.id"), nullable=False, index=True)
+    workspace_id: Mapped[str] = mapped_column(ForeignKey("hosted_workspaces.id", ondelete="CASCADE"), nullable=False, index=True)
+    user_id: Mapped[str] = mapped_column(ForeignKey("hosted_users.id", ondelete="CASCADE"), nullable=False, index=True)
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     last_four: Mapped[str | None] = mapped_column(String(8), nullable=True)
     cashback_rate: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
@@ -98,7 +98,7 @@ class HostedRedemptionMethodTypeRecord(HostedBase):
     __table_args__ = (UniqueConstraint("workspace_id", "name"),)
 
     id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid4()))
-    workspace_id: Mapped[str] = mapped_column(ForeignKey("hosted_workspaces.id"), nullable=False, index=True)
+    workspace_id: Mapped[str] = mapped_column(ForeignKey("hosted_workspaces.id", ondelete="CASCADE"), nullable=False, index=True)
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
     notes: Mapped[str | None] = mapped_column(Text, nullable=True)
@@ -109,14 +109,14 @@ class HostedRedemptionMethodRecord(HostedBase):
     __table_args__ = (Index("idx_hosted_redemption_methods_workspace_user", "workspace_id", "user_id"),)
 
     id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid4()))
-    workspace_id: Mapped[str] = mapped_column(ForeignKey("hosted_workspaces.id"), nullable=False, index=True)
+    workspace_id: Mapped[str] = mapped_column(ForeignKey("hosted_workspaces.id", ondelete="CASCADE"), nullable=False, index=True)
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     method_type_id: Mapped[str | None] = mapped_column(
-        ForeignKey("hosted_redemption_method_types.id"),
+        ForeignKey("hosted_redemption_method_types.id", ondelete="SET NULL"),
         nullable=True,
         index=True,
     )
-    user_id: Mapped[str | None] = mapped_column(ForeignKey("hosted_users.id"), nullable=True, index=True)
+    user_id: Mapped[str | None] = mapped_column(ForeignKey("hosted_users.id", ondelete="CASCADE"), nullable=True, index=True)
     is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
     notes: Mapped[str | None] = mapped_column(Text, nullable=True)
 
@@ -126,7 +126,7 @@ class HostedGameTypeRecord(HostedBase):
     __table_args__ = (UniqueConstraint("workspace_id", "name"),)
 
     id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid4()))
-    workspace_id: Mapped[str] = mapped_column(ForeignKey("hosted_workspaces.id"), nullable=False, index=True)
+    workspace_id: Mapped[str] = mapped_column(ForeignKey("hosted_workspaces.id", ondelete="CASCADE"), nullable=False, index=True)
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
     notes: Mapped[str | None] = mapped_column(Text, nullable=True)
@@ -137,9 +137,9 @@ class HostedGameRecord(HostedBase):
     __table_args__ = (UniqueConstraint("workspace_id", "name"),)
 
     id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid4()))
-    workspace_id: Mapped[str] = mapped_column(ForeignKey("hosted_workspaces.id"), nullable=False, index=True)
+    workspace_id: Mapped[str] = mapped_column(ForeignKey("hosted_workspaces.id", ondelete="CASCADE"), nullable=False, index=True)
     name: Mapped[str] = mapped_column(String(255), nullable=False)
-    game_type_id: Mapped[str] = mapped_column(ForeignKey("hosted_game_types.id"), nullable=False, index=True)
+    game_type_id: Mapped[str] = mapped_column(ForeignKey("hosted_game_types.id", ondelete="CASCADE"), nullable=False, index=True)
     rtp: Mapped[float | None] = mapped_column(Float, nullable=True)
     actual_rtp: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
     is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
@@ -154,9 +154,9 @@ class HostedPurchaseRecord(HostedBase):
     )
 
     id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid4()))
-    workspace_id: Mapped[str] = mapped_column(ForeignKey("hosted_workspaces.id"), nullable=False, index=True)
-    user_id: Mapped[str] = mapped_column(ForeignKey("hosted_users.id"), nullable=False, index=True)
-    site_id: Mapped[str] = mapped_column(ForeignKey("hosted_sites.id"), nullable=False, index=True)
+    workspace_id: Mapped[str] = mapped_column(ForeignKey("hosted_workspaces.id", ondelete="CASCADE"), nullable=False, index=True)
+    user_id: Mapped[str] = mapped_column(ForeignKey("hosted_users.id", ondelete="CASCADE"), nullable=False, index=True)
+    site_id: Mapped[str] = mapped_column(ForeignKey("hosted_sites.id", ondelete="CASCADE"), nullable=False, index=True)
     amount: Mapped[str] = mapped_column(String(32), nullable=False)
     sc_received: Mapped[str] = mapped_column(String(32), nullable=False, default="0.00")
     starting_sc_balance: Mapped[str] = mapped_column(String(32), nullable=False, default="0.00")
@@ -165,7 +165,7 @@ class HostedPurchaseRecord(HostedBase):
     purchase_date: Mapped[str] = mapped_column(String(32), nullable=False)
     purchase_time: Mapped[str | None] = mapped_column(String(32), nullable=True)
     purchase_entry_time_zone: Mapped[str | None] = mapped_column(String(128), nullable=True)
-    card_id: Mapped[str | None] = mapped_column(ForeignKey("hosted_cards.id"), nullable=True, index=True)
+    card_id: Mapped[str | None] = mapped_column(ForeignKey("hosted_cards.id", ondelete="SET NULL"), nullable=True, index=True)
     remaining_amount: Mapped[str] = mapped_column(String(32), nullable=False)
     status: Mapped[str] = mapped_column(String(64), nullable=False, default="active")
     notes: Mapped[str | None] = mapped_column(Text, nullable=True)
@@ -177,9 +177,9 @@ class HostedUnrealizedPositionRecord(HostedBase):
     __table_args__ = (UniqueConstraint("workspace_id", "site_id", "user_id"),)
 
     id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid4()))
-    workspace_id: Mapped[str] = mapped_column(ForeignKey("hosted_workspaces.id"), nullable=False, index=True)
-    site_id: Mapped[str] = mapped_column(ForeignKey("hosted_sites.id"), nullable=False, index=True)
-    user_id: Mapped[str] = mapped_column(ForeignKey("hosted_users.id"), nullable=False, index=True)
+    workspace_id: Mapped[str] = mapped_column(ForeignKey("hosted_workspaces.id", ondelete="CASCADE"), nullable=False, index=True)
+    site_id: Mapped[str] = mapped_column(ForeignKey("hosted_sites.id", ondelete="CASCADE"), nullable=False, index=True)
+    user_id: Mapped[str] = mapped_column(ForeignKey("hosted_users.id", ondelete="CASCADE"), nullable=False, index=True)
     notes: Mapped[str | None] = mapped_column(Text, nullable=True)
 
 
@@ -191,16 +191,16 @@ class HostedRedemptionRecord(HostedBase):
     )
 
     id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid4()))
-    workspace_id: Mapped[str] = mapped_column(ForeignKey("hosted_workspaces.id"), nullable=False, index=True)
-    user_id: Mapped[str] = mapped_column(ForeignKey("hosted_users.id"), nullable=False, index=True)
-    site_id: Mapped[str] = mapped_column(ForeignKey("hosted_sites.id"), nullable=False, index=True)
+    workspace_id: Mapped[str] = mapped_column(ForeignKey("hosted_workspaces.id", ondelete="CASCADE"), nullable=False, index=True)
+    user_id: Mapped[str] = mapped_column(ForeignKey("hosted_users.id", ondelete="CASCADE"), nullable=False, index=True)
+    site_id: Mapped[str] = mapped_column(ForeignKey("hosted_sites.id", ondelete="CASCADE"), nullable=False, index=True)
     amount: Mapped[str] = mapped_column(String(32), nullable=False)
     fees: Mapped[str] = mapped_column(String(32), nullable=False, default="0.00")
     redemption_date: Mapped[str] = mapped_column(String(32), nullable=False)
     redemption_time: Mapped[str] = mapped_column(String(32), nullable=False, default="00:00:00")
     redemption_entry_time_zone: Mapped[str | None] = mapped_column(String(128), nullable=True)
     redemption_method_id: Mapped[str | None] = mapped_column(
-        ForeignKey("hosted_redemption_methods.id"),
+        ForeignKey("hosted_redemption_methods.id", ondelete="SET NULL"),
         nullable=True,
         index=True,
     )
@@ -223,12 +223,12 @@ class HostedGameSessionRecord(HostedBase):
     )
 
     id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid4()))
-    workspace_id: Mapped[str] = mapped_column(ForeignKey("hosted_workspaces.id"), nullable=False, index=True)
-    user_id: Mapped[str] = mapped_column(ForeignKey("hosted_users.id"), nullable=False, index=True)
-    site_id: Mapped[str] = mapped_column(ForeignKey("hosted_sites.id"), nullable=False, index=True)
-    game_id: Mapped[str | None] = mapped_column(ForeignKey("hosted_games.id"), nullable=True, index=True)
+    workspace_id: Mapped[str] = mapped_column(ForeignKey("hosted_workspaces.id", ondelete="CASCADE"), nullable=False, index=True)
+    user_id: Mapped[str] = mapped_column(ForeignKey("hosted_users.id", ondelete="CASCADE"), nullable=False, index=True)
+    site_id: Mapped[str] = mapped_column(ForeignKey("hosted_sites.id", ondelete="CASCADE"), nullable=False, index=True)
+    game_id: Mapped[str | None] = mapped_column(ForeignKey("hosted_games.id", ondelete="CASCADE"), nullable=True, index=True)
     game_type_id: Mapped[str | None] = mapped_column(
-        ForeignKey("hosted_game_types.id"),
+        ForeignKey("hosted_game_types.id", ondelete="SET NULL"),
         nullable=True,
         index=True,
     )
@@ -270,9 +270,9 @@ class HostedGameSessionEventLinkRecord(HostedBase):
     )
 
     id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid4()))
-    workspace_id: Mapped[str] = mapped_column(ForeignKey("hosted_workspaces.id"), nullable=False, index=True)
+    workspace_id: Mapped[str] = mapped_column(ForeignKey("hosted_workspaces.id", ondelete="CASCADE"), nullable=False, index=True)
     game_session_id: Mapped[str] = mapped_column(
-        ForeignKey("hosted_game_sessions.id"),
+        ForeignKey("hosted_game_sessions.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
     )
@@ -287,8 +287,8 @@ class HostedGameRtpAggregateRecord(HostedBase):
     __table_args__ = (UniqueConstraint("workspace_id", "game_id"),)
 
     id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid4()))
-    workspace_id: Mapped[str] = mapped_column(ForeignKey("hosted_workspaces.id"), nullable=False, index=True)
-    game_id: Mapped[str] = mapped_column(ForeignKey("hosted_games.id"), nullable=False, index=True)
+    workspace_id: Mapped[str] = mapped_column(ForeignKey("hosted_workspaces.id", ondelete="CASCADE"), nullable=False, index=True)
+    game_id: Mapped[str] = mapped_column(ForeignKey("hosted_games.id", ondelete="CASCADE"), nullable=False, index=True)
     total_wager: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
     total_delta: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
     session_count: Mapped[int] = mapped_column(nullable=False, default=0)
@@ -300,9 +300,9 @@ class HostedRedemptionAllocationRecord(HostedBase):
     __table_args__ = (UniqueConstraint("workspace_id", "redemption_id", "purchase_id"),)
 
     id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid4()))
-    workspace_id: Mapped[str] = mapped_column(ForeignKey("hosted_workspaces.id"), nullable=False, index=True)
-    redemption_id: Mapped[str] = mapped_column(ForeignKey("hosted_redemptions.id"), nullable=False, index=True)
-    purchase_id: Mapped[str] = mapped_column(ForeignKey("hosted_purchases.id"), nullable=False, index=True)
+    workspace_id: Mapped[str] = mapped_column(ForeignKey("hosted_workspaces.id", ondelete="CASCADE"), nullable=False, index=True)
+    redemption_id: Mapped[str] = mapped_column(ForeignKey("hosted_redemptions.id", ondelete="CASCADE"), nullable=False, index=True)
+    purchase_id: Mapped[str] = mapped_column(ForeignKey("hosted_purchases.id", ondelete="CASCADE"), nullable=False, index=True)
     allocated_amount: Mapped[str] = mapped_column(String(32), nullable=False)
     created_at: Mapped[str | None] = mapped_column(String(64), nullable=True)
 
@@ -312,11 +312,11 @@ class HostedRealizedTransactionRecord(HostedBase):
     __table_args__ = (Index("idx_hosted_realized_workspace_user_site", "workspace_id", "user_id", "site_id"),)
 
     id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid4()))
-    workspace_id: Mapped[str] = mapped_column(ForeignKey("hosted_workspaces.id"), nullable=False, index=True)
+    workspace_id: Mapped[str] = mapped_column(ForeignKey("hosted_workspaces.id", ondelete="CASCADE"), nullable=False, index=True)
     redemption_date: Mapped[str] = mapped_column(String(32), nullable=False)
-    site_id: Mapped[str] = mapped_column(ForeignKey("hosted_sites.id"), nullable=False, index=True)
-    user_id: Mapped[str] = mapped_column(ForeignKey("hosted_users.id"), nullable=False, index=True)
-    redemption_id: Mapped[str] = mapped_column(ForeignKey("hosted_redemptions.id"), nullable=False, index=True)
+    site_id: Mapped[str] = mapped_column(ForeignKey("hosted_sites.id", ondelete="RESTRICT"), nullable=False, index=True)
+    user_id: Mapped[str] = mapped_column(ForeignKey("hosted_users.id", ondelete="CASCADE"), nullable=False, index=True)
+    redemption_id: Mapped[str] = mapped_column(ForeignKey("hosted_redemptions.id", ondelete="CASCADE"), nullable=False, index=True)
     cost_basis: Mapped[str] = mapped_column(String(32), nullable=False)
     payout: Mapped[str] = mapped_column(String(32), nullable=False)
     net_pl: Mapped[str] = mapped_column(String(32), nullable=False)
@@ -328,7 +328,7 @@ class HostedRealizedDailyNoteRecord(HostedBase):
     __table_args__ = (UniqueConstraint("workspace_id", "session_date"),)
 
     id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid4()))
-    workspace_id: Mapped[str] = mapped_column(ForeignKey("hosted_workspaces.id"), nullable=False, index=True)
+    workspace_id: Mapped[str] = mapped_column(ForeignKey("hosted_workspaces.id", ondelete="CASCADE"), nullable=False, index=True)
     session_date: Mapped[str] = mapped_column(String(32), nullable=False)
     notes: Mapped[str | None] = mapped_column(Text, nullable=True)
 
@@ -338,14 +338,14 @@ class HostedExpenseRecord(HostedBase):
     __table_args__ = (Index("idx_hosted_expenses_workspace_user", "workspace_id", "user_id"),)
 
     id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid4()))
-    workspace_id: Mapped[str] = mapped_column(ForeignKey("hosted_workspaces.id"), nullable=False, index=True)
+    workspace_id: Mapped[str] = mapped_column(ForeignKey("hosted_workspaces.id", ondelete="CASCADE"), nullable=False, index=True)
     expense_date: Mapped[str] = mapped_column(String(32), nullable=False)
     expense_time: Mapped[str | None] = mapped_column(String(32), nullable=True)
     amount: Mapped[str] = mapped_column(String(32), nullable=False)
     vendor: Mapped[str] = mapped_column(String(255), nullable=False)
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
     category: Mapped[str | None] = mapped_column(String(255), nullable=True)
-    user_id: Mapped[str | None] = mapped_column(ForeignKey("hosted_users.id"), nullable=True, index=True)
+    user_id: Mapped[str | None] = mapped_column(ForeignKey("hosted_users.id", ondelete="CASCADE"), nullable=True, index=True)
     expense_entry_time_zone: Mapped[str | None] = mapped_column(String(128), nullable=True)
 
 
@@ -354,9 +354,9 @@ class HostedDailySessionRecord(HostedBase):
     __table_args__ = (UniqueConstraint("workspace_id", "session_date", "user_id"),)
 
     id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid4()))
-    workspace_id: Mapped[str] = mapped_column(ForeignKey("hosted_workspaces.id"), nullable=False, index=True)
+    workspace_id: Mapped[str] = mapped_column(ForeignKey("hosted_workspaces.id", ondelete="CASCADE"), nullable=False, index=True)
     session_date: Mapped[str] = mapped_column(String(32), nullable=False)
-    user_id: Mapped[str] = mapped_column(ForeignKey("hosted_users.id"), nullable=False, index=True)
+    user_id: Mapped[str] = mapped_column(ForeignKey("hosted_users.id", ondelete="CASCADE"), nullable=False, index=True)
     total_other_income: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
     total_session_pnl: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
     net_daily_pnl: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
@@ -371,7 +371,7 @@ class HostedDailyDateTaxRecord(HostedBase):
     __table_args__ = (UniqueConstraint("workspace_id", "session_date"),)
 
     id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid4()))
-    workspace_id: Mapped[str] = mapped_column(ForeignKey("hosted_workspaces.id"), nullable=False, index=True)
+    workspace_id: Mapped[str] = mapped_column(ForeignKey("hosted_workspaces.id", ondelete="CASCADE"), nullable=False, index=True)
     session_date: Mapped[str] = mapped_column(String(32), nullable=False)
     net_daily_pnl: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
     tax_withholding_rate_pct: Mapped[float | None] = mapped_column(Float, nullable=True)
@@ -388,9 +388,9 @@ class HostedAccountAdjustmentRecord(HostedBase):
     )
 
     id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid4()))
-    workspace_id: Mapped[str] = mapped_column(ForeignKey("hosted_workspaces.id"), nullable=False, index=True)
-    user_id: Mapped[str] = mapped_column(ForeignKey("hosted_users.id"), nullable=False, index=True)
-    site_id: Mapped[str] = mapped_column(ForeignKey("hosted_sites.id"), nullable=False, index=True)
+    workspace_id: Mapped[str] = mapped_column(ForeignKey("hosted_workspaces.id", ondelete="CASCADE"), nullable=False, index=True)
+    user_id: Mapped[str] = mapped_column(ForeignKey("hosted_users.id", ondelete="CASCADE"), nullable=False, index=True)
+    site_id: Mapped[str] = mapped_column(ForeignKey("hosted_sites.id", ondelete="CASCADE"), nullable=False, index=True)
     effective_date: Mapped[str] = mapped_column(String(32), nullable=False)
     effective_time: Mapped[str] = mapped_column(String(32), nullable=False, default="00:00:00")
     effective_entry_time_zone: Mapped[str | None] = mapped_column(String(128), nullable=True)
@@ -430,6 +430,95 @@ def _ensure_hosted_schema_compatibility(engine) -> None:
             with engine.begin() as connection:
                 for statement in statements:
                     connection.execute(text(statement))
+
+    _migrate_fk_ondelete_rules(engine, inspector)
+
+
+# --- FK ondelete migration ------------------------------------------------
+
+# Maps Postgres pg_constraint confdeltype codes to ondelete keywords.
+_PG_DELTYPE = {"a": "NO ACTION", "r": "RESTRICT", "c": "CASCADE", "n": "SET NULL", "d": "SET DEFAULT"}
+
+
+def _desired_fk_ondelete() -> dict[str, dict[str, str]]:
+    """Return {table: {constraint_name: desired_ondelete}} derived from ORM models."""
+    result: dict[str, dict[str, str]] = {}
+    for table in HostedBase.metadata.sorted_tables:
+        tbl_fks: dict[str, str] = {}
+        for fk_constraint in table.foreign_key_constraints:
+            rule = (fk_constraint.ondelete or "NO ACTION").upper()
+            tbl_fks[fk_constraint.name] = rule
+        if tbl_fks:
+            result[table.name] = tbl_fks
+    return result
+
+
+def _migrate_fk_ondelete_rules(engine, inspector) -> None:
+    """Ensure live Postgres FK constraints match the ondelete rules in the ORM models.
+
+    Idempotent: skips constraints that already have the correct rule.
+    """
+    desired = _desired_fk_ondelete()
+    existing_tables = set(inspector.get_table_names())
+    statements: list[str] = []
+
+    for table_name, fk_rules in desired.items():
+        if table_name not in existing_tables:
+            continue
+
+        # Query actual ondelete behaviour from pg_constraint
+        live_fks: dict[str, str] = {}
+        for fk in inspector.get_foreign_keys(table_name):
+            name = fk.get("name")
+            if not name:
+                continue
+            live_fks[name] = True  # we know the constraint exists
+
+        for constraint_name, desired_rule in fk_rules.items():
+            if constraint_name not in live_fks:
+                continue  # constraint doesn't exist yet (create_all will handle it)
+
+            # We cannot cheaply read the current ondelete rule via the inspector,
+            # so query pg_constraint directly.
+            statements.append(
+                f"DO $$ BEGIN "
+                f"IF EXISTS ("
+                f"  SELECT 1 FROM pg_constraint "
+                f"  WHERE conname = '{constraint_name}' "
+                f"  AND confdeltype != '{_ondelete_to_pg_code(desired_rule)}'"
+                f") THEN "
+                f"  ALTER TABLE {table_name} DROP CONSTRAINT {constraint_name}; "
+                f"  {_build_add_constraint_sql(table_name, constraint_name, inspector, desired_rule)} "
+                f"END IF; "
+                f"END $$;"
+            )
+
+    if statements:
+        with engine.begin() as connection:
+            for stmt in statements:
+                connection.execute(text(stmt))
+
+
+def _ondelete_to_pg_code(rule: str) -> str:
+    """Convert an ondelete keyword to a pg_constraint confdeltype code."""
+    mapping = {"NO ACTION": "a", "RESTRICT": "r", "CASCADE": "c", "SET NULL": "n", "SET DEFAULT": "d"}
+    return mapping.get(rule.upper(), "a")
+
+
+def _build_add_constraint_sql(
+    table_name: str, constraint_name: str, inspector, desired_rule: str
+) -> str:
+    """Build an ALTER TABLE ADD CONSTRAINT statement from the inspector metadata."""
+    for fk in inspector.get_foreign_keys(table_name):
+        if fk.get("name") == constraint_name:
+            cols = ", ".join(fk["constrained_columns"])
+            ref_table = fk["referred_table"]
+            ref_cols = ", ".join(fk["referred_columns"])
+            return (
+                f"ALTER TABLE {table_name} ADD CONSTRAINT {constraint_name} "
+                f"FOREIGN KEY ({cols}) REFERENCES {ref_table}({ref_cols}) ON DELETE {desired_rule};"
+            )
+    return ""
 
 
 @lru_cache(maxsize=4)

--- a/services/user_service.py
+++ b/services/user_service.py
@@ -62,18 +62,8 @@ class UserService:
         return self.user_repo.get_by_id(user_id)
 
     def delete_user(self, user_id: int) -> None:
-        """Hard delete user (use with caution - prefer deactivate_user)"""
+        """Hard delete user and all associated data (CASCADE)."""
         user = self.user_repo.get_by_id(user_id)
         if not user:
             raise ValueError(f"User {user_id} not found")
-        
-        try:
-            self.user_repo.delete(user_id)
-        except Exception as e:
-            if "FOREIGN KEY constraint failed" in str(e):
-                raise ValueError(
-                    f"Cannot delete user '{user.name}' because they have related records. "
-                    f"Purchases, cards, or other data still reference this user. "
-                    f"Consider deactivating instead of deleting."
-                ) from e
-            raise
+        self.user_repo.delete(user_id)

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -211,6 +211,49 @@ function isTextEntryElement(element) {
   return element.isContentEditable;
 }
 
+function parseNumericValue(text) {
+  if (!text || typeof text !== "string") return null;
+  const trimmed = text.trim();
+  if (!trimmed || ["n/a", "na", "-", "\u2014", "\u2013"].includes(trimmed.toLowerCase())) return null;
+  let cleaned = trimmed.replace(/[$\u20ac\u00a3\u00a5,\s]/g, "");
+  if (cleaned.startsWith("(") && cleaned.endsWith(")")) cleaned = "-" + cleaned.slice(1, -1);
+  if (cleaned.endsWith("%")) cleaned = cleaned.slice(0, -1);
+  const num = Number(cleaned);
+  return Number.isFinite(num) ? num : null;
+}
+
+function computeCellStats(values) {
+  const count = values.length;
+  const nums = values.map(parseNumericValue).filter((v) => v !== null);
+  if (!nums.length) return { count, numericCount: 0, sum: 0, avg: 0, min: null, max: null };
+  const sum = nums.reduce((a, b) => a + b, 0);
+  return {
+    count,
+    numericCount: nums.length,
+    sum,
+    avg: sum / nums.length,
+    min: Math.min(...nums),
+    max: Math.max(...nums)
+  };
+}
+
+function getCellDisplayValue(user, columnKey) {
+  if (columnKey === "status") return user.is_active ? "Active" : "Inactive";
+  return String(user[columnKey] || "");
+}
+
+function HighlightMatch({ text, query }) {
+  if (!query || !text) return text || "";
+  const escaped = query.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const parts = text.split(new RegExp(`(${escaped})`, "gi"));
+  if (parts.length === 1) return text;
+  return parts.map((part, i) =>
+    part.toLowerCase() === query.toLowerCase()
+      ? <mark key={i} className="search-highlight">{part}</mark>
+      : part
+  );
+}
+
 const initialUserColumnFilters = {
   name: [],
   email: [],
@@ -308,13 +351,12 @@ function StatusModal({ overallTone, statusItems, onClose, onRetryHostedConnectio
       >
         <div className="modal-header">
           <div>
-            <p className="section-kicker">Hosted Status</p>
             <h2 id="status-modal-title">Connection Health</h2>
           </div>
           <button className="ghost-button" type="button" onClick={onClose}>Close</button>
         </div>
 
-        <div className="status-overview-card">
+        <div className="status-overview-strip">
           <span className={`status-dot large ${overallTone}`} aria-hidden="true" />
           <div>
             <strong>Overall status</strong>
@@ -360,15 +402,12 @@ function NotificationsModal({ onClose }) {
       >
         <div className="modal-header">
           <div>
-            <p className="section-kicker">Notifications</p>
-            <h2 id="notifications-modal-title">Notification Center</h2>
+            <h2 id="notifications-modal-title">Notifications</h2>
           </div>
           <button className="ghost-button" type="button" onClick={onClose}>Close</button>
         </div>
 
-        <section className="detail-section">
-          <p className="status-note">No notifications.</p>
-        </section>
+        <p className="status-note">No notifications.</p>
       </section>
     </div>
   );
@@ -386,20 +425,17 @@ function AccountModal({ accountOwner, accountRole, accountStatus, workspaceName,
       >
         <div className="modal-header">
           <div>
-            <p className="section-kicker">My Account</p>
-            <h2 id="account-modal-title">Hosted Account</h2>
+            <h2 id="account-modal-title">My Account</h2>
           </div>
           <button className="ghost-button" type="button" onClick={onClose}>Close</button>
         </div>
 
-        <section className="detail-section">
-          <dl className="detail-grid compact-grid">
-            <div><dt>Owner</dt><dd>{accountOwner}</dd></div>
-            <div><dt>Role</dt><dd>{accountRole}</dd></div>
-            <div><dt>Status</dt><dd>{accountStatus}</dd></div>
-            <div><dt>Workspace</dt><dd>{workspaceName}</dd></div>
-          </dl>
-        </section>
+        <dl className="detail-grid compact-grid">
+          <div><dt>Owner</dt><dd>{accountOwner}</dd></div>
+          <div><dt>Role</dt><dd>{accountRole}</dd></div>
+          <div><dt>Status</dt><dd>{accountStatus}</dd></div>
+          <div><dt>Workspace</dt><dd>{workspaceName}</dd></div>
+        </dl>
 
         <div className="modal-actions modal-actions-end">
           <button className="ghost-button" type="button" onClick={onSignOut}>Sign Out</button>
@@ -421,15 +457,12 @@ function SettingsModal({ onClose }) {
       >
         <div className="modal-header">
           <div>
-            <p className="section-kicker">Settings</p>
             <h2 id="settings-modal-title">Settings</h2>
           </div>
           <button className="ghost-button" type="button" onClick={onClose}>Close</button>
         </div>
 
-        <section className="detail-section">
-          <p className="status-note">No settings available.</p>
-        </section>
+        <p className="status-note">No settings available.</p>
       </section>
     </div>
   );
@@ -448,15 +481,11 @@ function ConfirmationModal({ title, message, confirmLabel = "Confirm", cancelLab
       >
         <div className="modal-header">
           <div>
-            <p className="section-kicker">Confirm Action</p>
             <h2 id="confirmation-modal-title">{title}</h2>
           </div>
-          <button className="ghost-button" type="button" onClick={onCancel}>Close</button>
         </div>
 
-        <section className="detail-section">
-          <p id="confirmation-modal-message" className="status-note">{message}</p>
-        </section>
+        <p id="confirmation-modal-message" className="status-note">{message}</p>
 
         <div className="modal-actions modal-actions-end">
           <button className="ghost-button" type="button" onClick={onCancel}>{cancelLabel}</button>
@@ -467,15 +496,14 @@ function ConfirmationModal({ title, message, confirmLabel = "Confirm", cancelLab
   );
 }
 
-function downloadUsersCsv(users) {
+function downloadUsersCsv(users, columns) {
+  const activeColumns = columns || userTableColumns;
   const rows = [
-    ["Name", "Email", "Status", "Notes"],
-    ...users.map((user) => [
-      user.name,
-      user.email || "",
-      user.is_active ? "Active" : "Inactive",
-      user.notes || ""
-    ])
+    activeColumns.map((c) => c.label),
+    ...users.map((user) => activeColumns.map((c) => {
+      if (c.key === "status") return user.is_active ? "Active" : "Inactive";
+      return String(user[c.key] || "");
+    }))
   ];
   const csv = rows
     .map((row) => row.map((value) => `"${String(value).replaceAll('"', '""')}"`).join(","))
@@ -740,6 +768,142 @@ function UserHeaderFilterMenu({
   );
 }
 
+function TableContextMenu({ position, items, onClose }) {
+  const menuRef = useRef(null);
+
+  useEffect(() => {
+    function handleClick(event) {
+      if (menuRef.current && !menuRef.current.contains(event.target)) onClose();
+    }
+    function handleKey(event) {
+      if (event.key === "Escape") onClose();
+    }
+    document.addEventListener("mousedown", handleClick);
+    document.addEventListener("keydown", handleKey);
+    return () => {
+      document.removeEventListener("mousedown", handleClick);
+      document.removeEventListener("keydown", handleKey);
+    };
+  }, [onClose]);
+
+  // Adjust position so menu doesn't overflow viewport
+  const style = {
+    position: "fixed",
+    zIndex: 1500,
+    left: Math.min(position.x, window.innerWidth - 220),
+    top: Math.min(position.y, window.innerHeight - items.length * 36 - 16),
+  };
+
+  return (
+    <div className="table-context-menu" ref={menuRef} style={style} role="menu">
+      {items.map((item, i) =>
+        item.divider
+          ? <div key={i} className="context-menu-divider" role="separator" />
+          : (
+            <button
+              key={i}
+              className={`context-menu-item${item.danger ? " danger" : ""}`}
+              type="button"
+              role="menuitem"
+              disabled={item.disabled}
+              onClick={() => { item.action(); onClose(); }}
+            >
+              {item.label}
+            </button>
+          )
+      )}
+    </div>
+  );
+}
+
+function ExportModal({ filteredUsers, selectedUsers, selectedCells, allColumns, onExport, onClose }) {
+  const hasSelection = selectedUsers.length > 0;
+  const hasCellSelection = selectedCells.size > 0;
+  const [scope, setScope] = useState(hasSelection ? "selected" : "filtered");
+  const [enabledColumns, setEnabledColumns] = useState(() => new Set(allColumns.map((c) => c.key)));
+
+  const scopeOptions = [
+    { value: "filtered", label: `All shown (${filteredUsers.length})` },
+    ...(hasSelection ? [{ value: "selected", label: `Selected rows (${selectedUsers.length})` }] : []),
+  ];
+
+  const dataUsers = scope === "selected" ? selectedUsers : filteredUsers;
+  const activeColumns = allColumns.filter((c) => enabledColumns.has(c.key));
+  const previewRows = dataUsers.slice(0, 5);
+
+  function toggleColumn(key) {
+    setEnabledColumns((current) => {
+      const next = new Set(current);
+      if (next.has(key)) { if (next.size > 1) next.delete(key); } else next.add(key);
+      return next;
+    });
+  }
+
+  return (
+    <div className="modal-backdrop" onClick={(event) => { if (event.target === event.currentTarget) onClose(); }}>
+      <section className="modal-card export-modal" aria-modal="true" role="dialog">
+        <header className="modal-header">
+          <h3>Export CSV</h3>
+          <button className="ghost-button" type="button" onClick={onClose}>Close</button>
+        </header>
+
+        <div className="export-modal-body">
+          <div className="export-section">
+            <label className="export-label">Data scope</label>
+            <div className="export-scope-options">
+              {scopeOptions.map((opt) => (
+                <label key={opt.value} className="export-radio-label">
+                  <input type="radio" name="export-scope" value={opt.value} checked={scope === opt.value} onChange={() => setScope(opt.value)} />
+                  {opt.label}
+                </label>
+              ))}
+            </div>
+          </div>
+
+          <div className="export-section">
+            <label className="export-label">Columns</label>
+            <div className="export-column-options">
+              {allColumns.map((col) => (
+                <label key={col.key} className="export-checkbox-label">
+                  <input type="checkbox" checked={enabledColumns.has(col.key)} onChange={() => toggleColumn(col.key)} />
+                  {col.label}
+                </label>
+              ))}
+            </div>
+          </div>
+
+          <div className="export-section">
+            <label className="export-label">Preview ({dataUsers.length} row{dataUsers.length !== 1 ? "s" : ""})</label>
+            <div className="export-preview-scroll">
+              <table className="export-preview-table">
+                <thead>
+                  <tr>{activeColumns.map((c) => <th key={c.key}>{c.label}</th>)}</tr>
+                </thead>
+                <tbody>
+                  {previewRows.map((user, i) => (
+                    <tr key={i}>
+                      {activeColumns.map((c) => (
+                        <td key={c.key}>{c.key === "status" ? (user.is_active ? "Active" : "Inactive") : String(user[c.key] || "")}</td>
+                      ))}
+                    </tr>
+                  ))}
+                  {dataUsers.length > 5 ? <tr><td colSpan={activeColumns.length} className="export-preview-more">... and {dataUsers.length - 5} more</td></tr> : null}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+
+        <div className="modal-actions modal-actions-end">
+          <button className="primary-button" type="button" onClick={() => { onExport(dataUsers, activeColumns); onClose(); }}>
+            Export {dataUsers.length} Row{dataUsers.length !== 1 ? "s" : ""}
+          </button>
+        </div>
+      </section>
+    </div>
+  );
+}
+
 function UserModal({
   mode,
   user,
@@ -769,36 +933,30 @@ function UserModal({
         >
           <div className="modal-header">
             <div>
-              <p className="section-kicker">Setup / Users</p>
               <h2 id="user-modal-title">View User</h2>
             </div>
             <button className="ghost-button" type="button" onClick={onClose}>{closeLabel}</button>
           </div>
 
-          <section className="detail-section">
-            <p className="section-kicker">User Details</p>
-            <div className="detail-columns">
-              <dl className="detail-grid single-column-grid">
-                <div><dt>Name</dt><dd>{user.name}</dd></div>
-                <div><dt>Email</dt><dd>{user.email || "-"}</dd></div>
-              </dl>
-              <dl className="detail-grid single-column-grid">
-                <div>
-                  <dt>Status</dt>
-                  <dd>
-                    <span className={user.is_active ? "status-chip active" : "status-chip inactive"}>
-                      {user.is_active ? "Active" : "Inactive"}
-                    </span>
-                  </dd>
-                </div>
-              </dl>
-            </div>
-          </section>
+          <div className="user-detail-body">
+            <dl className="detail-grid user-detail-grid">
+              <div><dt>Name</dt><dd>{user.name}</dd></div>
+              <div><dt>Email</dt><dd>{user.email || "-"}</dd></div>
+              <div>
+                <dt>Status</dt>
+                <dd>
+                  <span className={user.is_active ? "status-chip active" : "status-chip inactive"}>
+                    {user.is_active ? "Active" : "Inactive"}
+                  </span>
+                </dd>
+              </div>
+            </dl>
 
-          <section className="detail-section">
-            <p className="section-kicker">Notes</p>
-            <div className="notes-display">{user.notes || "-"}</div>
-          </section>
+            <div className="user-detail-notes">
+              <p className="detail-label">Notes</p>
+              <div className="notes-display">{user.notes || "-"}</div>
+            </div>
+          </div>
 
           <div className="modal-actions modal-actions-split">
             <div className="toolbar-row">
@@ -806,7 +964,6 @@ function UserModal({
             </div>
             <div className="toolbar-row">
               <button className="primary-button" type="button" onClick={onRequestEdit}>Edit User</button>
-              <button className="ghost-button" type="button" onClick={onClose}>{closeLabel}</button>
             </div>
           </div>
         </section>
@@ -825,7 +982,6 @@ function UserModal({
       >
         <div className="modal-header">
           <div>
-            <p className="section-kicker">Setup / Users</p>
             <h2 id="user-modal-title">{title}</h2>
           </div>
           <button className="ghost-button" type="button" onClick={onClose}>
@@ -900,7 +1056,6 @@ function UserModal({
         {submitError ? <p className="submit-error">{submitError}</p> : null}
 
         <div className="modal-actions modal-actions-end">
-          <button className="ghost-button" type="button" onClick={onClose}>{closeLabel}</button>
           <button className="primary-button" type="button" onClick={onSubmit} disabled={nameInvalid}>
             Save User
           </button>
@@ -914,6 +1069,7 @@ export default function App() {
   const usersScrollGateRef = useRef({ armed: false, lastScrollTop: 0 });
   const usersPagingRequestRef = useRef(false);
   const usersTableViewportRef = useRef(null);
+  const userNavCursorRef = useRef(null);
   const [currentRoute, setCurrentRoute] = useState(() => readCurrentRoute());
   const isMigrationPage = currentRoute === "/migration";
   const [railCollapsed, setRailCollapsed] = useState(false);
@@ -948,11 +1104,21 @@ export default function App() {
   const [openUserHeaderMenu, setOpenUserHeaderMenu] = useState(null);
   const [selectedUserIds, setSelectedUserIds] = useState([]);
   const [selectionAnchorUserId, setSelectionAnchorUserId] = useState(null);
+  const [selectedColumnKeys, setSelectedColumnKeys] = useState(new Set());
+  const [selectedCells, setSelectedCells] = useState(new Set());
+  const cellAnchorRef = useRef(null);
   const [usersTotalCount, setUsersTotalCount] = useState(null);
   const [usersNextOffset, setUsersNextOffset] = useState(0);
   const [usersHasMore, setUsersHasMore] = useState(false);
   const [usersLoadingInitial, setUsersLoadingInitial] = useState(false);
   const [usersLoadingMore, setUsersLoadingMore] = useState(false);
+  const [showBackToTop, setShowBackToTop] = useState(false);
+  const [contextMenu, setContextMenu] = useState(null);
+  const [columnWidths, setColumnWidths] = useState(null);
+  const columnResizeRef = useRef(null);
+  const headerRef = useRef(null);
+  const [exportModalOpen, setExportModalOpen] = useState(false);
+
   const [userModalMode, setUserModalMode] = useState(null);
   const [statusModalOpen, setStatusModalOpen] = useState(false);
   const [userForm, setUserForm] = useState(initialUserForm);
@@ -1089,11 +1255,9 @@ export default function App() {
 
     document.addEventListener("mousedown", handlePointerDown);
     window.addEventListener("resize", handleViewportChange);
-    window.addEventListener("scroll", handleViewportChange, true);
     return () => {
       document.removeEventListener("mousedown", handlePointerDown);
       window.removeEventListener("resize", handleViewportChange);
-      window.removeEventListener("scroll", handleViewportChange, true);
     };
   }, [openUserHeaderMenu]);
 
@@ -1107,6 +1271,7 @@ export default function App() {
       || settingsModalOpen
       || userModalMode
       || confirmationState
+      || exportModalOpen
     );
 
     if (!anyModalOpen) {
@@ -1170,6 +1335,11 @@ export default function App() {
         return;
       }
 
+      if (exportModalOpen) {
+        setExportModalOpen(false);
+        return;
+      }
+
       if (notificationsModalOpen) {
         setNotificationsModalOpen(false);
       }
@@ -1177,7 +1347,120 @@ export default function App() {
 
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [accountModalOpen, confirmationState, notificationsModalOpen, openUserHeaderMenu, settingsModalOpen, statusModalOpen, userModalMode, userModalDirty]);
+  }, [accountModalOpen, confirmationState, exportModalOpen, notificationsModalOpen, openUserHeaderMenu, settingsModalOpen, statusModalOpen, userModalMode, userModalDirty]);
+
+  useEffect(() => {
+    if (setupTab !== "users") return undefined;
+
+    function handleArrowNav(event) {
+      // Ctrl+C: copy selected cells as TSV
+      if (event.key === "c" && (event.metaKey || event.ctrlKey) && !event.shiftKey) {
+        if (isTextEntryElement(document.activeElement)) return;
+        if (selectedCells.size) {
+          event.preventDefault();
+          copyCellsAsTSV();
+          return;
+        }
+        if (selectedUserIds.length) {
+          event.preventDefault();
+          copyRowsAsTSV();
+          return;
+        }
+        return;
+      }
+
+      if (event.key === "a" && (event.metaKey || event.ctrlKey) && !event.shiftKey) {
+        if (isTextEntryElement(document.activeElement)) return;
+        if (confirmationState || userModalMode || openUserHeaderMenu) return;
+        if (!filteredUsers.length) return;
+        event.preventDefault();
+        // Toggle: if all filtered are already selected, deselect all
+        if (selectedUserIds.length === filteredUsers.length && filteredUsers.every((u) => selectedUserIds.includes(u.id))) {
+          setSelectedUserIds([]);
+          setSelectionAnchorUserId(null);
+          userNavCursorRef.current = null;
+        } else {
+          setSelectedUserIds(filteredUsers.map((u) => u.id));
+          setSelectionAnchorUserId(filteredUsers[0].id);
+          userNavCursorRef.current = filteredUsers[filteredUsers.length - 1].id;
+        }
+        return;
+      }
+
+      // Ctrl+F: focus search field
+      if (event.key === "f" && (event.metaKey || event.ctrlKey) && !event.shiftKey) {
+        if (confirmationState || userModalMode || openUserHeaderMenu) return;
+        event.preventDefault();
+        const searchInput = document.getElementById("users-search-input");
+        if (searchInput) searchInput.focus();
+        return;
+      }
+
+      // Escape: clear search field if focused and has content, otherwise blur
+      if (event.key === "Escape") {
+        const searchInput = document.getElementById("users-search-input");
+        if (document.activeElement === searchInput) {
+          event.preventDefault();
+          if (usersSearch) {
+            setUsersSearch("");
+          } else {
+            searchInput.blur();
+          }
+          return;
+        }
+      }
+
+      if (event.key !== "ArrowUp" && event.key !== "ArrowDown" && event.key !== "Enter") return;
+      if (isTextEntryElement(document.activeElement)) return;
+      if (confirmationState || userModalMode || openUserHeaderMenu) return;
+
+      if (event.key === "Enter") {
+        if (selectedUserIds.length === 1) {
+          const user = filteredUsers.find((u) => u.id === selectedUserIds[0]);
+          if (user) openUserModal("view", user);
+        }
+        return;
+      }
+
+      if (!filteredUsers.length || !selectedUserIds.length) return;
+
+      event.preventDefault();
+      const orderedIds = filteredUsers.map((u) => u.id);
+      const cursorId = userNavCursorRef.current ?? selectedUserIds[selectedUserIds.length - 1];
+      const currentIndex = orderedIds.indexOf(cursorId);
+      if (currentIndex === -1) return;
+
+      const nextIndex = event.key === "ArrowDown"
+        ? Math.min(currentIndex + 1, orderedIds.length - 1)
+        : Math.max(currentIndex - 1, 0);
+      const nextId = orderedIds[nextIndex];
+      userNavCursorRef.current = nextId;
+
+      if (event.shiftKey) {
+        setSelectedUserIds(() => {
+          const anchor = selectionAnchorUserId && orderedIds.includes(selectionAnchorUserId)
+            ? orderedIds.indexOf(selectionAnchorUserId)
+            : currentIndex;
+          const [start, end] = anchor < nextIndex ? [anchor, nextIndex] : [nextIndex, anchor];
+          return orderedIds.slice(start, end + 1);
+        });
+      } else {
+        setSelectedUserIds([nextId]);
+        setSelectionAnchorUserId(nextId);
+      }
+
+      const viewport = usersTableViewportRef.current;
+      if (viewport) {
+        requestAnimationFrame(() => {
+          const row = viewport.querySelector(`tbody tr:nth-child(${nextIndex + 1})`);
+          if (row) row.scrollIntoView({ block: "nearest" });
+        });
+      }
+    }
+
+    window.addEventListener("keydown", handleArrowNav);
+    return () => window.removeEventListener("keydown", handleArrowNav);
+  }, [confirmationState, filteredUsers, openUserHeaderMenu, selectedCells, selectedUserIds, selectionAnchorUserId, setupTab, userModalMode]);
 
   const userSuggestions = useMemo(() => ({
     names: [...new Set(users.map((user) => user.name).filter(Boolean))],
@@ -1207,6 +1490,9 @@ export default function App() {
   function clearUserSelection() {
     setSelectedUserIds([]);
     setSelectionAnchorUserId(null);
+    setSelectedCells(new Set());
+    setSelectedColumnKeys(new Set());
+    cellAnchorRef.current = null;
   }
 
   function closeUserModalImmediately() {
@@ -1240,6 +1526,7 @@ export default function App() {
   }
 
   async function loadUsers(accessToken, { append = false } = {}) {
+
     if (!accessToken) {
       setUsers([]);
       setUsersTotalCount(null);
@@ -1382,6 +1669,10 @@ export default function App() {
 
   function handleUserRowSelection(event, userId) {
     event.preventDefault();
+    // Clear cell/column selection when doing row selection
+    setSelectedCells(new Set());
+    setSelectedColumnKeys(new Set());
+    cellAnchorRef.current = null;
     const orderedIds = filteredUsers.map((user) => user.id);
 
     if (event.shiftKey && selectionAnchorUserId && orderedIds.includes(selectionAnchorUserId)) {
@@ -1405,6 +1696,280 @@ export default function App() {
 
     setSelectedUserIds([userId]);
     setSelectionAnchorUserId(userId);
+    userNavCursorRef.current = userId;
+  }
+
+  function handleCellClick(event, userId, columnKey) {
+    if (!event.altKey) return false; // only Alt/Option+click enters cell mode
+    event.stopPropagation();
+    event.preventDefault();
+
+    // Clear row selection when entering cell mode
+    setSelectedUserIds([]);
+    setSelectionAnchorUserId(null);
+
+    const cellId = `${userId}:${columnKey}`;
+    const columnKeys = userTableColumns.map((c) => c.key);
+
+    if (event.shiftKey && cellAnchorRef.current) {
+      // Rectangular range from anchor to this cell
+      const anchor = cellAnchorRef.current;
+      const orderedIds = filteredUsers.map((u) => u.id);
+      const anchorRowIdx = orderedIds.indexOf(anchor.userId);
+      const targetRowIdx = orderedIds.indexOf(userId);
+      const anchorColIdx = columnKeys.indexOf(anchor.columnKey);
+      const targetColIdx = columnKeys.indexOf(columnKey);
+      if (anchorRowIdx === -1 || targetRowIdx === -1) return true;
+
+      const [rowStart, rowEnd] = anchorRowIdx < targetRowIdx ? [anchorRowIdx, targetRowIdx] : [targetRowIdx, anchorRowIdx];
+      const [colStart, colEnd] = anchorColIdx < targetColIdx ? [anchorColIdx, targetColIdx] : [targetColIdx, anchorColIdx];
+
+      const next = new Set();
+      for (let r = rowStart; r <= rowEnd; r++) {
+        for (let c = colStart; c <= colEnd; c++) {
+          next.add(`${orderedIds[r]}:${columnKeys[c]}`);
+        }
+      }
+      setSelectedCells(next);
+      setSelectedColumnKeys(new Set());
+    } else {
+      // Alt+click: toggle individual cell (Ctrl+Alt adds to selection)
+      if (event.metaKey || event.ctrlKey) {
+        setSelectedCells((current) => {
+          const next = new Set(current);
+          if (next.has(cellId)) next.delete(cellId); else next.add(cellId);
+          return next;
+        });
+      } else {
+        setSelectedCells((current) => current.size === 1 && current.has(cellId) ? new Set() : new Set([cellId]));
+      }
+      setSelectedColumnKeys(new Set());
+      cellAnchorRef.current = { userId, columnKey };
+    }
+    return true;
+  }
+
+  function copyCellsAsTSV() {
+    const columnKeys = userTableColumns.map((c) => c.key);
+    const orderedIds = filteredUsers.map((u) => u.id);
+    const rows = [];
+    for (const uid of orderedIds) {
+      const row = [];
+      let hasCell = false;
+      for (const col of columnKeys) {
+        if (selectedCells.has(`${uid}:${col}`)) {
+          const u = filteredUsers.find((x) => x.id === uid);
+          row.push(u ? getCellDisplayValue(u, col) : "");
+          hasCell = true;
+        } else {
+          row.push("");
+        }
+      }
+      if (hasCell) rows.push(row);
+    }
+    const usedCols = columnKeys.map((_, ci) => rows.some((r) => r[ci] !== ""));
+    const tsv = rows.map((r) => r.filter((_, ci) => usedCols[ci]).join("\t")).join("\n");
+    navigator.clipboard.writeText(tsv).catch(() => {});
+  }
+
+  function copyRowsAsTSV() {
+    const columnKeys = userTableColumns.map((c) => c.key);
+    const orderedIds = filteredUsers.map((u) => u.id);
+    const rows = [];
+    for (const uid of orderedIds) {
+      if (!selectedUserIds.includes(uid)) continue;
+      const u = filteredUsers.find((x) => x.id === uid);
+      if (!u) continue;
+      rows.push(columnKeys.map((col) => getCellDisplayValue(u, col)));
+    }
+    const tsv = rows.map((r) => r.join("\t")).join("\n");
+    navigator.clipboard.writeText(tsv).catch(() => {});
+  }
+
+  function handleTableContextMenu(event, user) {
+    event.preventDefault();
+    setContextMenu(null);
+
+    // Detect which cell column was right-clicked
+    let td = event.target;
+    while (td && td.tagName !== "TD") td = td.parentElement;
+    const clickedColumnKey = td?.dataset?.col || null;
+
+    const items = [];
+    const isRowSelected = selectedUserIds.includes(user.id);
+    const hasCellSelection = selectedCells.size > 0;
+    const hasRowSelection = selectedUserIds.length > 0;
+
+    // 1. Copy the specific clicked cell value
+    if (clickedColumnKey) {
+      const cellValue = getCellDisplayValue(user, clickedColumnKey);
+      const truncated = cellValue.length > 30 ? `${cellValue.slice(0, 27)}…` : cellValue;
+      items.push({ label: `Copy "${truncated}"`, action: () => { navigator.clipboard.writeText(cellValue).catch(() => {}); }});
+    }
+
+    // 2. Copy selected cells as TSV (if any)
+    if (hasCellSelection) {
+      items.push({ label: `Copy ${selectedCells.size} cell${selectedCells.size > 1 ? "s" : ""}`, action: copyCellsAsTSV });
+    }
+
+    // 3. Copy selected rows as TSV (if any)
+    if (hasRowSelection) {
+      const count = selectedUserIds.length;
+      items.push({ label: count > 1 ? `Copy ${count} rows` : "Copy row", action: copyRowsAsTSV });
+    }
+
+    items.push({ divider: true });
+
+    // Row actions
+    if (!isRowSelected) {
+      items.push({ label: "Select row", action: () => { setSelectedUserIds([user.id]); setSelectionAnchorUserId(user.id); }});
+      items.push({ divider: true });
+    }
+
+    const targetUsers = isRowSelected ? selectedUsers : [user];
+    const targetCount = targetUsers.length;
+
+    items.push({ label: "View", action: () => openUserModal("view", targetCount === 1 ? targetUsers[0] : user), disabled: targetCount !== 1 });
+    items.push({ label: "Edit", action: () => openUserModal("edit", targetCount === 1 ? targetUsers[0] : user), disabled: targetCount !== 1 });
+    items.push({ divider: true });
+
+    if (hasCellSelection) {
+      items.push({ label: "Clear cell selection", action: () => { setSelectedCells(new Set()); setSelectedColumnKeys(new Set()); cellAnchorRef.current = null; }});
+    }
+
+    items.push({
+      label: targetCount > 1 ? `Delete ${targetCount} users` : "Delete",
+      danger: true,
+      action: () => handleDeleteUser(targetUsers),
+      disabled: !hostedWorkspaceReady
+    });
+
+    setContextMenu({ x: event.clientX, y: event.clientY, items });
+  }
+
+  function getComputedColumnWidths() {
+    // Read current rendered widths from the header grid cells
+    const header = headerRef.current;
+    if (!header) return null;
+    const cells = header.querySelectorAll(".users-table-header-cell");
+    // First cell is checkbox — skip it, return widths for data columns only
+    const widths = [];
+    for (let i = 1; i < cells.length; i++) {
+      widths.push(cells[i].getBoundingClientRect().width);
+    }
+    return widths.length === userTableColumns.length ? widths : null;
+  }
+
+  function getColumnMinWidth(colIndex) {
+    // Measure header label text + filter button + padding to determine smart minimum
+    const header = headerRef.current;
+    if (!header) return 80;
+    const cells = header.querySelectorAll(".users-table-header-cell");
+    const cell = cells[colIndex + 1]; // +1 for checkbox column
+    if (!cell) return 80;
+    const label = cell.querySelector(".users-table-header-label");
+    const canvas = document.createElement("canvas");
+    const ctx = canvas.getContext("2d");
+    ctx.font = "0.71rem -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif";
+    const labelW = label ? ctx.measureText(label.textContent || "").width : 30;
+    // label text + sort/filter button (~28px) + cell padding (2×10) + gap (4) + resize handle (5)
+    return Math.ceil(labelW + 57);
+  }
+
+  function handleColumnResizeStart(event, colIndex) {
+    event.preventDefault();
+    event.stopPropagation();
+    const startX = event.clientX;
+    let widths = columnWidths || getComputedColumnWidths();
+    if (!widths) return;
+    widths = [...widths];
+    const startWidth = widths[colIndex];
+
+    // Pre-compute per-column minimums
+    const minWidths = widths.map((_, i) => getColumnMinWidth(i));
+
+    function ensureViewportFill(w) {
+      const viewport = usersTableViewportRef.current;
+      if (!viewport) return w;
+      const available = viewport.clientWidth - 36; // subtract checkbox column
+      const total = w.reduce((a, b) => a + b, 0);
+      if (total < available) {
+        const result = [...w];
+        result[result.length - 1] += available - total;
+        return result;
+      }
+      return w;
+    }
+
+    function onMouseMove(moveEvent) {
+      const delta = moveEvent.clientX - startX;
+      widths[colIndex] = Math.max(minWidths[colIndex], startWidth + delta);
+      setColumnWidths(ensureViewportFill([...widths]));
+    }
+
+    function onMouseUp() {
+      document.removeEventListener("mousemove", onMouseMove);
+      document.removeEventListener("mouseup", onMouseUp);
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+      columnResizeRef.current = null;
+    }
+
+    document.body.style.cursor = "col-resize";
+    document.body.style.userSelect = "none";
+    columnResizeRef.current = true;
+    document.addEventListener("mousemove", onMouseMove);
+    document.addEventListener("mouseup", onMouseUp);
+  }
+
+  function handleColumnAutoFit(colIndex) {
+    let widths = columnWidths || getComputedColumnWidths();
+    if (!widths) return;
+    widths = [...widths];
+
+    const columnKey = userTableColumns[colIndex]?.key;
+    if (!columnKey) return;
+
+    // Use a canvas context to measure text width directly (avoids DOM layout constraints)
+    const canvas = document.createElement("canvas");
+    const ctx = canvas.getContext("2d");
+    // Match the table cell font
+    ctx.font = "0.84rem -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif";
+
+    let maxWidth = 60;
+
+    // Measure header label text
+    const header = headerRef.current;
+    if (header) {
+      const headerCells = header.querySelectorAll(".users-table-header-cell");
+      if (headerCells[colIndex + 1]) {
+        const label = headerCells[colIndex + 1].querySelector(".users-table-header-label");
+        if (label) {
+          const textWidth = ctx.measureText(label.textContent || "").width;
+          maxWidth = Math.max(maxWidth, textWidth + 52); // +padding+sort button
+        }
+      }
+    }
+
+    // Measure each row's cell content
+    for (const user of filteredUsers) {
+      const value = getCellDisplayValue(user, columnKey);
+      const textWidth = ctx.measureText(value).width;
+      maxWidth = Math.max(maxWidth, textWidth + 24); // +cell padding
+    }
+
+    widths[colIndex] = Math.min(Math.ceil(maxWidth), 600); // cap at reasonable max
+
+    // Ensure columns fill viewport
+    const viewport = usersTableViewportRef.current;
+    if (viewport) {
+      const available = viewport.clientWidth - 36;
+      const total = widths.reduce((a, b) => a + b, 0);
+      if (total < available) {
+        widths[widths.length - 1] += available - total;
+      }
+    }
+    setColumnWidths([...widths]);
   }
 
   async function loadNextUsersPage() {
@@ -1427,7 +1992,7 @@ export default function App() {
   }
 
   useEffect(() => {
-    if (!usersHasMore || usersFiltersActive || usersLoadingInitial || usersLoadingMore || !hasAuthenticatedSession) {
+    if (setupTab !== "users" || !usersHasMore || usersFiltersActive || usersLoadingInitial || usersLoadingMore || !hasAuthenticatedSession) {
       return undefined;
     }
 
@@ -1458,7 +2023,7 @@ export default function App() {
 
     viewport.addEventListener("scroll", handleViewportScroll, { passive: true });
     return () => viewport.removeEventListener("scroll", handleViewportScroll);
-  }, [hasAuthenticatedSession, usersFiltersActive, usersHasMore, usersLoadingInitial, usersLoadingMore, usersNextOffset]);
+  }, [hasAuthenticatedSession, setupTab, usersFiltersActive, usersHasMore, usersLoadingInitial, usersLoadingMore, usersNextOffset]);
 
   function openUserHeaderOptions(event, columnKey) {
     const buttonRect = event.currentTarget.getBoundingClientRect();
@@ -2244,28 +2809,23 @@ export default function App() {
       <main className="workspace-shell">
         {setupTab === "users" ? (
           <section className="workspace-panel setup-panel users-page" aria-label="Setup Users">
-            <div className="users-page-header">
-              <div className="users-page-title-row">
-                <div>
-                  <p className="section-kicker">Setup</p>
-                  <h2>Users</h2>
-                </div>
-              </div>
-              <div className="users-page-header-copy">
-                <p className="users-page-note">Manage workspace users, inspect individual records, and export the current filtered view.</p>
-              </div>
-            </div>
-
             <div className="users-surface">
-              <div className="sticky-tools users-sticky-tools">
-                <div className="toolbar-row wrap-toolbar users-toolbar-panel">
-                  <button className="primary-button" type="button" onClick={() => openUserModal("create")} disabled={!hostedWorkspaceReady}>Add User</button>
-                  <button className="ghost-button" type="button" onClick={() => selectedUser && openUserModal("view", selectedUser)} disabled={!hostedWorkspaceReady || selectedUserIds.length !== 1}>View</button>
-                  <button className="ghost-button" type="button" onClick={() => selectedUser && openUserModal("edit", selectedUser)} disabled={!hostedWorkspaceReady || selectedUserIds.length !== 1}>Edit</button>
-                  <button className="ghost-button" type="button" onClick={() => handleDeleteUser()} disabled={!hostedWorkspaceReady || !selectedUserIds.length}>Delete</button>
-                  <button className="ghost-button" type="button" onClick={() => downloadUsersCsv(filteredUsers)} disabled={!filteredUsers.length}>Export CSV</button>
-                  <button className="ghost-button" type="button" onClick={handleUsersRefresh} disabled={!hostedWorkspaceReady}>Refresh</button>
-                  {devToolsVisible ? <button className="ghost-button" type="button" onClick={handleSeedDemoUsers} disabled={!hostedWorkspaceReady}>Seed 200 Demo Users</button> : null}
+              <div className="users-toolbar">
+                <div className="users-toolbar-top">
+                  <nav className="users-breadcrumb" aria-label="Breadcrumb">
+                    <span className="breadcrumb-segment">Setup</span>
+                    <span className="breadcrumb-separator" aria-hidden="true">›</span>
+                    <h2 className="breadcrumb-segment current" title="Manage workspace users, inspect individual records, and export the current filtered view.">Users</h2>
+                  </nav>
+                  <div className="toolbar-row wrap-toolbar users-toolbar-actions">
+                    <button className="primary-button" type="button" onClick={() => openUserModal("create")} disabled={!hostedWorkspaceReady}>Add User</button>
+                    <button className="ghost-button" type="button" onClick={() => selectedUser && openUserModal("view", selectedUser)} disabled={!hostedWorkspaceReady || selectedUserIds.length !== 1}>View</button>
+                    <button className="ghost-button" type="button" onClick={() => selectedUser && openUserModal("edit", selectedUser)} disabled={!hostedWorkspaceReady || selectedUserIds.length !== 1}>Edit</button>
+                    <button className="ghost-button" type="button" onClick={() => handleDeleteUser()} disabled={!hostedWorkspaceReady || !selectedUserIds.length}>Delete</button>
+                    <button className="ghost-button" type="button" onClick={() => setExportModalOpen(true)} disabled={!filteredUsers.length}>Export CSV</button>
+                    <button className="ghost-button" type="button" onClick={handleUsersRefresh} disabled={!hostedWorkspaceReady}>Refresh</button>
+                    {devToolsVisible ? <button className="ghost-button" type="button" onClick={handleSeedDemoUsers} disabled={!hostedWorkspaceReady}>Seed 200 Demo Users</button> : null}
+                  </div>
                 </div>
                 <div className="users-search-bar">
                   <label className="users-search-field" htmlFor="users-search-input">
@@ -2287,133 +2847,274 @@ export default function App() {
                 </div>
               </div>
 
-              <div className="users-summary-rail users-summary-rail-top" aria-label="User summary">
-                <div className="users-page-metrics">
-                  <span className="users-metric-chip">{filteredUserCount} shown</span>
-                  <span className="users-metric-chip subdued">{totalUserCount} total</span>
-                  {selectedUserIds.length ? <span className="users-metric-chip accent">{selectedUserIds.length} selected</span> : null}
-                  {usersFiltersActive ? <span className="users-metric-chip subdued">Filtered view</span> : null}
-                </div>
-              </div>
-
-              <div className="users-table-stack">
-                <div className="table-shell">
-                  <div className="table-viewport" ref={usersTableViewportRef}>
-                    <table className="data-table">
-                      <thead>
-                        <tr>
-                          {userTableColumns.map((column) => {
-                            const sortDirection = usersSort.column === column.key ? usersSort.direction : null;
-                            const filterValues = userColumnFilters[column.key];
-                            return (
-                              <th key={column.key}>
-                                <div className="table-header-menu-wrap">
-                                  <button
-                                    className={sortDirection || filterValues.length ? "table-sort-button active" : "table-sort-button"}
-                                    type="button"
-                                    aria-label={`${column.label} options`}
-                                    onClick={(event) => openUserHeaderOptions(event, column.key)}
-                                  >
-                                    <span>{column.label}</span>
-                                    <span className="table-sort-indicator" aria-hidden="true">
-                                      {sortDirection === "asc"
-                                        ? "↑"
-                                        : sortDirection === "desc"
-                                          ? "↓"
-                                          : filterValues.length
-                                            ? filterValues.length
-                                            : <Icon name="filterMenu" className="app-icon table-filter-icon" />}
-                                    </span>
-                                  </button>
-
-                                  {openUserHeaderMenu?.key === column.key ? (
-                                    <UserHeaderFilterMenu
-                                      column={column}
-                                      options={userFilterOptions[column.key]}
-                                      selectedValues={filterValues}
-                                      sortDirection={sortDirection}
-                                      onClearFilter={() => {
-                                        setUserColumnFilters((current) => ({ ...current, [column.key]: [] }));
-                                        setOpenUserHeaderMenu(null);
-                                      }}
-                                      onSortAsc={() => {
-                                        setUsersSort({ column: column.key, direction: "asc" });
-                                        setOpenUserHeaderMenu(null);
-                                      }}
-                                      onSortDesc={() => {
-                                        setUsersSort({ column: column.key, direction: "desc" });
-                                        setOpenUserHeaderMenu(null);
-                                      }}
-                                      onClearSort={() => {
-                                        setUsersSort({ column: null, direction: "asc" });
-                                        setOpenUserHeaderMenu(null);
-                                      }}
-                                      onApplyFilter={(values) => {
-                                        setUserColumnFilters((current) => ({ ...current, [column.key]: values }));
-                                      }}
-                                      onClose={() => setOpenUserHeaderMenu(null)}
-                                      style={openUserHeaderMenu}
-                                    />
-                                  ) : null}
-                                </div>
-                              </th>
-                            );
-                          })}
-                        </tr>
-                      </thead>
-                      <tbody>
-                        {filteredUsers.length ? filteredUsers.map((user) => (
-                          <tr
-                            key={user.id}
-                            className={selectedUserIds.includes(user.id) ? "selected-row" : undefined}
-                            aria-selected={selectedUserIds.includes(user.id)}
-                            onMouseDown={(event) => {
-                              if (event.shiftKey || event.metaKey || event.ctrlKey) {
-                                event.preventDefault();
-                              }
-                            }}
-                            onClick={(event) => handleUserRowSelection(event, user.id)}
-                            onDoubleClick={() => openUserModal("view", user)}
-                          >
-                            <td>{user.name}</td>
-                            <td>{user.email || ""}</td>
-                            <td>
-                              <span className={user.is_active ? "status-chip active" : "status-chip inactive"}>
-                                {user.is_active ? "Active" : "Inactive"}
-                              </span>
-                            </td>
-                            <td className="notes-cell">{(user.notes || "").slice(0, 100) || "-"}</td>
-                          </tr>
-                        )) : (
-                          <tr>
-                            <td colSpan="4" className="empty-state-cell">
-                              {hostedWorkspaceReady ? "No users match the current view." : "Connect the hosted workspace to load users."}
-                            </td>
-                          </tr>
-                        )}
-                      </tbody>
-                    </table>
+              <div className="users-table-scroll-area table-viewport" ref={usersTableViewportRef} onScroll={(e) => setShowBackToTop(e.currentTarget.scrollTop > 120)}>
+                <div className="users-table-header" ref={headerRef} style={columnWidths ? { gridTemplateColumns: `36px ${columnWidths.map((w) => `${w}px`).join(" ")}`, minWidth: `${36 + columnWidths.reduce((a, b) => a + b, 0)}px` } : undefined}>
+                  <div className="users-table-header-cell users-checkbox-cell">
+                    <input
+                      type="checkbox"
+                      className="row-select-checkbox"
+                      aria-label="Select all rows"
+                      checked={filteredUsers.length > 0 && selectedUserIds.length === filteredUsers.length}
+                      ref={(el) => { if (el) el.indeterminate = selectedUserIds.length > 0 && selectedUserIds.length < filteredUsers.length; }}
+                      onChange={() => {
+                        if (selectedUserIds.length === filteredUsers.length) {
+                          setSelectedUserIds([]);
+                          setSelectionAnchorUserId(null);
+                          userNavCursorRef.current = null;
+                        } else {
+                          setSelectedUserIds(filteredUsers.map((u) => u.id));
+                          setSelectionAnchorUserId(filteredUsers[0]?.id ?? null);
+                          userNavCursorRef.current = filteredUsers[filteredUsers.length - 1]?.id ?? null;
+                        }
+                      }}
+                      disabled={!filteredUsers.length}
+                    />
                   </div>
-                  {usersLoadingMore ? <div className="table-loading-row">Loading more users...</div> : null}
-                  {usersHasMore && !usersLoadingMore ? (
-                    <div className="table-load-more-row">
-                      <button className="ghost-button" type="button" onClick={loadNextUsersPage}>Load More Users</button>
-                    </div>
-                  ) : null}
+                  {userTableColumns.map((column, colIndex) => {
+                    const sortDirection = usersSort.column === column.key ? usersSort.direction : null;
+                    const filterValues = userColumnFilters[column.key];
+                    return (
+                      <div key={column.key} className={`users-table-header-cell${selectedColumnKeys.has(column.key) ? " selected-column" : ""}`} onClick={(event) => {
+                        // Clear row selection when selecting columns
+                        setSelectedUserIds([]);
+                        setSelectionAnchorUserId(null);
+
+                        const columnKeys = userTableColumns.map((c) => c.key);
+                        let nextCols;
+                        if (event.shiftKey && selectedColumnKeys.size) {
+                          const lastKey = [...selectedColumnKeys].pop();
+                          const lastIdx = columnKeys.indexOf(lastKey);
+                          const curIdx = columnKeys.indexOf(column.key);
+                          const [start, end] = lastIdx < curIdx ? [lastIdx, curIdx] : [curIdx, lastIdx];
+                          nextCols = new Set(columnKeys.slice(start, end + 1));
+                        } else if (event.metaKey || event.ctrlKey) {
+                          nextCols = new Set(selectedColumnKeys);
+                          if (nextCols.has(column.key)) nextCols.delete(column.key); else nextCols.add(column.key);
+                        } else {
+                          nextCols = selectedColumnKeys.size === 1 && selectedColumnKeys.has(column.key) ? new Set() : new Set([column.key]);
+                        }
+                        setSelectedColumnKeys(nextCols);
+
+                        // Populate selectedCells with all cells in selected columns
+                        const next = new Set();
+                        for (const user of filteredUsers) {
+                          for (const col of nextCols) {
+                            next.add(`${user.id}:${col}`);
+                          }
+                        }
+                        setSelectedCells(next);
+                        cellAnchorRef.current = null;
+                      }} onContextMenu={(event) => { event.preventDefault(); openUserHeaderOptions(event, column.key); }}>
+                        <span className="users-table-header-label">{column.label}</span>
+                        <button
+                          className={sortDirection || filterValues.length ? "table-sort-button active" : "table-sort-button"}
+                          type="button"
+                          aria-label={`${column.label} options`}
+                          onClick={(event) => { event.stopPropagation(); openUserHeaderOptions(event, column.key); }}
+                        >
+                          <span className="table-sort-indicator" aria-hidden="true">
+                            {sortDirection === "asc"
+                              ? "↑"
+                              : sortDirection === "desc"
+                                ? "↓"
+                                : filterValues.length
+                                  ? filterValues.length
+                                  : <Icon name="filterMenu" className="app-icon table-filter-icon" />}
+                          </span>
+                        </button>
+
+                        {openUserHeaderMenu?.key === column.key ? (
+                          <UserHeaderFilterMenu
+                              column={column}
+                              options={userFilterOptions[column.key]}
+                              selectedValues={filterValues}
+                              sortDirection={sortDirection}
+                              onClearFilter={() => {
+                                setUserColumnFilters((current) => ({ ...current, [column.key]: [] }));
+                                setOpenUserHeaderMenu(null);
+                              }}
+                              onSortAsc={() => {
+                                setUsersSort({ column: column.key, direction: "asc" });
+                                setOpenUserHeaderMenu(null);
+                              }}
+                              onSortDesc={() => {
+                                setUsersSort({ column: column.key, direction: "desc" });
+                                setOpenUserHeaderMenu(null);
+                              }}
+                              onClearSort={() => {
+                                setUsersSort({ column: null, direction: "asc" });
+                                setOpenUserHeaderMenu(null);
+                              }}
+                              onApplyFilter={(values) => {
+                                setUserColumnFilters((current) => ({ ...current, [column.key]: values }));
+                              }}
+                            onClose={() => setOpenUserHeaderMenu(null)}
+                            style={openUserHeaderMenu}
+                          />
+                        ) : null}
+                        <div
+                          className="column-resize-handle"
+                          onMouseDown={(event) => handleColumnResizeStart(event, colIndex)}
+                          onDoubleClick={(event) => { event.stopPropagation(); handleColumnAutoFit(colIndex); }}
+                          onClick={(event) => event.stopPropagation()}
+                        />
+                      </div>
+                    );
+                  })}
                 </div>
+
+                <table className="data-table users-data-table" style={columnWidths ? { tableLayout: "fixed" } : undefined}>
+                  <colgroup>
+                    <col style={{ width: "36px" }} />
+                    {columnWidths
+                      ? columnWidths.map((w, i) => <col key={i} style={{ width: `${w}px` }} />)
+                      : <>
+                          <col style={{ width: "20%" }} />
+                          <col style={{ width: "30%" }} />
+                          <col style={{ width: "12%" }} />
+                          <col />
+                        </>
+                    }
+                  </colgroup>
+                  <tbody>
+                    {filteredUsers.length ? filteredUsers.map((user) => (
+                      <tr
+                        key={user.id}
+                        className={selectedUserIds.includes(user.id) ? "selected-row" : undefined}
+                        aria-selected={selectedUserIds.includes(user.id)}
+                        onMouseDown={(event) => {
+                          if (event.shiftKey || event.metaKey || event.ctrlKey) {
+                            event.preventDefault();
+                          }
+                        }}
+                        onClick={(event) => handleUserRowSelection(event, user.id)}
+                        onDoubleClick={() => openUserModal("view", user)}
+                        onContextMenu={(event) => handleTableContextMenu(event, user)}
+                      >
+                        <td className="row-checkbox-cell" onClick={(event) => event.stopPropagation()}>
+                          <input
+                            type="checkbox"
+                            className="row-select-checkbox"
+                            aria-label={`Select ${user.name}`}
+                            checked={selectedUserIds.includes(user.id)}
+                            onChange={() => {
+                              setSelectedUserIds((current) =>
+                                current.includes(user.id)
+                                  ? current.filter((id) => id !== user.id)
+                                  : [...current, user.id]
+                              );
+                              setSelectionAnchorUserId(user.id);
+                            }}
+                          />
+                        </td>
+                        <td data-col="name" className={selectedCells.has(`${user.id}:name`) ? "selected-cell" : selectedColumnKeys.has("name") ? "selected-column-cell" : undefined} onClick={(event) => { if (handleCellClick(event, user.id, "name")) return; }}><HighlightMatch text={user.name} query={usersSearch} /></td>
+                        <td data-col="email" className={selectedCells.has(`${user.id}:email`) ? "selected-cell" : selectedColumnKeys.has("email") ? "selected-column-cell" : undefined} onClick={(event) => { if (handleCellClick(event, user.id, "email")) return; }}><HighlightMatch text={user.email || ""} query={usersSearch} /></td>
+                        <td data-col="status" className={selectedCells.has(`${user.id}:status`) ? "selected-cell" : selectedColumnKeys.has("status") ? "selected-column-cell" : undefined} onClick={(event) => { if (handleCellClick(event, user.id, "status")) return; }}>
+                          <span className={user.is_active ? "status-chip active" : "status-chip inactive"}>
+                            {user.is_active ? "Active" : "Inactive"}
+                          </span>
+                        </td>
+                        <td data-col="notes" className={`notes-cell${selectedCells.has(`${user.id}:notes`) ? " selected-cell" : selectedColumnKeys.has("notes") ? " selected-column-cell" : ""}`} onClick={(event) => { if (handleCellClick(event, user.id, "notes")) return; }} title={(user.notes || "").length > 100 ? user.notes : undefined}><HighlightMatch text={(user.notes || "").slice(0, 100) || "-"} query={usersSearch} /></td>
+                      </tr>
+                    )) : (
+                      <tr>
+                        <td colSpan="5" className="empty-state-cell">
+                          <div className="empty-state-graphic">
+                            <svg width="64" height="64" viewBox="0 0 64 64" fill="none" aria-hidden="true">
+                              <rect x="8" y="16" width="48" height="36" rx="4" stroke="rgba(255,255,255,0.12)" strokeWidth="1.5" />
+                              <line x1="8" y1="28" x2="56" y2="28" stroke="rgba(255,255,255,0.08)" strokeWidth="1" />
+                              <line x1="8" y1="38" x2="56" y2="38" stroke="rgba(255,255,255,0.06)" strokeWidth="1" />
+                              <line x1="28" y1="16" x2="28" y2="52" stroke="rgba(255,255,255,0.06)" strokeWidth="1" />
+                              <circle cx="32" cy="40" r="8" stroke="rgba(126,195,172,0.25)" strokeWidth="1.5" />
+                              <line x1="38" y1="46" x2="44" y2="52" stroke="rgba(126,195,172,0.25)" strokeWidth="1.5" strokeLinecap="round" />
+                            </svg>
+                            <p>{hostedWorkspaceReady
+                              ? (usersSearch
+                                ? <>No results for &ldquo;{usersSearch}&rdquo;. <button className="inline-link-button" type="button" onClick={() => { setUsersSearch(""); clearUserSelection(); }}>Clear search</button></>
+                                : "No users match the current view.")
+                              : "Connect the hosted workspace to load users."
+                            }</p>
+                          </div>
+                        </td>
+                      </tr>
+                    )}
+                  </tbody>
+                </table>
+              </div>{/* end .users-table-scroll-area */}
+
                 <div className="users-summary-rail users-summary-rail-bottom" aria-label="User summary">
                   <div className="users-page-metrics">
                     <span className="users-metric-chip">{filteredUserCount} shown</span>
                     <span className="users-metric-chip subdued">{totalUserCount} total</span>
                     {selectedUserIds.length ? <span className="users-metric-chip accent">{selectedUserIds.length} selected</span> : null}
                     {usersFiltersActive ? <span className="users-metric-chip subdued">Filtered view</span> : null}
+                    {selectedCells.size ? (() => {
+                      const cellValues = [];
+                      for (const cellId of selectedCells) {
+                        const [userId, colKey] = cellId.split(":");
+                        const user = filteredUsers.find((u) => u.id === userId);
+                        if (user) cellValues.push(getCellDisplayValue(user, colKey));
+                      }
+                      const stats = computeCellStats(cellValues);
+                      return (
+                        <>
+                          <span className="users-metric-chip column-agg">Count: {stats.count}</span>
+                          {stats.numericCount > 0 ? (
+                            <>
+                              <span className="users-metric-chip column-agg">Sum: {stats.sum.toLocaleString(undefined, { minimumFractionDigits: 0, maximumFractionDigits: 2 })}</span>
+                              <span className="users-metric-chip column-agg">Avg: {stats.avg.toLocaleString(undefined, { minimumFractionDigits: 0, maximumFractionDigits: 2 })}</span>
+                              <span className="users-metric-chip column-agg">Min: {stats.min}</span>
+                              <span className="users-metric-chip column-agg">Max: {stats.max}</span>
+                            </>
+                          ) : null}
+                          {stats.numericCount === 0 ? <span className="users-metric-chip column-agg">{new Set(cellValues).size} unique</span> : null}
+                        </>
+                      );
+                    })() : null}
                   </div>
-                </div>
-              </div>
-            </div>
+                  <div className="users-summary-actions">
+                    {usersHasMore && !usersFiltersActive ? (
+                      <button className="ghost-button" type="button" onClick={loadNextUsersPage} disabled={usersLoadingMore}>
+                        {usersLoadingMore ? "Loading..." : "Load More Users"}
+                      </button>
+                    ) : null}
+                  </div>
+                </div>{/* end .users-summary-rail-bottom */}
+
+              <button
+                className={`back-to-top-button${showBackToTop ? " visible" : ""}`}
+                type="button"
+                aria-label="Back to top"
+                onClick={() => {
+                  const viewport = usersTableViewportRef.current;
+                  if (viewport) viewport.scrollTo({ top: 0, behavior: "smooth" });
+                }}
+              >
+                ↑
+              </button>
+            </div>{/* end .users-surface */}
           </section>
       ) : null}
       </main>
+
+      {contextMenu ? (
+        <TableContextMenu
+          position={{ x: contextMenu.x, y: contextMenu.y }}
+          items={contextMenu.items}
+          onClose={() => setContextMenu(null)}
+        />
+      ) : null}
+
+      {exportModalOpen ? (
+        <ExportModal
+          filteredUsers={filteredUsers}
+          selectedUsers={selectedUsers}
+          selectedCells={selectedCells}
+          allColumns={userTableColumns}
+          onExport={(users, columns) => downloadUsersCsv(users, columns)}
+          onClose={() => setExportModalOpen(false)}
+        />
+      ) : null}
 
       {notificationsModalOpen ? (
         <NotificationsModal onClose={() => setNotificationsModalOpen(false)} />

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -913,6 +913,7 @@ function UserModal({
 export default function App() {
   const usersScrollGateRef = useRef({ armed: false, lastScrollTop: 0 });
   const usersPagingRequestRef = useRef(false);
+  const usersTableViewportRef = useRef(null);
   const [currentRoute, setCurrentRoute] = useState(() => readCurrentRoute());
   const isMigrationPage = currentRoute === "/migration";
   const [railCollapsed, setRailCollapsed] = useState(false);
@@ -1056,7 +1057,6 @@ export default function App() {
 
   const filteredUserCount = filteredUsers.length;
   const totalUserCount = usersTotalCount ?? users.length;
-  const usersTotalKnown = usersTotalCount !== null;
   const devToolsVisible = Boolean(import.meta.env.DEV);
 
   const selectedUsers = users.filter((user) => selectedUserIds.includes(user.id));
@@ -1323,14 +1323,12 @@ export default function App() {
         }
       }
 
-      const totalCount = hasMore && ((reportedTotalCount ?? 0) <= mergedUsers.length)
-        ? null
-        : Math.max(reportedTotalCount ?? 0, mergedUsers.length);
+      const totalCount = Math.max(reportedTotalCount ?? 0, mergedUsers.length);
 
       if (!append) {
         usersScrollGateRef.current = {
           armed: false,
-          lastScrollTop: window.scrollY || document.documentElement.scrollTop || 0,
+          lastScrollTop: usersTableViewportRef.current?.scrollTop || 0,
         };
       }
 
@@ -1343,9 +1341,7 @@ export default function App() {
       if (!mergedUsers.length) {
         setUsersStatus("No hosted users yet. Add your first user to get started.");
       } else if (hasMore) {
-        setUsersStatus(totalCount === null
-          ? `Loaded ${mergedUsers.length} hosted users. More may be available.`
-          : `Loaded ${mergedUsers.length} of ${totalCount} hosted users.`);
+        setUsersStatus(`Loaded ${mergedUsers.length} of ${totalCount} hosted users.`);
       } else {
         setUsersStatus("Hosted users ready.");
       }
@@ -1435,8 +1431,13 @@ export default function App() {
       return undefined;
     }
 
-    function handleWindowScroll() {
-      const scrollTop = window.scrollY || document.documentElement.scrollTop || 0;
+    const viewport = usersTableViewportRef.current;
+    if (!viewport) {
+      return undefined;
+    }
+
+    function handleViewportScroll() {
+      const scrollTop = viewport.scrollTop || 0;
       const scrollGate = usersScrollGateRef.current;
 
       if (!scrollGate.armed) {
@@ -1447,19 +1448,16 @@ export default function App() {
       }
 
       scrollGate.lastScrollTop = scrollTop;
-      const viewportBottom = scrollTop + window.innerHeight;
-      const documentHeight = Math.max(
-        document.body.scrollHeight,
-        document.documentElement.scrollHeight,
-      );
+      const viewportBottom = scrollTop + viewport.clientHeight;
+      const documentHeight = viewport.scrollHeight;
 
       if (documentHeight - viewportBottom <= 220) {
         loadNextUsersPage();
       }
     }
 
-    window.addEventListener("scroll", handleWindowScroll, { passive: true });
-    return () => window.removeEventListener("scroll", handleWindowScroll);
+    viewport.addEventListener("scroll", handleViewportScroll, { passive: true });
+    return () => viewport.removeEventListener("scroll", handleViewportScroll);
   }, [hasAuthenticatedSession, usersFiltersActive, usersHasMore, usersLoadingInitial, usersLoadingMore, usersNextOffset]);
 
   function openUserHeaderOptions(event, columnKey) {
@@ -2253,151 +2251,168 @@ export default function App() {
                   <h2>Users</h2>
                 </div>
               </div>
-              <div className="toolbar-row wrap-toolbar users-toolbar-panel">
-                <button className="primary-button" type="button" onClick={() => openUserModal("create")} disabled={!hostedWorkspaceReady}>Add User</button>
-                <button className="ghost-button" type="button" onClick={() => selectedUser && openUserModal("view", selectedUser)} disabled={!hostedWorkspaceReady || selectedUserIds.length !== 1}>View</button>
-                <button className="ghost-button" type="button" onClick={() => selectedUser && openUserModal("edit", selectedUser)} disabled={!hostedWorkspaceReady || selectedUserIds.length !== 1}>Edit</button>
-                <button className="ghost-button" type="button" onClick={() => handleDeleteUser()} disabled={!hostedWorkspaceReady || !selectedUserIds.length}>Delete</button>
-                <button className="ghost-button" type="button" onClick={() => downloadUsersCsv(filteredUsers)} disabled={!filteredUsers.length}>Export CSV</button>
-                <button className="ghost-button" type="button" onClick={handleUsersRefresh} disabled={!hostedWorkspaceReady}>Refresh</button>
-                {devToolsVisible ? <button className="ghost-button" type="button" onClick={handleSeedDemoUsers} disabled={!hostedWorkspaceReady}>Seed 200 Demo Users</button> : null}
-              </div>
               <div className="users-page-header-copy">
                 <p className="users-page-note">Manage workspace users, inspect individual records, and export the current filtered view.</p>
-                <div className="users-page-metrics" aria-label="User summary">
-                  <span className="users-metric-chip">{filteredUserCount} shown</span>
-                  {usersTotalKnown ? <span className="users-metric-chip subdued">{totalUserCount} total</span> : null}
-                  {selectedUserIds.length ? <span className="users-metric-chip accent">{selectedUserIds.length} selected</span> : null}
-                  {usersFiltersActive ? <span className="users-metric-chip subdued">Filtered view</span> : null}
-                </div>
               </div>
             </div>
 
             <div className="users-surface">
-              <div className="users-search-bar">
-                <label className="users-search-field" htmlFor="users-search-input">
-                  <span className="users-search-icon" aria-hidden="true"><Icon name="search" className="app-icon" /></span>
-                  <input
-                    id="users-search-input"
-                    className="text-input hero-search-input"
-                    type="search"
-                    placeholder="Search users..."
-                    value={usersSearch}
-                    disabled={!hostedWorkspaceReady}
-                    onChange={(event) => setUsersSearch(event.target.value)}
-                  />
-                </label>
-                <div className="toolbar-row users-search-actions">
-                  <button className="ghost-button" type="button" onClick={() => { setUsersSearch(""); clearUserSelection(); }}>Clear Search</button>
-                  <button className="ghost-button" type="button" onClick={clearAllUserFilters}>Clear All Filters</button>
+              <div className="sticky-tools users-sticky-tools">
+                <div className="toolbar-row wrap-toolbar users-toolbar-panel">
+                  <button className="primary-button" type="button" onClick={() => openUserModal("create")} disabled={!hostedWorkspaceReady}>Add User</button>
+                  <button className="ghost-button" type="button" onClick={() => selectedUser && openUserModal("view", selectedUser)} disabled={!hostedWorkspaceReady || selectedUserIds.length !== 1}>View</button>
+                  <button className="ghost-button" type="button" onClick={() => selectedUser && openUserModal("edit", selectedUser)} disabled={!hostedWorkspaceReady || selectedUserIds.length !== 1}>Edit</button>
+                  <button className="ghost-button" type="button" onClick={() => handleDeleteUser()} disabled={!hostedWorkspaceReady || !selectedUserIds.length}>Delete</button>
+                  <button className="ghost-button" type="button" onClick={() => downloadUsersCsv(filteredUsers)} disabled={!filteredUsers.length}>Export CSV</button>
+                  <button className="ghost-button" type="button" onClick={handleUsersRefresh} disabled={!hostedWorkspaceReady}>Refresh</button>
+                  {devToolsVisible ? <button className="ghost-button" type="button" onClick={handleSeedDemoUsers} disabled={!hostedWorkspaceReady}>Seed 200 Demo Users</button> : null}
+                </div>
+                <div className="users-search-bar">
+                  <label className="users-search-field" htmlFor="users-search-input">
+                    <span className="users-search-icon" aria-hidden="true"><Icon name="search" className="app-icon" /></span>
+                    <input
+                      id="users-search-input"
+                      className="text-input hero-search-input"
+                      type="text"
+                      placeholder="Search users..."
+                      value={usersSearch}
+                      disabled={!hostedWorkspaceReady}
+                      onChange={(event) => setUsersSearch(event.target.value)}
+                    />
+                  </label>
+                  <div className="toolbar-row users-search-actions">
+                    <button className="ghost-button" type="button" onClick={() => { setUsersSearch(""); clearUserSelection(); }}>Clear Search</button>
+                    <button className="ghost-button" type="button" onClick={clearAllUserFilters}>Clear All Filters</button>
+                  </div>
                 </div>
               </div>
 
-              <div className="table-shell">
-                <table className="data-table">
-                  <thead>
-                    <tr>
-                      {userTableColumns.map((column) => {
-                        const sortDirection = usersSort.column === column.key ? usersSort.direction : null;
-                        const filterValues = userColumnFilters[column.key];
-                        return (
-                          <th key={column.key}>
-                            <div className="table-header-menu-wrap">
-                              <button
-                                className={sortDirection || filterValues.length ? "table-sort-button active" : "table-sort-button"}
-                                type="button"
-                                aria-label={`${column.label} options`}
-                                onClick={(event) => openUserHeaderOptions(event, column.key)}
-                              >
-                                <span>{column.label}</span>
-                                <span className="table-sort-indicator" aria-hidden="true">
-                                  {sortDirection === "asc"
-                                    ? "↑"
-                                    : sortDirection === "desc"
-                                      ? "↓"
-                                      : filterValues.length
-                                        ? filterValues.length
-                                        : <Icon name="filterMenu" className="app-icon table-filter-icon" />}
-                                </span>
-                              </button>
+              <div className="users-summary-rail users-summary-rail-top" aria-label="User summary">
+                <div className="users-page-metrics">
+                  <span className="users-metric-chip">{filteredUserCount} shown</span>
+                  <span className="users-metric-chip subdued">{totalUserCount} total</span>
+                  {selectedUserIds.length ? <span className="users-metric-chip accent">{selectedUserIds.length} selected</span> : null}
+                  {usersFiltersActive ? <span className="users-metric-chip subdued">Filtered view</span> : null}
+                </div>
+              </div>
 
-                              {openUserHeaderMenu?.key === column.key ? (
-                                <UserHeaderFilterMenu
-                                  column={column}
-                                  options={userFilterOptions[column.key]}
-                                  selectedValues={filterValues}
-                                  sortDirection={sortDirection}
-                                  onClearFilter={() => {
-                                    setUserColumnFilters((current) => ({ ...current, [column.key]: [] }));
-                                    setOpenUserHeaderMenu(null);
-                                  }}
-                                  onSortAsc={() => {
-                                    setUsersSort({ column: column.key, direction: "asc" });
-                                    setOpenUserHeaderMenu(null);
-                                  }}
-                                  onSortDesc={() => {
-                                    setUsersSort({ column: column.key, direction: "desc" });
-                                    setOpenUserHeaderMenu(null);
-                                  }}
-                                  onClearSort={() => {
-                                    setUsersSort({ column: null, direction: "asc" });
-                                    setOpenUserHeaderMenu(null);
-                                  }}
-                                  onApplyFilter={(values) => {
-                                    setUserColumnFilters((current) => ({ ...current, [column.key]: values }));
-                                  }}
-                                  onClose={() => setOpenUserHeaderMenu(null)}
-                                  style={openUserHeaderMenu}
-                                />
-                              ) : null}
-                            </div>
-                          </th>
-                        );
-                      })}
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {filteredUsers.length ? filteredUsers.map((user) => (
-                      <tr
-                        key={user.id}
-                        className={selectedUserIds.includes(user.id) ? "selected-row" : undefined}
-                        aria-selected={selectedUserIds.includes(user.id)}
-                        onMouseDown={(event) => {
-                          if (event.shiftKey || event.metaKey || event.ctrlKey) {
-                            event.preventDefault();
-                          }
-                        }}
-                        onClick={(event) => handleUserRowSelection(event, user.id)}
-                        onDoubleClick={() => openUserModal("view", user)}
-                      >
-                        <td>{user.name}</td>
-                        <td>{user.email || ""}</td>
-                        <td>
-                          <span className={user.is_active ? "status-chip active" : "status-chip inactive"}>
-                            {user.is_active ? "Active" : "Inactive"}
-                          </span>
-                        </td>
-                        <td className="notes-cell">{(user.notes || "").slice(0, 100) || "-"}</td>
-                      </tr>
-                    )) : (
-                      <tr>
-                        <td colSpan="4" className="empty-state-cell">
-                          {hostedWorkspaceReady ? "No users match the current view." : "Connect the hosted workspace to load users."}
-                        </td>
-                      </tr>
-                    )}
-                  </tbody>
-                </table>
-                {usersLoadingMore ? <div className="table-loading-row">Loading more users...</div> : null}
-                {usersHasMore && !usersLoadingMore ? (
-                  <div className="table-load-more-row">
-                    <button className="ghost-button" type="button" onClick={loadNextUsersPage}>Load More Users</button>
+              <div className="users-table-stack">
+                <div className="table-shell">
+                  <div className="table-viewport" ref={usersTableViewportRef}>
+                    <table className="data-table">
+                      <thead>
+                        <tr>
+                          {userTableColumns.map((column) => {
+                            const sortDirection = usersSort.column === column.key ? usersSort.direction : null;
+                            const filterValues = userColumnFilters[column.key];
+                            return (
+                              <th key={column.key}>
+                                <div className="table-header-menu-wrap">
+                                  <button
+                                    className={sortDirection || filterValues.length ? "table-sort-button active" : "table-sort-button"}
+                                    type="button"
+                                    aria-label={`${column.label} options`}
+                                    onClick={(event) => openUserHeaderOptions(event, column.key)}
+                                  >
+                                    <span>{column.label}</span>
+                                    <span className="table-sort-indicator" aria-hidden="true">
+                                      {sortDirection === "asc"
+                                        ? "↑"
+                                        : sortDirection === "desc"
+                                          ? "↓"
+                                          : filterValues.length
+                                            ? filterValues.length
+                                            : <Icon name="filterMenu" className="app-icon table-filter-icon" />}
+                                    </span>
+                                  </button>
+
+                                  {openUserHeaderMenu?.key === column.key ? (
+                                    <UserHeaderFilterMenu
+                                      column={column}
+                                      options={userFilterOptions[column.key]}
+                                      selectedValues={filterValues}
+                                      sortDirection={sortDirection}
+                                      onClearFilter={() => {
+                                        setUserColumnFilters((current) => ({ ...current, [column.key]: [] }));
+                                        setOpenUserHeaderMenu(null);
+                                      }}
+                                      onSortAsc={() => {
+                                        setUsersSort({ column: column.key, direction: "asc" });
+                                        setOpenUserHeaderMenu(null);
+                                      }}
+                                      onSortDesc={() => {
+                                        setUsersSort({ column: column.key, direction: "desc" });
+                                        setOpenUserHeaderMenu(null);
+                                      }}
+                                      onClearSort={() => {
+                                        setUsersSort({ column: null, direction: "asc" });
+                                        setOpenUserHeaderMenu(null);
+                                      }}
+                                      onApplyFilter={(values) => {
+                                        setUserColumnFilters((current) => ({ ...current, [column.key]: values }));
+                                      }}
+                                      onClose={() => setOpenUserHeaderMenu(null)}
+                                      style={openUserHeaderMenu}
+                                    />
+                                  ) : null}
+                                </div>
+                              </th>
+                            );
+                          })}
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {filteredUsers.length ? filteredUsers.map((user) => (
+                          <tr
+                            key={user.id}
+                            className={selectedUserIds.includes(user.id) ? "selected-row" : undefined}
+                            aria-selected={selectedUserIds.includes(user.id)}
+                            onMouseDown={(event) => {
+                              if (event.shiftKey || event.metaKey || event.ctrlKey) {
+                                event.preventDefault();
+                              }
+                            }}
+                            onClick={(event) => handleUserRowSelection(event, user.id)}
+                            onDoubleClick={() => openUserModal("view", user)}
+                          >
+                            <td>{user.name}</td>
+                            <td>{user.email || ""}</td>
+                            <td>
+                              <span className={user.is_active ? "status-chip active" : "status-chip inactive"}>
+                                {user.is_active ? "Active" : "Inactive"}
+                              </span>
+                            </td>
+                            <td className="notes-cell">{(user.notes || "").slice(0, 100) || "-"}</td>
+                          </tr>
+                        )) : (
+                          <tr>
+                            <td colSpan="4" className="empty-state-cell">
+                              {hostedWorkspaceReady ? "No users match the current view." : "Connect the hosted workspace to load users."}
+                            </td>
+                          </tr>
+                        )}
+                      </tbody>
+                    </table>
                   </div>
-                ) : null}
+                  {usersLoadingMore ? <div className="table-loading-row">Loading more users...</div> : null}
+                  {usersHasMore && !usersLoadingMore ? (
+                    <div className="table-load-more-row">
+                      <button className="ghost-button" type="button" onClick={loadNextUsersPage}>Load More Users</button>
+                    </div>
+                  ) : null}
+                </div>
+                <div className="users-summary-rail users-summary-rail-bottom" aria-label="User summary">
+                  <div className="users-page-metrics">
+                    <span className="users-metric-chip">{filteredUserCount} shown</span>
+                    <span className="users-metric-chip subdued">{totalUserCount} total</span>
+                    {selectedUserIds.length ? <span className="users-metric-chip accent">{selectedUserIds.length} selected</span> : null}
+                    {usersFiltersActive ? <span className="users-metric-chip subdued">Filtered view</span> : null}
+                  </div>
+                </div>
               </div>
             </div>
           </section>
-        ) : null}
+      ) : null}
       </main>
 
       {notificationsModalOpen ? (

--- a/web/src/App.test.jsx
+++ b/web/src/App.test.jsx
@@ -1219,29 +1219,28 @@ describe("App", () => {
     expect(await findUserCell("Alpha")).toBeInTheDocument();
     expect(within(await screen.findByRole("table")).queryByText("Beta")).not.toBeInTheDocument();
 
-    Object.defineProperty(window, "innerHeight", { configurable: true, value: 900, writable: true });
-    Object.defineProperty(window, "scrollY", { configurable: true, value: 0, writable: true });
-    Object.defineProperty(document.body, "scrollHeight", { configurable: true, value: 1000 });
-    Object.defineProperty(document.documentElement, "scrollHeight", { configurable: true, value: 1000 });
-    Object.defineProperty(document.documentElement, "scrollTop", { configurable: true, value: 0, writable: true });
-    fireEvent.scroll(window);
+    const tableViewport = (await screen.findByRole("table")).closest(".table-viewport");
+    expect(tableViewport).not.toBeNull();
+
+    Object.defineProperty(tableViewport, "clientHeight", { configurable: true, value: 600 });
+    Object.defineProperty(tableViewport, "scrollHeight", { configurable: true, value: 1000, writable: true });
+    Object.defineProperty(tableViewport, "scrollTop", { configurable: true, value: 0, writable: true });
+    fireEvent.scroll(tableViewport);
 
     await waitFor(() => {
       expect(global.fetch).toHaveBeenCalledTimes(4);
     });
 
-    Object.defineProperty(window, "scrollY", { configurable: true, value: 1200, writable: true });
-    Object.defineProperty(document.body, "scrollHeight", { configurable: true, value: 2280 });
-    Object.defineProperty(document.documentElement, "scrollHeight", { configurable: true, value: 2280 });
-    Object.defineProperty(document.documentElement, "scrollTop", { configurable: true, value: 1200, writable: true });
-    fireEvent.scroll(window);
+    Object.defineProperty(tableViewport, "scrollHeight", { configurable: true, value: 1820, writable: true });
+    Object.defineProperty(tableViewport, "scrollTop", { configurable: true, value: 1220, writable: true });
+    fireEvent.scroll(tableViewport);
 
     expect(await findUserCell("Beta")).toBeInTheDocument();
 
     const rows = within(await screen.findByRole("table")).getAllByRole("row");
     fireEvent.click(within(rows[1]).getByText("Alpha"));
     fireEvent.click(within(rows[2]).getByText("Beta"), { ctrlKey: true });
-    expect(screen.getByText(/2 selected/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/2 selected/i)).toHaveLength(2);
 
     fireEvent.click(screen.getByRole("button", { name: /^delete$/i }));
     const deleteDialog = await screen.findByRole("alertdialog", { name: /delete users\?/i });
@@ -1325,6 +1324,8 @@ describe("App", () => {
     render(<App />);
 
     expect(await findUserCell("User 001")).toBeInTheDocument();
+    expect(screen.getAllByText("100 shown")).toHaveLength(2);
+    expect(screen.getAllByText("151 total")).toHaveLength(2);
     const table = await screen.findByRole("table");
     expect(within(table).getAllByRole("row")).toHaveLength(101);
     expect(within(table).queryByText("User 151")).not.toBeInTheDocument();
@@ -1406,14 +1407,15 @@ describe("App", () => {
     render(<App />);
 
     expect(await findUserCell("User 001")).toBeInTheDocument();
-    expect(screen.queryByText(/101 total/i)).not.toBeInTheDocument();
-    expect(screen.queryByText(/more available/i)).not.toBeInTheDocument();
-    expect(screen.queryByText(/100 loaded/i)).not.toBeInTheDocument();
+    expect(screen.getAllByText("100 shown")).toHaveLength(2);
+    expect(screen.getAllByText("100 total")).toHaveLength(2);
     expect(screen.getByRole("button", { name: /load more users/i })).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: /load more users/i }));
 
     expect(await findUserCell("User 101")).toBeInTheDocument();
+    expect(screen.getAllByText("101 shown")).toHaveLength(2);
+    expect(screen.getAllByText("101 total")).toHaveLength(2);
   });
 
   it("falls back when the hosted API repeats the first page for later offsets", async () => {
@@ -1511,6 +1513,8 @@ describe("App", () => {
     fireEvent.click(screen.getByRole("button", { name: /load more users/i }));
 
     expect(await findUserCell("User 151")).toBeInTheDocument();
+    expect(screen.getAllByText("151 shown")).toHaveLength(2);
+    expect(screen.getAllByText("151 total")).toHaveLength(2);
     expect(global.fetch).toHaveBeenCalledWith(
       "https://api.sezzions.test/v1/workspace/users?limit=500&offset=0",
       expect.objectContaining({

--- a/web/src/App.test.jsx
+++ b/web/src/App.test.jsx
@@ -1118,7 +1118,7 @@ describe("App", () => {
     fireEvent.click(screen.getByRole("button", { name: /sort a to z/i }));
 
     const rows = screen.getAllByRole("row");
-    const nameCellsAsc = rows.slice(1).map((row) => within(row).getAllByRole("cell")[0]);
+    const nameCellsAsc = rows.map((row) => within(row).getAllByRole("cell")[1]);
     expect(nameCellsAsc[0]).toHaveTextContent("Elliot");
 
     fireEvent.click(screen.getByRole("button", { name: /status options/i }));
@@ -1238,9 +1238,9 @@ describe("App", () => {
     expect(await findUserCell("Beta")).toBeInTheDocument();
 
     const rows = within(await screen.findByRole("table")).getAllByRole("row");
-    fireEvent.click(within(rows[1]).getByText("Alpha"));
-    fireEvent.click(within(rows[2]).getByText("Beta"), { ctrlKey: true });
-    expect(screen.getAllByText(/2 selected/i)).toHaveLength(2);
+    fireEvent.click(within(rows[0]).getByText("Alpha"));
+    fireEvent.click(within(rows[1]).getByText("Beta"), { ctrlKey: true });
+    expect(screen.getByText(/2 selected/i)).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: /^delete$/i }));
     const deleteDialog = await screen.findByRole("alertdialog", { name: /delete users\?/i });
@@ -1324,10 +1324,10 @@ describe("App", () => {
     render(<App />);
 
     expect(await findUserCell("User 001")).toBeInTheDocument();
-    expect(screen.getAllByText("100 shown")).toHaveLength(2);
-    expect(screen.getAllByText("151 total")).toHaveLength(2);
+    expect(screen.getByText("100 shown")).toBeInTheDocument();
+    expect(screen.getByText("151 total")).toBeInTheDocument();
     const table = await screen.findByRole("table");
-    expect(within(table).getAllByRole("row")).toHaveLength(101);
+    expect(within(table).getAllByRole("row")).toHaveLength(100);
     expect(within(table).queryByText("User 151")).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: /load more users/i })).toBeInTheDocument();
   });
@@ -1407,15 +1407,15 @@ describe("App", () => {
     render(<App />);
 
     expect(await findUserCell("User 001")).toBeInTheDocument();
-    expect(screen.getAllByText("100 shown")).toHaveLength(2);
-    expect(screen.getAllByText("100 total")).toHaveLength(2);
+    expect(screen.getByText("100 shown")).toBeInTheDocument();
+    expect(screen.getByText("100 total")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /load more users/i })).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: /load more users/i }));
 
     expect(await findUserCell("User 101")).toBeInTheDocument();
-    expect(screen.getAllByText("101 shown")).toHaveLength(2);
-    expect(screen.getAllByText("101 total")).toHaveLength(2);
+    expect(screen.getByText("101 shown")).toBeInTheDocument();
+    expect(screen.getByText("101 total")).toBeInTheDocument();
   });
 
   it("falls back when the hosted API repeats the first page for later offsets", async () => {
@@ -1513,8 +1513,8 @@ describe("App", () => {
     fireEvent.click(screen.getByRole("button", { name: /load more users/i }));
 
     expect(await findUserCell("User 151")).toBeInTheDocument();
-    expect(screen.getAllByText("151 shown")).toHaveLength(2);
-    expect(screen.getAllByText("151 total")).toHaveLength(2);
+    expect(screen.getByText("151 shown")).toBeInTheDocument();
+    expect(screen.getByText("151 total")).toBeInTheDocument();
     expect(global.fetch).toHaveBeenCalledWith(
       "https://api.sezzions.test/v1/workspace/users?limit=500&offset=0",
       expect.objectContaining({

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -219,16 +219,19 @@ h3 {
 }
 
 .app-shell {
+  height: 100vh;
   min-height: 100vh;
   padding: 22px;
   display: grid;
   grid-template-columns: 280px minmax(0, 1fr);
+  grid-template-rows: auto minmax(0, 1fr);
   grid-template-areas:
     "header header"
     "rail main";
   gap: 22px;
   position: relative;
-  align-content: start;
+  align-content: stretch;
+  overflow: hidden;
 }
 
 .app-shell.rail-collapsed {
@@ -585,6 +588,8 @@ h3 {
   align-content: stretch;
   min-width: 0;
   min-height: 0;
+  height: 100%;
+  overflow: hidden;
 }
 
 .workspace-header,
@@ -712,14 +717,17 @@ h3 {
 
 .users-page {
   grid-template-rows: auto minmax(0, 1fr);
-  min-height: calc(100vh - 150px);
+  min-height: 0;
+  height: 100%;
+  overflow: hidden;
 }
 
 .users-surface {
   display: grid;
   gap: 12px;
-  grid-template-rows: auto minmax(0, 1fr);
+  grid-template-rows: auto auto minmax(0, 1fr) auto;
   min-height: 0;
+  overflow: hidden;
 }
 
 .users-page-header {
@@ -787,6 +795,12 @@ h3 {
   border: 1px solid rgba(255, 255, 255, 0.05);
   background: rgba(255, 255, 255, 0.02);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+
+.users-sticky-tools {
+  display: grid;
+  gap: 10px;
+  padding: 0 0 6px;
 }
 
 .detail-section,
@@ -863,7 +877,7 @@ h3 {
 
 .users-search-icon {
   position: absolute;
-  left: 16px;
+  left: 20px;
   z-index: 1;
   color: #86a59c;
   pointer-events: none;
@@ -877,9 +891,10 @@ h3 {
 .hero-search-input {
   min-height: 42px;
   border-radius: 12px;
-  padding-left: 46px;
   background: rgba(255, 255, 255, 0.06);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  -webkit-appearance: none;
+  appearance: none;
 }
 
 .users-search-actions {
@@ -908,20 +923,69 @@ h3 {
   box-shadow: 0 0 0 1px rgba(239, 136, 99, 0.28);
 }
 
+.users-search-field .hero-search-input {
+  padding: 10px 16px 10px 62px;
+}
+
+.users-table-stack {
+  display: grid;
+  gap: 0;
+  min-height: 0;
+}
+
 .table-shell {
-  overflow: visible;
+  overflow: hidden;
   border: 1px solid var(--border);
   border-radius: 12px;
   background: rgba(255, 255, 255, 0.02);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
-  height: auto;
-  min-height: calc(100vh - 255px);
+  display: grid;
+  grid-template-rows: minmax(0, 1fr) auto auto;
+  height: 100%;
+  min-height: 0;
+}
+
+.users-summary-rail {
+  min-height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  padding: 4px 2px 0;
+}
+
+.users-summary-rail-top {
+  padding-top: 0;
+}
+
+.table-viewport {
+  min-height: 0;
+  overflow: auto;
+  scrollbar-gutter: stable both-edges;
+  overscroll-behavior: contain;
 }
 
 .data-table {
   width: 100%;
   border-collapse: collapse;
   min-width: 720px;
+}
+
+.data-table thead th {
+  position: sticky;
+  top: 0;
+  z-index: 4;
+  background: #131a23;
+  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.05);
+}
+
+.users-summary-rail-bottom {
+  position: static;
+  padding: 10px 14px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 12px;
+  background: #141c26;
+  backdrop-filter: none;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
 }
 
 .data-table th,
@@ -1448,6 +1512,10 @@ h3 {
 
   .users-search-bar {
     grid-template-columns: 1fr;
+  }
+
+  .users-sticky-tools {
+    top: 8px;
   }
 
   .header-utility-button {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -560,10 +560,10 @@ h3 {
 }
 
 .detail-grid div {
-  padding: 14px;
-  border-radius: 16px;
-  background: var(--panel-soft);
-  border: 1px solid var(--border);
+  padding: 0;
+  border-radius: 0;
+  background: none;
+  border: none;
 }
 
 .detail-grid dd {
@@ -716,24 +716,133 @@ h3 {
 }
 
 .users-page {
-  grid-template-rows: auto minmax(0, 1fr);
+  grid-template-rows: minmax(0, 1fr);
   min-height: 0;
   height: 100%;
-  overflow: hidden;
+  padding: 0;
+  background: transparent;
+  box-shadow: none;
+  position: relative;
 }
 
 .users-surface {
-  display: grid;
-  gap: 12px;
-  grid-template-rows: auto auto minmax(0, 1fr) auto;
   min-height: 0;
   overflow: hidden;
+  border-radius: 17px;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+}
+
+.users-table-scroll-area {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  overflow-x: auto;
+  overscroll-behavior: contain;
+  /* Firefox scrollbar */
+  scrollbar-color: rgba(255, 255, 255, 0.12) transparent;
+  scrollbar-width: thin;
+}
+
+/* WebKit scrollbar */
+.users-table-scroll-area::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+.users-table-scroll-area::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.users-table-scroll-area::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.10);
+  border-radius: 4px;
+  border: 2px solid transparent;
+  background-clip: padding-box;
+}
+
+.users-table-scroll-area::-webkit-scrollbar-thumb:hover {
+  background: rgba(255, 255, 255, 0.20);
+  border: 2px solid transparent;
+  background-clip: padding-box;
+}
+
+.users-table-scroll-area::-webkit-scrollbar-corner {
+  background: transparent;
+}
+
+.users-intro-band {
+  padding: 14px 14px 0;
+  flex-shrink: 0;
+}
+
+.users-sticky-band {
+  /* no longer needed — action bar is outside scroll area */
+}
+
+.users-toolbar {
+  flex-shrink: 0;
+  display: grid;
+  gap: 6px;
+  padding: 8px 14px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  background: var(--panel);
+}
+
+.users-toolbar-top {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.users-breadcrumb {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  font-size: 0.82rem;
+  color: var(--muted);
+  white-space: nowrap;
+  margin-right: auto;
+}
+
+.breadcrumb-separator {
+  color: rgba(255, 255, 255, 0.22);
+  font-size: 1em;
+}
+
+.breadcrumb-segment.current {
+  color: var(--text);
+  font-weight: 600;
+  font-size: 1.05rem;
+}
+
+h2.breadcrumb-segment {
+  font-size: inherit;
+  line-height: inherit;
+  margin: 0;
+}
+
+.users-toolbar-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.users-action-bar {
+  display: grid;
+  gap: 10px;
+  padding: 10px 14px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  background: var(--panel);
+  backdrop-filter: blur(16px);
 }
 
 .users-page-header {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
-  gap: 14px 18px;
+  gap: 6px 14px;
   align-items: flex-start;
 }
 
@@ -744,11 +853,24 @@ h3 {
 
 .users-page-title-row h2 {
   line-height: 1.05;
+  font-size: 1.2rem;
+}
+
+.users-action-bar .toolbar-row {
+  gap: 8px;
+}
+
+.users-toolbar .toolbar-row {
+  gap: 6px;
+}
+
+.users-action-bar .users-search-bar {
+  gap: 8px;
 }
 
 .users-page-header-copy {
   display: grid;
-  gap: 8px;
+  gap: 4px;
   grid-column: 1 / -1;
   max-width: none;
 }
@@ -756,8 +878,12 @@ h3 {
 .users-page-note {
   margin: 0;
   color: var(--muted);
-  line-height: 1.45;
-  font-size: 0.92rem;
+  line-height: 1.4;
+  font-size: 0.82rem;
+}
+
+.users-page-header-surface {
+  padding: 0;
 }
 
 .users-page-metrics {
@@ -769,13 +895,13 @@ h3 {
 .users-metric-chip {
   display: inline-flex;
   align-items: center;
-  min-height: 28px;
-  padding: 0 10px;
+  min-height: 24px;
+  padding: 0 8px;
   border-radius: 999px;
   border: 1px solid rgba(126, 195, 172, 0.16);
   background: rgba(255, 255, 255, 0.025);
   color: #dce5df;
-  font-size: 0.78rem;
+  font-size: 0.72rem;
 }
 
 .users-metric-chip.subdued {
@@ -790,21 +916,23 @@ h3 {
 }
 
 .users-toolbar-panel {
-  padding: 6px;
-  border-radius: 12px;
-  border: 1px solid rgba(255, 255, 255, 0.05);
-  background: rgba(255, 255, 255, 0.02);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  padding: 0;
+  border-radius: 0;
+  border: none;
+  background: transparent;
+  box-shadow: none;
 }
 
 .users-sticky-tools {
   display: grid;
-  gap: 10px;
-  padding: 0 0 6px;
+  gap: 12px;
+  padding: 16px 18px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
 }
 
 .detail-section,
-.status-overview-card {
+.status-overview-card,
+.status-overview-strip {
   display: grid;
   gap: 12px;
 }
@@ -815,12 +943,22 @@ h3 {
   gap: 12px;
 }
 
-.detail-section,
-.status-overview-card {
+.detail-section {
   padding: 16px;
   border-radius: 16px;
   border: 1px solid var(--border);
   background: var(--panel-soft);
+}
+
+.status-overview-card,
+.status-overview-strip {
+  padding: 12px 16px;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: var(--panel-soft);
+  display: flex;
+  align-items: center;
+  gap: 12px;
 }
 
 .utility-modal {
@@ -845,10 +983,33 @@ h3 {
   grid-template-columns: 1fr;
 }
 
+.user-detail-body {
+  display: grid;
+  gap: 16px;
+}
+
+.user-detail-grid {
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.user-detail-notes {
+  display: grid;
+  gap: 6px;
+}
+
+.detail-label {
+  margin: 0;
+  font-size: 0.74rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: #7ec3ac;
+}
+
 .notes-display {
-  min-height: 88px;
-  padding: 12px;
-  border-radius: 14px;
+  min-height: 72px;
+  padding: 10px 12px;
+  border-radius: 10px;
   background: rgba(255, 255, 255, 0.03);
   border: 1px solid var(--border);
   color: var(--text);
@@ -861,10 +1022,15 @@ h3 {
   border-bottom: 1px solid var(--border);
 }
 
+.users-sticky-tools.sticky-tools {
+  padding-bottom: 14px;
+  border-bottom: none;
+}
+
 .users-search-bar {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
-  gap: 10px;
+  gap: 12px;
   align-items: center;
 }
 
@@ -877,7 +1043,7 @@ h3 {
 
 .users-search-icon {
   position: absolute;
-  left: 20px;
+  left: 16px;
   z-index: 1;
   color: #86a59c;
   pointer-events: none;
@@ -889,12 +1055,20 @@ h3 {
 }
 
 .hero-search-input {
-  min-height: 42px;
-  border-radius: 12px;
+  min-height: 36px;
+  border-radius: 10px;
   background: rgba(255, 255, 255, 0.06);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
   -webkit-appearance: none;
   appearance: none;
+}
+
+.users-page .primary-button,
+.users-page .ghost-button {
+  min-height: 32px;
+  padding: 0 10px;
+  font-size: 0.82rem;
+  border-radius: 8px;
 }
 
 .users-search-actions {
@@ -924,44 +1098,121 @@ h3 {
 }
 
 .users-search-field .hero-search-input {
-  padding: 10px 16px 10px 62px;
+  padding: 8px 14px 8px 52px;
+  font-size: 0.84rem;
 }
 
-.users-table-stack {
+.data-table.users-data-table {
+  border-collapse: separate;
+  border-spacing: 0;
+  table-layout: fixed;
+}
+
+.users-table-header {
   display: grid;
-  gap: 0;
-  min-height: 0;
+  grid-template-columns: 36px 20% 30% 12% 1fr;
+  background: #131a23;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  position: sticky;
+  top: 0;
+  z-index: 5;
+  min-width: 720px;
+}
+
+.users-table-header-cell {
+  padding: 7px 10px;
+  background: rgba(255, 255, 255, 0.035);
+  font-size: 0.71rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #b8c0ca;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 4px;
+  cursor: pointer;
+  user-select: none;
+  position: relative;
+}
+
+.users-table-header-cell:hover {
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.users-table-header-cell.selected-column {
+  background: rgba(100, 180, 220, 0.12);
+  box-shadow: inset 0 -2px 0 rgba(100, 180, 220, 0.5);
+}
+
+.column-resize-handle {
+  position: absolute;
+  right: -2px;
+  top: 4px;
+  bottom: 4px;
+  width: 5px;
+  cursor: col-resize;
+  z-index: 2;
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 2px;
+  transition: background 160ms ease;
+}
+
+.column-resize-handle:hover,
+.column-resize-handle:active {
+  background: rgba(126, 195, 172, 0.45);
+}
+
+.users-table-header-label {
+  flex: 1;
+  min-width: 0;
+}
+
+.users-table-header-cell .table-sort-button {
+  flex: 0 0 auto;
+  width: auto;
+  min-height: 22px;
+  padding: 0 4px;
+}
+
+.selected-column-cell {
+  background: rgba(100, 180, 220, 0.08);
+  box-shadow: inset 0 -1px 0 rgba(100, 180, 220, 0.15);
+}
+
+.selected-cell {
+  background: rgba(100, 180, 220, 0.18);
+  box-shadow: inset 0 0 0 1px rgba(100, 180, 220, 0.45);
+}
+
+.search-highlight {
+  background: rgba(212, 170, 61, 0.28);
+  color: #fff;
+  border-radius: 2px;
+  padding: 0 1px;
+}
+
+.data-table td {
+  cursor: default;
 }
 
 .table-shell {
   overflow: hidden;
-  border: 1px solid var(--border);
-  border-radius: 12px;
-  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-bottom: none;
+  border-radius: 16px 16px 0 0;
+  background: rgba(20, 28, 38, 0.96);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
-  display: grid;
-  grid-template-rows: minmax(0, 1fr) auto auto;
-  height: 100%;
+  position: relative;
   min-height: 0;
+  display: grid;
 }
 
 .users-summary-rail {
-  min-height: 40px;
-  display: flex;
+  min-height: 56px;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 14px;
   align-items: center;
-  justify-content: flex-start;
-  padding: 4px 2px 0;
-}
-
-.users-summary-rail-top {
-  padding-top: 0;
-}
-
-.table-viewport {
-  min-height: 0;
-  overflow: auto;
-  scrollbar-gutter: stable both-edges;
-  overscroll-behavior: contain;
 }
 
 .data-table {
@@ -972,40 +1223,83 @@ h3 {
 
 .data-table thead th {
   position: sticky;
-  top: 0;
+  top: var(--users-action-bar-h, 0px);
   z-index: 4;
   background: #131a23;
   box-shadow: 0 1px 0 rgba(255, 255, 255, 0.05);
 }
 
+.table-viewport {
+  min-height: 0;
+}
+
 .users-summary-rail-bottom {
-  position: static;
-  padding: 10px 14px;
-  border: 1px solid rgba(255, 255, 255, 0.06);
-  border-radius: 12px;
-  background: #141c26;
-  backdrop-filter: none;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
+  flex-shrink: 0;
+  padding: 8px 14px;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+  background: #131a23;
+  box-shadow: none;
+}
+
+.users-summary-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.back-to-top-button {
+  position: absolute;
+  bottom: 60px;
+  right: 20px;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(20, 28, 38, 0.92);
+  color: #b8c0ca;
+  font-size: 1rem;
+  cursor: pointer;
+  display: grid;
+  place-items: center;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  transition: opacity 180ms ease, background 160ms ease, color 160ms ease;
+  z-index: 20;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.back-to-top-button.visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.back-to-top-button:hover {
+  background: rgba(40, 52, 68, 0.95);
+  color: #e7e2d7;
+  border-color: rgba(255, 255, 255, 0.18);
 }
 
 .data-table th,
 .data-table td {
-  padding: 10px 14px;
+  padding: 7px 10px;
   text-align: left;
   border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  font-size: 0.84rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .table-sort-button {
   width: 100%;
-  min-height: 30px;
-  padding: 0 10px;
+  min-height: 26px;
+  padding: 0 8px;
   border: none;
   background: transparent;
   color: inherit;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  font-size: 0.72rem;
+  font-size: 0.68rem;
   font-weight: 700;
   letter-spacing: 0.06em;
   text-transform: uppercase;
@@ -1178,6 +1472,11 @@ h3 {
   user-select: none;
 }
 
+.data-table tbody tr {
+  cursor: pointer;
+  user-select: none;
+}
+
 .data-table tbody tr:hover {
   background: rgba(255, 255, 255, 0.045);
   box-shadow: inset 2px 0 0 rgba(126, 195, 172, 0.42);
@@ -1192,17 +1491,43 @@ h3 {
   background: transparent;
 }
 
+.users-checkbox-cell {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 7px 4px;
+  cursor: default;
+}
+
+.row-checkbox-cell {
+  width: 36px;
+  text-align: center;
+  padding: 7px 4px;
+}
+
+.row-select-checkbox {
+  width: 15px;
+  height: 15px;
+  cursor: pointer;
+  accent-color: var(--accent, #d46b3d);
+}
+
+.users-metric-chip.column-agg {
+  color: rgba(100, 180, 220, 0.9);
+  border-color: rgba(100, 180, 220, 0.25);
+}
+
 .notes-cell {
   color: var(--muted);
   max-width: 360px;
-  font-size: 0.92rem;
+  font-size: 0.82rem;
 }
 
 .status-chip {
   display: inline-flex;
   align-items: center;
-  min-height: 28px;
-  padding: 0 10px;
+  min-height: 22px;
+  padding: 0 8px;
   border-radius: 999px;
   font-size: 0.82rem;
   font-weight: 700;
@@ -1222,6 +1547,168 @@ h3 {
   color: var(--muted);
   text-align: center;
   padding: 42px 18px;
+}
+
+.empty-state-graphic {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+}
+
+.empty-state-graphic p {
+  margin: 0;
+  font-size: 0.84rem;
+  color: var(--muted);
+}
+
+.inline-link-button {
+  background: none;
+  border: none;
+  color: rgba(126, 195, 172, 0.8);
+  cursor: pointer;
+  font-size: inherit;
+  padding: 0;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.inline-link-button:hover {
+  color: rgba(126, 195, 172, 1);
+}
+
+.table-context-menu {
+  min-width: 180px;
+  padding: 6px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(18, 25, 34, 0.98);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.4);
+  display: flex;
+  flex-direction: column;
+}
+
+.context-menu-item {
+  width: 100%;
+  min-height: 32px;
+  padding: 0 12px;
+  border: none;
+  border-radius: 7px;
+  background: transparent;
+  color: var(--text);
+  text-align: left;
+  font-size: 0.82rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+}
+
+.context-menu-item:hover {
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.context-menu-item:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.context-menu-item:disabled:hover {
+  background: transparent;
+}
+
+.context-menu-item.danger {
+  color: #ef8863;
+}
+
+.context-menu-item.danger:hover {
+  background: rgba(239, 136, 99, 0.1);
+}
+
+.context-menu-divider {
+  height: 1px;
+  margin: 4px 8px;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.export-modal {
+  width: min(640px, 100%);
+}
+
+.export-modal-body {
+  display: grid;
+  gap: 18px;
+}
+
+.export-section {
+  display: grid;
+  gap: 8px;
+}
+
+.export-label {
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #b8c0ca;
+}
+
+.export-scope-options,
+.export-column-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px 16px;
+}
+
+.export-radio-label,
+.export-checkbox-label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.84rem;
+  cursor: pointer;
+  color: var(--text);
+}
+
+.export-radio-label input,
+.export-checkbox-label input {
+  accent-color: var(--accent, #d46b3d);
+}
+
+.export-preview-scroll {
+  overflow-x: auto;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 10px;
+  max-height: 200px;
+}
+
+.export-preview-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.78rem;
+}
+
+.export-preview-table th {
+  background: rgba(255, 255, 255, 0.035);
+  padding: 6px 10px;
+  text-align: left;
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #b8c0ca;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.export-preview-table td {
+  padding: 5px 10px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+  color: var(--text);
+}
+
+.export-preview-more {
+  text-align: center;
+  color: var(--muted);
+  font-style: italic;
 }
 
 .table-loading-row {
@@ -1297,12 +1784,13 @@ h3 {
   display: grid;
   grid-template-columns: 140px minmax(0, 1fr);
   gap: 12px 16px;
-  align-items: center;
+  align-items: start;
 }
 
 .field-label {
   margin: 0;
   font-size: 0.74rem;
+  padding-top: 10px;
 }
 
 .field-label-top {
@@ -1375,9 +1863,11 @@ h3 {
   gap: 6px;
 }
 
-.modal-header h2 {
-  font-size: clamp(1.3rem, 2.2vw, 1.7rem);
-  line-height: 1.08;
+.modal-header h2,
+.modal-header h3 {
+  font-size: clamp(1.1rem, 2vw, 1.4rem);
+  line-height: 1.12;
+  margin: 0;
 }
 
 .status-list {
@@ -1479,6 +1969,7 @@ h3 {
   .workspace-header,
   .panel-header,
   .users-page-header,
+  .users-toolbar-top,
   .modal-header {
     flex-direction: column;
     align-items: stretch;


### PR DESCRIPTION
## Summary

Comprehensive redesign of the hosted web Users tab with desktop-parity features, plus unification of FK cascade rules across desktop and hosted schemas.

### Web UI Changes
- Compact breadcrumb toolbar (Setup > Users)
- Column resize/auto-fit with smart minimums
- Cell-level selection, stats footer, keyboard navigation
- Search highlighting, context menu, export modal
- Back-to-top button, modal dialog overhaul
- Form alignment fix, empty states, tooltips

### Backend (Desktop + Hosted)
- Unified FK cascade rules: daily_sessions, realized_transactions, expenses, redemption_methods all CASCADE on user delete
- Auto-migration for existing SQLite databases
- Auto-migration for live Supabase Postgres on deploy
- Simplified delete_user() service method

### Tests
- All 1159 desktop tests passing
- All 19 web tests passing