### PR TITLE
Port Setup → Sites CRUD to hosted web app

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -16,12 +16,13 @@ You are assisting with **Sezzions**, a casino session tracker.
 2. Desktop UI (`desktop/ui/`) must not talk to the database directly. Web UI talks to `api/` endpoints.
 3. Preserve current app behavior unless explicitly instructed to change it.
 4. For accounting changes, add or update scenario-based tests to define expected outputs.
-5. Keep docs tidy:
+5. **DRY / Reusability**: When implementing a pattern that already exists (or will exist for multiple entities), extract shared logic into a reusable source (utility, base class, generic component, shared hook) rather than copy-pasting per entity. Before writing new code, search the codebase for existing implementations of the same pattern. See `docs/PROJECT_SPEC.md` §2 "Design Principles" for the full doctrinal rules.
+6. Keep docs tidy:
    - Update canonical docs in `docs/`
    - Decisions go in `docs/adr/`
    - Status updates go in `docs/status/`
    - Archive old docs in `docs/archive/`
-6. Avoid documentation sprawl:
+7. Avoid documentation sprawl:
    - Prefer updating `docs/PROJECT_SPEC.md` over creating new docs
    - Add a changelog entry to `docs/status/CHANGELOG.md` for noteworthy changes
    - Prefer GitHub Issues for new work items

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@ This file defines how humans and AI agents should work in this repository.
 - Web UI (`web/src/`) talks to `api/` endpoints, which call `services/hosted/`.
 - Business rules live in services.
 - Keep behavior changes intentional: prefer tests that assert business outputs.
+- **DRY / Reusability (Doctrinal)**: When two or more entities share the same structural pattern (CRUD repos, API routes, React table tabs, etc.), extract the shared logic into a reusable source — do not copy-paste and adapt per entity. Before writing new code, search the codebase for existing implementations. Shared components must have generic names (not entity-prefixed). See `docs/PROJECT_SPEC.md` §2 "Design Principles" for the full rules.
 
 ## Documentation Rules
 

--- a/api/app.py
+++ b/api/app.py
@@ -13,6 +13,7 @@ from services.hosted.persistence import get_hosted_session_factory
 from services.hosted.uploaded_sqlite_inspection_service import (
     HostedUploadedSQLiteInspectionService,
 )
+from services.hosted.workspace_site_service import HostedWorkspaceSiteService
 from services.hosted.workspace_user_service import HostedWorkspaceUserService
 from services.hosted.workspace_import_planning_service import (
     HostedWorkspaceImportPlanningService,
@@ -37,6 +38,27 @@ class HostedWorkspaceUserUpdateRequest(BaseModel):
 
 class HostedWorkspaceUserBatchDeleteRequest(BaseModel):
     user_ids: list[str]
+
+
+class HostedWorkspaceSiteCreateRequest(BaseModel):
+    name: str
+    url: str | None = None
+    sc_rate: float = 1.0
+    playthrough_requirement: float = 1.0
+    notes: str | None = None
+
+
+class HostedWorkspaceSiteUpdateRequest(BaseModel):
+    name: str
+    url: str | None = None
+    sc_rate: float = 1.0
+    playthrough_requirement: float = 1.0
+    notes: str | None = None
+    is_active: bool = True
+
+
+class HostedWorkspaceSiteBatchDeleteRequest(BaseModel):
+    site_ids: list[str]
 
 cors_config = load_hosted_backend_config(required=False, require_db_password=False)
 app.add_middleware(
@@ -79,6 +101,16 @@ def get_hosted_workspace_user_service() -> HostedWorkspaceUserService:
 
     session_factory = get_hosted_session_factory(config.sqlalchemy_url)
     return HostedWorkspaceUserService(session_factory)
+
+
+def get_hosted_workspace_site_service() -> HostedWorkspaceSiteService:
+    try:
+        config = load_hosted_backend_config(require_db_password=True)
+    except HostedConfigurationError as exc:
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(exc)) from exc
+
+    session_factory = get_hosted_session_factory(config.sqlalchemy_url)
+    return HostedWorkspaceSiteService(session_factory)
 
 
 def get_hosted_uploaded_sqlite_inspection_service() -> HostedUploadedSQLiteInspectionService:
@@ -225,6 +257,120 @@ def workspace_users_batch_delete(
         deleted_count = service.delete_users(
             supabase_user_id=session.user_id,
             user_ids=payload.user_ids,
+        )
+    except LookupError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+    return {"deleted_count": deleted_count}
+
+
+# ── Sites ──────────────────────────────────────────────────────
+
+
+@app.get("/v1/workspace/sites")
+def workspace_sites_list(
+    limit: int = Query(100, ge=1, le=500),
+    offset: int = Query(0, ge=0),
+    session: AuthenticatedSession = Depends(get_authenticated_session),
+    service: HostedWorkspaceSiteService = Depends(get_hosted_workspace_site_service),
+) -> dict[str, object]:
+    try:
+        page = service.list_sites_page(
+            supabase_user_id=session.user_id,
+            limit=limit,
+            offset=offset,
+        )
+    except LookupError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+
+    return {
+        "sites": [site.as_dict() if hasattr(site, "as_dict") else site for site in page["sites"]],
+        "offset": page["offset"],
+        "limit": page["limit"],
+        "next_offset": page["next_offset"],
+        "total_count": page["total_count"],
+        "has_more": page["has_more"],
+    }
+
+
+@app.post("/v1/workspace/sites")
+def workspace_sites_create(
+    payload: HostedWorkspaceSiteCreateRequest = Body(...),
+    session: AuthenticatedSession = Depends(get_authenticated_session),
+    service: HostedWorkspaceSiteService = Depends(get_hosted_workspace_site_service),
+) -> dict[str, object]:
+    try:
+        site = service.create_site(
+            supabase_user_id=session.user_id,
+            name=payload.name,
+            url=payload.url,
+            sc_rate=payload.sc_rate,
+            playthrough_requirement=payload.playthrough_requirement,
+            notes=payload.notes,
+        )
+    except LookupError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+    return site.as_dict() if hasattr(site, "as_dict") else site
+
+
+@app.patch("/v1/workspace/sites/{site_id}")
+def workspace_sites_update(
+    site_id: str = Path(...),
+    payload: HostedWorkspaceSiteUpdateRequest = Body(...),
+    session: AuthenticatedSession = Depends(get_authenticated_session),
+    service: HostedWorkspaceSiteService = Depends(get_hosted_workspace_site_service),
+) -> dict[str, object]:
+    try:
+        site = service.update_site(
+            supabase_user_id=session.user_id,
+            site_id=site_id,
+            name=payload.name,
+            url=payload.url,
+            sc_rate=payload.sc_rate,
+            playthrough_requirement=payload.playthrough_requirement,
+            notes=payload.notes,
+            is_active=payload.is_active,
+        )
+    except LookupError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+    return site.as_dict() if hasattr(site, "as_dict") else site
+
+
+@app.delete("/v1/workspace/sites/{site_id}", status_code=status.HTTP_204_NO_CONTENT)
+def workspace_sites_delete(
+    site_id: str = Path(...),
+    session: AuthenticatedSession = Depends(get_authenticated_session),
+    service: HostedWorkspaceSiteService = Depends(get_hosted_workspace_site_service),
+) -> Response:
+    try:
+        service.delete_site(
+            supabase_user_id=session.user_id,
+            site_id=site_id,
+        )
+    except LookupError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@app.post("/v1/workspace/sites/batch-delete")
+def workspace_sites_batch_delete(
+    payload: HostedWorkspaceSiteBatchDeleteRequest = Body(...),
+    session: AuthenticatedSession = Depends(get_authenticated_session),
+    service: HostedWorkspaceSiteService = Depends(get_hosted_workspace_site_service),
+) -> dict[str, int]:
+    try:
+        deleted_count = service.delete_sites(
+            supabase_user_id=session.user_id,
+            site_ids=payload.site_ids,
         )
     except LookupError as exc:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc

--- a/docs/PROJECT_SPEC.md
+++ b/docs/PROJECT_SPEC.md
@@ -93,6 +93,25 @@ Key rules:
 - UI must not talk to the database directly.
 - **Transaction Atomicity**: All multi-step database operations (create/update/delete with cascading recalculations) use `with self.db.transaction()` context manager in `AppFacade` to ensure atomicity. Operations either fully succeed or fully roll back—no partial writes.
 
+### Design Principles (Doctrinal)
+
+These principles are **canonical** and apply to all new code across both the desktop and hosted/web stacks.
+
+1. **DRY by default — extract shared patterns, don't duplicate them.**
+   When two or more entities, layers, or features share the same structural pattern (e.g., CRUD operations, validation shapes, API route scaffolding, React table behavior), extract the shared logic into a single reusable source (utility function, base class, generic component, shared hook, etc.) rather than copy-pasting and adapting per entity. Each entity should only contain the code that is *unique to that entity*; everything else should be called from a common source.
+
+2. **Parallel stacks are acceptable; parallel *copies* are not.**
+   Desktop and hosted/web may have separate repository and service implementations (different ORMs, different ID types, different auth models). That structural separation is intentional. But within each stack, common patterns must be consolidated. For example: if every hosted repository implements the same `list_by_workspace_id` / `create` / `update` / `delete` / `delete_many` shape, that shape should be a shared generic rather than N separate files with the same boilerplate.
+
+3. **Frontend components should be generic by default.**
+   Table infrastructure (header menus, filter trees, context menus, export modals, column resize, keyboard navigation) should be shared across all entity tabs. Entity-specific tabs should compose these shared components with entity-specific configuration (column definitions, form fields, API endpoints), not duplicate the entire component tree.
+
+4. **Before writing new code, check if the pattern already exists.**
+   Agents and developers must search the codebase for existing implementations of the same pattern before creating new files. If a reusable version already exists, use it. If an existing implementation is entity-specific but could be generalized, generalize it rather than duplicating it.
+
+5. **Name shared code for what it does, not which entity first used it.**
+   Shared components and utilities should have generic names (e.g., `HeaderFilterMenu`, not `UserHeaderFilterMenu`) so they communicate reusability. If a component is created for one entity but is structurally generic, rename it when the second consumer appears.
+
 ### Primary Entrypoint
 - Run the desktop app via `python3 desktop/sezzions.py` (from repo root)
 - Source runtime default is `./sezzions.db`.

--- a/docs/archive/2025-07-25-pr-242-sites-crud.md
+++ b/docs/archive/2025-07-25-pr-242-sites-crud.md
@@ -1,0 +1,52 @@
+## Summary
+
+Ports Setup > Sites CRUD to the hosted web app, matching the existing Users pattern end-to-end.
+
+Closes #242
+
+## Changes
+
+### Backend
+- **Model**: Added `HostedSite` dataclass to `services/hosted/models.py` with validation (name required, sc_rate >= 0, playthrough_requirement >= 0)
+- **Repository**: New `repositories/hosted_site_repository.py` — full CRUD (list, count, create, update, delete, delete_many)
+- **Service**: New `services/hosted/workspace_site_service.py` — business logic with workspace isolation
+- **API**: 5 new endpoints in `api/app.py`:
+  - `GET /v1/workspace/sites` (paginated list)
+  - `POST /v1/workspace/sites` (create)
+  - `PATCH /v1/workspace/sites/{site_id}` (update)
+  - `DELETE /v1/workspace/sites/{site_id}` (delete, 204)
+  - `POST /v1/workspace/sites/batch-delete` (bulk delete)
+
+### Frontend
+- **SitesTab**: New component set (`SitesTab.jsx`, `SiteModal.jsx`, `sitesConstants.js`, `sitesUtils.js`)
+- **AppShell**: Sites tab enabled, renders SitesTab when selected
+- Reuses generic components from UsersTab (ExportModal, TableContextMenu, UserHeaderFilterMenu, FilterTreeNode)
+- 6-column table: Name, URL, SC Rate, Playthrough, Status, Notes
+- Full feature parity with Users: search, sort, column filters, cell/row/column selection, keyboard navigation, resize, context menus, export CSV, infinite scroll pagination
+
+### Tests
+- 12 API tests (`tests/api/test_workspace_sites.py`): all CRUD + auth + error cases
+- 13 service integration tests (`tests/services/hosted/test_workspace_site_service.py`): happy path, edge cases, cross-workspace isolation, atomic batch delete
+- 19 existing web tests pass with no regressions
+
+## Test Matrix
+
+| Category | Test | Status |
+|----------|------|--------|
+| Happy path | Create site with full fields | PASS |
+| Happy path | List sites (paginated) | PASS |
+| Happy path | Update all fields | PASS |
+| Happy path | Delete single + batch | PASS |
+| Edge case | Reject blank name | PASS |
+| Edge case | Reject negative sc_rate | PASS |
+| Edge case | Reject negative playthrough | PASS |
+| Edge case | Cross-workspace isolation | PASS |
+| Failure injection | Batch delete with invalid ID (atomic rollback) | PASS |
+| Invariant | Only workspace-scoped sites affected | PASS |
+
+## Pitfalls / Follow-ups
+
+- ExportModal imports `userTableColumns` but only uses `allColumns` prop — works fine but the dead import could be cleaned up in a shared-components refactor
+- UserHeaderFilterMenu / FilterTreeNode names are user-specific but the components are generic — consider renaming to shared names in a future refactor
+- SiteModal does not yet have a "seed demo sites" dev tool (Users has one) — could add if useful
+- Sites with URLs could eventually support click-to-open behavior in the table

--- a/docs/archive/2026-03-30-issue-sites-crud-body.md
+++ b/docs/archive/2026-03-30-issue-sites-crud-body.md
@@ -1,0 +1,94 @@
+## Problem / motivation
+
+The web app currently only supports Setup -> Users. Sites are the next entity in the dependency chain (Cards, Games, and Purchases all reference Sites). Without a Sites CRUD page, we cannot proceed to port any downstream entities.
+
+## Proposed solution
+
+Port the desktop Setup -> Sites tab to the hosted web app, following the same architecture established by the Users implementation:
+
+- **API layer**: Add CRUD endpoints for workspace sites (`/v1/workspace/sites`)
+- **Service layer**: Add `HostedWorkspaceSiteService` mirroring `HostedWorkspaceUserService`
+- **Web component**: Add `SitesTab/` component group mirroring `UsersTab/`
+
+The hosted `sites` table already exists in the PostgreSQL schema (`HostedSiteRecord` in `services/hosted/persistence.py`) with columns: id, workspace_id, name, url, sc_rate, playthrough_requirement, is_active, notes, created_at, updated_at.
+
+## Scope
+
+In-scope:
+- FastAPI endpoints: list (paginated), create, update, delete, batch-delete
+- `HostedWorkspaceSiteService` with workspace-scoped CRUD
+- `SitesTab` React component with table, search, column filters, sorting, keyboard nav
+- Site modal (view/create/edit modes) with all fields
+- Export CSV
+- Enable the "Sites" rail nav button in AppShell
+- Web tests (Vitest) covering CRUD flows, edge cases, failure injection
+- API tests (pytest) covering endpoint behavior
+
+Out-of-scope:
+- Cards or other entities that reference Sites
+- Import/migration of Sites from SQLite
+- Desktop app changes
+
+## UX / fields / checkboxes
+
+Screen/Tab: Setup -> Sites (rail nav, already listed but disabled)
+
+Table columns:
+- Name
+- URL
+- SC Rate
+- Playthrough Requirement
+- Status (Active/Inactive chip)
+- Notes (truncated to 100 chars)
+
+Site modal fields:
+- Name (required, text input)
+- URL (optional, text input)
+- SC Rate (number input, default 1.0)
+- Playthrough Requirement (number input, default 1.0)
+- Is Active (checkbox/toggle, edit mode only)
+- Notes (optional, textarea)
+
+Buttons/actions:
+- Add Site, View, Edit, Delete, Export CSV, Refresh
+- Delete confirmation modal (single and batch)
+- Dirty-form confirmation on Escape/close
+
+## Implementation notes / strategy
+
+Approach:
+- Copy the Users pattern exactly: service, router, React component group
+- API endpoints register in `api/app.py` alongside existing user routes
+- `SitesTab` receives `apiBaseUrl` and `hostedWorkspaceReady` props (same as UsersTab)
+- Enable the Sites tab in `setupTabs` array in `AppShell.jsx` (`enabled: true`)
+- Unique constraint on (workspace_id, name) already exists in schema; API should return 409 on duplicate
+
+Data model / migrations:
+- No schema changes needed; `HostedSiteRecord` already defined in persistence.py
+
+Risk areas:
+- SC Rate and Playthrough Requirement are numeric fields; need input validation (positive numbers, reasonable bounds)
+- URL field needs basic format validation or accept freeform text
+
+## Acceptance criteria
+
+- Given a signed-in user with a bootstrapped workspace, when they click "Sites" in the Setup rail nav, then the Sites table loads and displays all workspace sites
+- Given no sites exist, when the user clicks "Add Site" and fills in the name, then a new site is created and appears in the table
+- Given an existing site, when the user double-clicks it, then the View Site modal opens with all fields displayed read-only
+- Given the Edit modal is open, when the user changes the name and clicks Save, then the site is updated via PATCH and the table refreshes
+- Given one or more sites are selected, when the user clicks Delete and confirms, then the sites are removed
+- Given sites exist, when the user types in the search bar, then the table filters by name, URL, and notes
+- Given sites exist, when the user clicks Export CSV, then a CSV file downloads with the filtered/selected sites
+- All new API endpoints return appropriate error codes (400 for validation, 404 for not found, 409 for duplicate name)
+- Web test suite passes with new Sites tests added
+- Desktop test suite remains green (no regressions)
+
+## Test plan
+
+Automated tests:
+- API (pytest): list, create, update, delete, batch-delete, duplicate name (409), missing fields (422), not-found (404)
+- Web (Vitest): render Sites tab after bootstrap, create site, edit site, delete site with confirmation, search filtering, Export CSV modal
+
+Manual verification:
+- Sign in, navigate to Sites, add/edit/delete a site, verify table updates
+- Confirm SC Rate and Playthrough fields accept and display decimal values correctly

--- a/docs/archive/2026-03-31-issue-url-routing-body.md
+++ b/docs/archive/2026-03-31-issue-url-routing-body.md
@@ -1,0 +1,60 @@
+## Problem / Motivation
+
+The web app currently uses `useState` for tab switching inside `AppShell.jsx`. Clicking between Setup tabs (Users, Sites, etc.) does not update the browser URL. This means:
+
+- No deep-linkable URLs (cannot bookmark or share a link to a specific tab)
+- Browser back/forward buttons do not navigate between tabs
+- Refreshing the page always resets to the default tab (Users)
+- The only URL-level routing is a minimal hash check (`#/migration`) for shell selection
+
+## Proposed Solution
+
+Install `react-router-dom` v6 and implement proper URL-based routing:
+
+- `/setup/users` - Users tab
+- `/setup/sites` - Sites tab
+- `/setup/cards` - Cards tab (when enabled)
+- `/setup/redemption-methods` - Redemption Methods tab (when enabled)
+- `/setup/game-types` - Game Types tab (when enabled)
+- `/setup/games` - Games tab (when enabled)
+- `/setup/tools` - Tools tab (when enabled)
+- `/` redirects to `/setup/users` (or future dashboard)
+
+Replace the current hash-based shell routing (`routing.js`) and state-based tab switching with `<BrowserRouter>`, `<Routes>`, `<Route>`, and `useNavigate()`. Update side rail links to use `<NavLink>` for automatic active styling.
+
+## Scope
+
+- Install `react-router-dom`
+- Wrap app in `<BrowserRouter>` in `main.jsx`
+- Convert `App.jsx` shell selection from hash-based to route-based
+- Convert `AppShell.jsx` tab switching from `useState` to URL routes
+- Update side rail nav items to `<NavLink>`
+- Configure Vite dev server for SPA fallback (history API)
+- Remove or deprecate `web/src/services/routing.js`
+
+## Out of Scope
+
+- Adding new tabs or features
+- Authentication flow changes
+- API routing changes
+
+## Acceptance Criteria
+
+- [ ] Clicking a Setup tab updates the browser URL to match (e.g. `/setup/sites`)
+- [ ] Browser back/forward navigates between previously visited tabs
+- [ ] Refreshing the page stays on the current tab
+- [ ] Direct navigation to a tab URL (e.g. paste `/setup/sites`) loads the correct tab
+- [ ] The migration shell route still works
+- [ ] Unauthenticated users see the marketing shell (no change)
+- [ ] All existing web tests pass
+- [ ] Vite dev server handles SPA fallback correctly
+
+## Test Plan
+
+- Verify each tab URL renders the correct content
+- Verify browser history navigation (back/forward)
+- Verify page refresh persistence
+- Verify direct URL entry
+- Verify redirect from `/` to default tab
+- Verify migration route still works
+- Verify unauthenticated redirect behavior unchanged

--- a/docs/status/CHANGELOG.md
+++ b/docs/status/CHANGELOG.md
@@ -9,6 +9,52 @@ Rules:
 
 ---
 
+## 2026-03-31
+
+```yaml
+id: 2026-03-31-02
+type: bugfix
+areas: [backend, database]
+issue: "#242"
+summary: "Fix FK cascade migration silently nulling redemption_method_id"
+details: >
+  _migrate_user_fk_cascade() and _migrate_redemption_methods_table() ran
+  DROP TABLE with PRAGMA foreign_keys=ON, which triggered ON DELETE SET NULL
+  on redemptions.redemption_method_id, silently nulling 288 method assignments.
+  Added PRAGMA foreign_keys=OFF/ON around all table-rebuild migrations.
+  Restored affected data from the 3/30 auto-backup.
+
+files_changed:
+  - repositories/database.py
+```
+
+```yaml
+id: 2026-03-31-01
+type: feature
+areas: [web, api, backend]
+issue: "#242"
+pr: "#243"
+summary: "Port Setup > Sites CRUD to hosted web app"
+details: >
+  Full Sites management tab for the hosted web app: list/create/edit/delete
+  with inline editing, status toggles, and confirmation dialogs matching the
+  Users tab pattern. Backend: HostedSite SQLAlchemy model, hosted_site_repository,
+  workspace_site_service, 5 API endpoints. Frontend: SitesTab, SiteModal,
+  sitesConstants, sitesUtils. Added DRY/reusability design principles to
+  PROJECT_SPEC.md, copilot-instructions.md, and AGENTS.md.
+
+files_changed:
+  - api/app.py
+  - models/hosted_site.py
+  - repositories/hosted_site_repository.py
+  - services/hosted/workspace_site_service.py
+  - web/src/components/SitesTab/ (new)
+  - web/src/components/AppShell.jsx
+  - docs/PROJECT_SPEC.md
+  - .github/copilot-instructions.md
+  - AGENTS.md
+```
+
 ## 2026-03-30
 
 ```yaml

--- a/repositories/database.py
+++ b/repositories/database.py
@@ -829,6 +829,10 @@ class DatabaseManager:
         if row and 'UNIQUE' in row[0] and 'name' in row[0]:
             # Need to recreate table without UNIQUE constraint on name
             try:
+                # Disable FK enforcement so DROP TABLE doesn't trigger
+                # ON DELETE SET NULL on child tables (e.g. redemptions.redemption_method_id).
+                cursor.execute("PRAGMA foreign_keys=OFF")
+
                 # Create new table
                 cursor.execute('''
                     CREATE TABLE redemption_methods_new (
@@ -857,9 +861,11 @@ class DatabaseManager:
                 # Rename new table
                 cursor.execute('ALTER TABLE redemption_methods_new RENAME TO redemption_methods')
                 
+                cursor.execute("PRAGMA foreign_keys=ON")
                 self._connection.commit()
             except Exception as e:
                 # If migration fails, roll back and continue
+                cursor.execute("PRAGMA foreign_keys=ON")
                 self._connection.rollback()
                 pass
 
@@ -1126,12 +1132,17 @@ class DatabaseManager:
                 if not row or old_fragment not in row[0]:
                     continue  # Already migrated or table doesn't exist
 
+                # Disable FK enforcement so DROP TABLE doesn't trigger
+                # ON DELETE SET NULL / CASCADE on child tables.
+                cursor.execute("PRAGMA foreign_keys=OFF")
                 cursor.execute(create_sql)
                 cursor.execute(f'INSERT INTO {table}_new ({columns}) SELECT {columns} FROM {table}')
                 cursor.execute(f'DROP TABLE {table}')
                 cursor.execute(f'ALTER TABLE {table}_new RENAME TO {table}')
+                cursor.execute("PRAGMA foreign_keys=ON")
                 self._connection.commit()
             except Exception:
+                cursor.execute("PRAGMA foreign_keys=ON")
                 self._connection.rollback()
 
     def _normalize_time_fields(self):

--- a/repositories/hosted_site_repository.py
+++ b/repositories/hosted_site_repository.py
@@ -1,0 +1,134 @@
+"""Persistence helpers for hosted workspace-owned business sites."""
+
+from __future__ import annotations
+
+from sqlalchemy import delete, func, select
+
+from services.hosted.models import HostedSite
+from services.hosted.persistence import HostedSiteRecord
+
+
+class HostedSiteRepository:
+    def list_by_workspace_id(
+        self,
+        session,
+        workspace_id: str,
+        *,
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> list[HostedSite]:
+        query = (
+            select(HostedSiteRecord)
+            .where(HostedSiteRecord.workspace_id == workspace_id)
+            .order_by(HostedSiteRecord.name.asc(), HostedSiteRecord.id.asc())
+            .offset(offset)
+        )
+        if limit is not None:
+            query = query.limit(limit)
+
+        records = session.scalars(query).all()
+        return [self._record_to_model(record) for record in records]
+
+    def count_by_workspace_id(self, session, workspace_id: str) -> int:
+        return session.scalar(
+            select(func.count())
+            .select_from(HostedSiteRecord)
+            .where(HostedSiteRecord.workspace_id == workspace_id)
+        ) or 0
+
+    def create(
+        self,
+        session,
+        *,
+        workspace_id: str,
+        name: str,
+        url: str | None = None,
+        sc_rate: float = 1.0,
+        playthrough_requirement: float = 1.0,
+        notes: str | None = None,
+        is_active: bool = True,
+    ) -> HostedSite:
+        record = HostedSiteRecord(
+            workspace_id=workspace_id,
+            name=name,
+            url=url,
+            sc_rate=sc_rate,
+            playthrough_requirement=playthrough_requirement,
+            notes=notes,
+            is_active=is_active,
+        )
+        session.add(record)
+        session.flush()
+        return self._record_to_model(record)
+
+    def update(
+        self,
+        session,
+        *,
+        site_id: str,
+        workspace_id: str,
+        name: str,
+        url: str | None,
+        sc_rate: float,
+        playthrough_requirement: float,
+        notes: str | None,
+        is_active: bool,
+    ) -> HostedSite | None:
+        record = session.scalar(
+            select(HostedSiteRecord).where(
+                HostedSiteRecord.id == site_id,
+                HostedSiteRecord.workspace_id == workspace_id,
+            )
+        )
+        if record is None:
+            return None
+
+        record.name = name
+        record.url = url
+        record.sc_rate = sc_rate
+        record.playthrough_requirement = playthrough_requirement
+        record.notes = notes
+        record.is_active = is_active
+        session.flush()
+        return self._record_to_model(record)
+
+    def delete(self, session, *, site_id: str, workspace_id: str) -> bool:
+        record = session.scalar(
+            select(HostedSiteRecord).where(
+                HostedSiteRecord.id == site_id,
+                HostedSiteRecord.workspace_id == workspace_id,
+            )
+        )
+        if record is None:
+            return False
+
+        session.delete(record)
+        session.flush()
+        return True
+
+    def delete_many(self, session, *, site_ids: list[str], workspace_id: str) -> int:
+        normalized_ids = list(dict.fromkeys(site_ids))
+        if not normalized_ids:
+            return 0
+
+        result = session.execute(
+            delete(HostedSiteRecord).where(
+                HostedSiteRecord.workspace_id == workspace_id,
+                HostedSiteRecord.id.in_(normalized_ids),
+            )
+        )
+        session.flush()
+        return int(result.rowcount or 0)
+
+    @staticmethod
+    def _record_to_model(record: HostedSiteRecord) -> HostedSite:
+        return HostedSite(
+            id=record.id,
+            workspace_id=record.workspace_id,
+            name=record.name,
+            url=record.url,
+            sc_rate=record.sc_rate,
+            playthrough_requirement=record.playthrough_requirement,
+            is_active=record.is_active,
+            notes=record.notes,
+        )

--- a/services/hosted/models.py
+++ b/services/hosted/models.py
@@ -75,3 +75,46 @@ class HostedUser:
             "notes": self.notes,
             "is_active": self.is_active,
         }
+
+
+@dataclass
+class HostedSite:
+    """Sweepstakes site/casino owned by a hosted workspace."""
+
+    name: str
+    workspace_id: Optional[str] = None
+    url: Optional[str] = None
+    sc_rate: float = 1.0
+    playthrough_requirement: float = 1.0
+    is_active: bool = True
+    notes: Optional[str] = None
+    id: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        self.name = self.name.strip()
+        if not self.name:
+            raise ValueError("Site name is required")
+
+        if self.url is not None:
+            self.url = self.url.strip() or None
+
+        if self.notes is not None:
+            self.notes = self.notes.strip() or None
+
+        if self.sc_rate < 0:
+            raise ValueError("SC rate must be non-negative")
+
+        if self.playthrough_requirement < 0:
+            raise ValueError("Playthrough requirement must be non-negative")
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "id": self.id,
+            "workspace_id": self.workspace_id,
+            "name": self.name,
+            "url": self.url,
+            "sc_rate": self.sc_rate,
+            "playthrough_requirement": self.playthrough_requirement,
+            "is_active": self.is_active,
+            "notes": self.notes,
+        }

--- a/services/hosted/workspace_site_service.py
+++ b/services/hosted/workspace_site_service.py
@@ -1,0 +1,173 @@
+"""Hosted workspace-managed site/casino directory service."""
+
+from __future__ import annotations
+
+from repositories.hosted_account_repository import HostedAccountRepository
+from repositories.hosted_site_repository import HostedSiteRepository
+from repositories.hosted_workspace_repository import HostedWorkspaceRepository
+from services.hosted.models import HostedSite, HostedWorkspace
+
+
+class HostedWorkspaceSiteService:
+    def __init__(self, session_factory) -> None:
+        self.session_factory = session_factory
+        self.account_repository = HostedAccountRepository()
+        self.workspace_repository = HostedWorkspaceRepository()
+        self.site_repository = HostedSiteRepository()
+
+    def list_sites(self, *, supabase_user_id: str) -> list[HostedSite]:
+        with self.session_factory() as session:
+            workspace = self._require_workspace(session, supabase_user_id)
+            return self.site_repository.list_by_workspace_id(session, workspace.id)
+
+    def list_sites_page(
+        self,
+        *,
+        supabase_user_id: str,
+        limit: int,
+        offset: int = 0,
+    ) -> dict[str, object]:
+        with self.session_factory() as session:
+            workspace = self._require_workspace(session, supabase_user_id)
+            total_count = self.site_repository.count_by_workspace_id(session, workspace.id)
+            sites = self.site_repository.list_by_workspace_id(
+                session,
+                workspace.id,
+                limit=limit,
+                offset=offset,
+            )
+            next_offset = offset + len(sites)
+            has_more = next_offset < total_count
+            return {
+                "sites": sites,
+                "offset": offset,
+                "limit": limit,
+                "next_offset": next_offset,
+                "total_count": total_count,
+                "has_more": has_more,
+            }
+
+    def create_site(
+        self,
+        *,
+        supabase_user_id: str,
+        name: str,
+        url: str | None = None,
+        sc_rate: float = 1.0,
+        playthrough_requirement: float = 1.0,
+        notes: str | None = None,
+    ) -> HostedSite:
+        candidate = HostedSite(
+            name=name,
+            url=url,
+            sc_rate=sc_rate,
+            playthrough_requirement=playthrough_requirement,
+            notes=notes,
+        )
+
+        with self.session_factory() as session:
+            workspace = self._require_workspace(session, supabase_user_id)
+            created_site = self.site_repository.create(
+                session,
+                workspace_id=workspace.id,
+                name=candidate.name,
+                url=candidate.url,
+                sc_rate=candidate.sc_rate,
+                playthrough_requirement=candidate.playthrough_requirement,
+                notes=candidate.notes,
+                is_active=candidate.is_active,
+            )
+            session.commit()
+            return created_site
+
+    def update_site(
+        self,
+        *,
+        supabase_user_id: str,
+        site_id: str,
+        name: str,
+        url: str | None = None,
+        sc_rate: float = 1.0,
+        playthrough_requirement: float = 1.0,
+        notes: str | None = None,
+        is_active: bool = True,
+    ) -> HostedSite:
+        candidate = HostedSite(
+            name=name,
+            url=url,
+            sc_rate=sc_rate,
+            playthrough_requirement=playthrough_requirement,
+            notes=notes,
+            is_active=is_active,
+        )
+
+        with self.session_factory() as session:
+            workspace = self._require_workspace(session, supabase_user_id)
+            updated_site = self.site_repository.update(
+                session,
+                site_id=site_id,
+                workspace_id=workspace.id,
+                name=candidate.name,
+                url=candidate.url,
+                sc_rate=candidate.sc_rate,
+                playthrough_requirement=candidate.playthrough_requirement,
+                notes=candidate.notes,
+                is_active=candidate.is_active,
+            )
+            if updated_site is None:
+                raise LookupError("Hosted site was not found in the authenticated workspace.")
+
+            session.commit()
+            return updated_site
+
+    def delete_site(
+        self,
+        *,
+        supabase_user_id: str,
+        site_id: str,
+    ) -> None:
+        with self.session_factory() as session:
+            workspace = self._require_workspace(session, supabase_user_id)
+            deleted = self.site_repository.delete(
+                session,
+                site_id=site_id,
+                workspace_id=workspace.id,
+            )
+            if not deleted:
+                raise LookupError("Hosted site was not found in the authenticated workspace.")
+
+            session.commit()
+
+    def delete_sites(
+        self,
+        *,
+        supabase_user_id: str,
+        site_ids: list[str],
+    ) -> int:
+        normalized_ids = list(dict.fromkeys(site_ids))
+        if not normalized_ids:
+            raise ValueError("At least one hosted site id is required.")
+
+        with self.session_factory() as session:
+            workspace = self._require_workspace(session, supabase_user_id)
+            deleted_count = self.site_repository.delete_many(
+                session,
+                site_ids=normalized_ids,
+                workspace_id=workspace.id,
+            )
+            if deleted_count != len(normalized_ids):
+                raise LookupError("One or more hosted sites were not found in the authenticated workspace.")
+
+            session.commit()
+            return deleted_count
+
+    def _require_workspace(self, session, supabase_user_id: str) -> HostedWorkspace:
+        account = self.account_repository.get_by_supabase_user_id(session, supabase_user_id)
+        if account is None:
+            raise LookupError("Hosted workspace bootstrap must complete before managing workspace sites.")
+
+        workspace = self.workspace_repository.get_by_account_id(session, account.id)
+        if workspace is None:
+            raise LookupError("Hosted workspace bootstrap must complete before managing workspace sites.")
+
+        return workspace

--- a/tests/api/test_workspace_sites.py
+++ b/tests/api/test_workspace_sites.py
@@ -1,0 +1,410 @@
+from fastapi.testclient import TestClient
+
+from api.app import app, get_hosted_workspace_site_service
+from api.auth import AuthenticatedSession, get_authenticated_session
+
+
+client = TestClient(app)
+
+
+def test_workspace_sites_list_endpoint_returns_workspace_sites() -> None:
+    class StubWorkspaceSiteService:
+        def list_sites_page(self, *, supabase_user_id: str, limit: int, offset: int):
+            assert supabase_user_id == "owner-123"
+            assert limit == 100
+            assert offset == 0
+            return {
+                "sites": [
+                    {
+                        "id": "site-1",
+                        "workspace_id": "workspace-123",
+                        "name": "Lucky Slots",
+                        "url": "https://luckyslots.com",
+                        "sc_rate": 1.0,
+                        "playthrough_requirement": 1.0,
+                        "is_active": True,
+                        "notes": None,
+                    }
+                ],
+                "offset": 0,
+                "limit": 100,
+                "next_offset": 1,
+                "total_count": 1,
+                "has_more": False,
+            }
+
+    app.dependency_overrides[get_authenticated_session] = lambda: AuthenticatedSession(
+        user_id="owner-123",
+        email="owner@sezzions.com",
+        audience="authenticated",
+        role="authenticated",
+    )
+    app.dependency_overrides[get_hosted_workspace_site_service] = lambda: StubWorkspaceSiteService()
+
+    try:
+        response = client.get("/v1/workspace/sites")
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    assert response.json()["sites"][0]["name"] == "Lucky Slots"
+    assert response.json()["total_count"] == 1
+
+
+def test_workspace_sites_list_endpoint_accepts_limit_and_offset() -> None:
+    class StubWorkspaceSiteService:
+        def list_sites_page(self, *, supabase_user_id: str, limit: int, offset: int):
+            assert supabase_user_id == "owner-123"
+            assert limit == 25
+            assert offset == 50
+            return {
+                "sites": [],
+                "offset": offset,
+                "limit": limit,
+                "next_offset": offset,
+                "total_count": 90,
+                "has_more": True,
+            }
+
+    app.dependency_overrides[get_authenticated_session] = lambda: AuthenticatedSession(
+        user_id="owner-123",
+        email="owner@sezzions.com",
+        audience="authenticated",
+        role="authenticated",
+    )
+    app.dependency_overrides[get_hosted_workspace_site_service] = lambda: StubWorkspaceSiteService()
+
+    try:
+        response = client.get("/v1/workspace/sites?limit=25&offset=50")
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    assert response.json()["limit"] == 25
+    assert response.json()["offset"] == 50
+    assert response.json()["has_more"] is True
+
+
+def test_workspace_sites_create_endpoint_returns_created_site() -> None:
+    class StubWorkspaceSiteService:
+        def create_site(
+            self,
+            *,
+            supabase_user_id: str,
+            name: str,
+            url: str | None,
+            sc_rate: float,
+            playthrough_requirement: float,
+            notes: str | None,
+        ):
+            assert supabase_user_id == "owner-123"
+            return {
+                "id": "site-1",
+                "workspace_id": "workspace-123",
+                "name": name,
+                "url": url,
+                "sc_rate": sc_rate,
+                "playthrough_requirement": playthrough_requirement,
+                "is_active": True,
+                "notes": notes,
+            }
+
+    app.dependency_overrides[get_authenticated_session] = lambda: AuthenticatedSession(
+        user_id="owner-123",
+        email="owner@sezzions.com",
+        audience="authenticated",
+        role="authenticated",
+    )
+    app.dependency_overrides[get_hosted_workspace_site_service] = lambda: StubWorkspaceSiteService()
+
+    try:
+        response = client.post(
+            "/v1/workspace/sites",
+            json={
+                "name": "Lucky Slots",
+                "url": "https://luckyslots.com",
+                "sc_rate": 2.5,
+                "playthrough_requirement": 3.0,
+                "notes": "Top site",
+            },
+        )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    assert response.json()["name"] == "Lucky Slots"
+    assert response.json()["sc_rate"] == 2.5
+    assert response.json()["playthrough_requirement"] == 3.0
+    assert response.json()["workspace_id"] == "workspace-123"
+
+
+def test_workspace_sites_create_endpoint_uses_defaults_for_optional_fields() -> None:
+    class StubWorkspaceSiteService:
+        def create_site(
+            self,
+            *,
+            supabase_user_id: str,
+            name: str,
+            url: str | None,
+            sc_rate: float,
+            playthrough_requirement: float,
+            notes: str | None,
+        ):
+            assert sc_rate == 1.0
+            assert playthrough_requirement == 1.0
+            assert url is None
+            assert notes is None
+            return {
+                "id": "site-1",
+                "workspace_id": "workspace-123",
+                "name": name,
+                "url": url,
+                "sc_rate": sc_rate,
+                "playthrough_requirement": playthrough_requirement,
+                "is_active": True,
+                "notes": notes,
+            }
+
+    app.dependency_overrides[get_authenticated_session] = lambda: AuthenticatedSession(
+        user_id="owner-123",
+        email="owner@sezzions.com",
+        audience="authenticated",
+        role="authenticated",
+    )
+    app.dependency_overrides[get_hosted_workspace_site_service] = lambda: StubWorkspaceSiteService()
+
+    try:
+        response = client.post("/v1/workspace/sites", json={"name": "Minimal Site"})
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    assert response.json()["name"] == "Minimal Site"
+    assert response.json()["sc_rate"] == 1.0
+
+
+def test_workspace_sites_update_endpoint_returns_updated_site() -> None:
+    class StubWorkspaceSiteService:
+        def update_site(
+            self,
+            *,
+            supabase_user_id: str,
+            site_id: str,
+            name: str,
+            url: str | None,
+            sc_rate: float,
+            playthrough_requirement: float,
+            notes: str | None,
+            is_active: bool,
+        ):
+            assert supabase_user_id == "owner-123"
+            assert site_id == "site-1"
+            return {
+                "id": site_id,
+                "workspace_id": "workspace-123",
+                "name": name,
+                "url": url,
+                "sc_rate": sc_rate,
+                "playthrough_requirement": playthrough_requirement,
+                "is_active": is_active,
+                "notes": notes,
+            }
+
+    app.dependency_overrides[get_authenticated_session] = lambda: AuthenticatedSession(
+        user_id="owner-123",
+        email="owner@sezzions.com",
+        audience="authenticated",
+        role="authenticated",
+    )
+    app.dependency_overrides[get_hosted_workspace_site_service] = lambda: StubWorkspaceSiteService()
+
+    try:
+        response = client.patch(
+            "/v1/workspace/sites/site-1",
+            json={
+                "name": "Lucky Slots Updated",
+                "url": "https://luckyslots.com/new",
+                "sc_rate": 3.0,
+                "playthrough_requirement": 2.0,
+                "notes": "Updated",
+                "is_active": False,
+            },
+        )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    assert response.json()["name"] == "Lucky Slots Updated"
+    assert response.json()["is_active"] is False
+    assert response.json()["sc_rate"] == 3.0
+
+
+def test_workspace_sites_delete_endpoint_returns_204() -> None:
+    class StubWorkspaceSiteService:
+        def delete_site(self, *, supabase_user_id: str, site_id: str):
+            assert supabase_user_id == "owner-123"
+            assert site_id == "site-1"
+
+    app.dependency_overrides[get_authenticated_session] = lambda: AuthenticatedSession(
+        user_id="owner-123",
+        email="owner@sezzions.com",
+        audience="authenticated",
+        role="authenticated",
+    )
+    app.dependency_overrides[get_hosted_workspace_site_service] = lambda: StubWorkspaceSiteService()
+
+    try:
+        response = client.delete("/v1/workspace/sites/site-1")
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 204
+    assert response.content == b""
+
+
+def test_workspace_sites_batch_delete_endpoint_returns_deleted_count() -> None:
+    class StubWorkspaceSiteService:
+        def delete_sites(self, *, supabase_user_id: str, site_ids: list[str]):
+            assert supabase_user_id == "owner-123"
+            assert site_ids == ["site-1", "site-2", "site-3"]
+            return 3
+
+    app.dependency_overrides[get_authenticated_session] = lambda: AuthenticatedSession(
+        user_id="owner-123",
+        email="owner@sezzions.com",
+        audience="authenticated",
+        role="authenticated",
+    )
+    app.dependency_overrides[get_hosted_workspace_site_service] = lambda: StubWorkspaceSiteService()
+
+    try:
+        response = client.post(
+            "/v1/workspace/sites/batch-delete",
+            json={"site_ids": ["site-1", "site-2", "site-3"]},
+        )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    assert response.json() == {"deleted_count": 3}
+
+
+def test_workspace_sites_endpoints_require_bearer_auth() -> None:
+    list_response = client.get("/v1/workspace/sites")
+    create_response = client.post("/v1/workspace/sites", json={"name": "Test"})
+    update_response = client.patch("/v1/workspace/sites/site-1", json={"name": "Test"})
+    delete_response = client.delete("/v1/workspace/sites/site-1")
+    batch_delete_response = client.post("/v1/workspace/sites/batch-delete", json={"site_ids": ["site-1"]})
+
+    assert list_response.status_code == 401
+    assert create_response.status_code == 401
+    assert update_response.status_code == 401
+    assert delete_response.status_code == 401
+    assert batch_delete_response.status_code == 401
+
+
+def test_workspace_sites_create_endpoint_returns_400_for_invalid_name() -> None:
+    class RejectingWorkspaceSiteService:
+        def create_site(
+            self,
+            *,
+            supabase_user_id: str,
+            name: str,
+            url: str | None,
+            sc_rate: float,
+            playthrough_requirement: float,
+            notes: str | None,
+        ):
+            raise ValueError("Site name is required")
+
+    app.dependency_overrides[get_authenticated_session] = lambda: AuthenticatedSession(
+        user_id="owner-123",
+        email="owner@sezzions.com",
+        audience="authenticated",
+        role="authenticated",
+    )
+    app.dependency_overrides[get_hosted_workspace_site_service] = lambda: RejectingWorkspaceSiteService()
+
+    try:
+        response = client.post("/v1/workspace/sites", json={"name": "   "})
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Site name is required"
+
+
+def test_workspace_sites_update_endpoint_returns_409_for_missing_workspace_site() -> None:
+    class MissingWorkspaceSiteService:
+        def update_site(
+            self,
+            *,
+            supabase_user_id: str,
+            site_id: str,
+            name: str,
+            url: str | None,
+            sc_rate: float,
+            playthrough_requirement: float,
+            notes: str | None,
+            is_active: bool,
+        ):
+            raise LookupError("Hosted site was not found in the authenticated workspace.")
+
+    app.dependency_overrides[get_authenticated_session] = lambda: AuthenticatedSession(
+        user_id="owner-123",
+        email="owner@sezzions.com",
+        audience="authenticated",
+        role="authenticated",
+    )
+    app.dependency_overrides[get_hosted_workspace_site_service] = lambda: MissingWorkspaceSiteService()
+
+    try:
+        response = client.patch("/v1/workspace/sites/site-1", json={"name": "Test"})
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "Hosted site was not found in the authenticated workspace."
+
+
+def test_workspace_sites_delete_endpoint_returns_409_for_missing_workspace_site() -> None:
+    class MissingWorkspaceSiteService:
+        def delete_site(self, *, supabase_user_id: str, site_id: str):
+            raise LookupError("Hosted site was not found in the authenticated workspace.")
+
+    app.dependency_overrides[get_authenticated_session] = lambda: AuthenticatedSession(
+        user_id="owner-123",
+        email="owner@sezzions.com",
+        audience="authenticated",
+        role="authenticated",
+    )
+    app.dependency_overrides[get_hosted_workspace_site_service] = lambda: MissingWorkspaceSiteService()
+
+    try:
+        response = client.delete("/v1/workspace/sites/site-1")
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "Hosted site was not found in the authenticated workspace."
+
+
+def test_workspace_sites_batch_delete_endpoint_returns_409_for_missing_workspace_site() -> None:
+    class MissingWorkspaceSiteService:
+        def delete_sites(self, *, supabase_user_id: str, site_ids: list[str]):
+            raise LookupError("One or more hosted sites were not found in the authenticated workspace.")
+
+    app.dependency_overrides[get_authenticated_session] = lambda: AuthenticatedSession(
+        user_id="owner-123",
+        email="owner@sezzions.com",
+        audience="authenticated",
+        role="authenticated",
+    )
+    app.dependency_overrides[get_hosted_workspace_site_service] = lambda: MissingWorkspaceSiteService()
+
+    try:
+        response = client.post("/v1/workspace/sites/batch-delete", json={"site_ids": ["site-1", "site-2"]})
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 409

--- a/tests/services/hosted/test_workspace_site_service.py
+++ b/tests/services/hosted/test_workspace_site_service.py
@@ -1,0 +1,368 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from services.hosted.account_bootstrap_service import HostedAccountBootstrapService
+from services.hosted.persistence import HostedBase
+from services.hosted.workspace_site_service import HostedWorkspaceSiteService
+
+
+def _session_factory():
+    engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+    HostedBase.metadata.create_all(engine)
+    return engine, sessionmaker(bind=engine, expire_on_commit=False)
+
+
+def test_create_site_creates_workspace_owned_business_site() -> None:
+    engine, session_factory = _session_factory()
+    bootstrap_service = HostedAccountBootstrapService(session_factory)
+    service = HostedWorkspaceSiteService(session_factory)
+
+    try:
+        bootstrap = bootstrap_service.bootstrap_account_workspace(
+            supabase_user_id="owner-123",
+            owner_email="owner@sezzions.com",
+        )
+        created_site = service.create_site(
+            supabase_user_id="owner-123",
+            name="Lucky Slots",
+            url="https://luckyslots.com",
+            sc_rate=2.5,
+            playthrough_requirement=3.0,
+            notes="Top sweepstakes site.",
+        )
+    finally:
+        engine.dispose()
+
+    assert created_site.workspace_id == bootstrap.workspace.id
+    assert created_site.name == "Lucky Slots"
+    assert created_site.url == "https://luckyslots.com"
+    assert created_site.sc_rate == 2.5
+    assert created_site.playthrough_requirement == 3.0
+    assert created_site.notes == "Top sweepstakes site."
+    assert created_site.is_active is True
+
+
+def test_create_site_uses_default_sc_rate_and_playthrough() -> None:
+    engine, session_factory = _session_factory()
+    bootstrap_service = HostedAccountBootstrapService(session_factory)
+    service = HostedWorkspaceSiteService(session_factory)
+
+    try:
+        bootstrap_service.bootstrap_account_workspace(
+            supabase_user_id="owner-123",
+            owner_email="owner@sezzions.com",
+        )
+        created_site = service.create_site(
+            supabase_user_id="owner-123",
+            name="Minimal Site",
+        )
+    finally:
+        engine.dispose()
+
+    assert created_site.sc_rate == 1.0
+    assert created_site.playthrough_requirement == 1.0
+    assert created_site.url is None
+    assert created_site.notes is None
+
+
+def test_list_sites_returns_only_sites_for_authenticated_users_workspace() -> None:
+    engine, session_factory = _session_factory()
+    bootstrap_service = HostedAccountBootstrapService(session_factory)
+    service = HostedWorkspaceSiteService(session_factory)
+
+    try:
+        bootstrap_service.bootstrap_account_workspace(
+            supabase_user_id="owner-123",
+            owner_email="owner1@sezzions.com",
+        )
+        bootstrap_service.bootstrap_account_workspace(
+            supabase_user_id="owner-456",
+            owner_email="owner2@sezzions.com",
+        )
+
+        service.create_site(supabase_user_id="owner-123", name="Charlie Casino")
+        service.create_site(supabase_user_id="owner-123", name="Alpha Slots")
+        service.create_site(supabase_user_id="owner-456", name="Other Workspace Site")
+
+        sites = service.list_sites(supabase_user_id="owner-123")
+    finally:
+        engine.dispose()
+
+    assert [site.name for site in sites] == ["Alpha Slots", "Charlie Casino"]
+
+
+def test_list_sites_page_returns_sorted_page_metadata() -> None:
+    engine, session_factory = _session_factory()
+    bootstrap_service = HostedAccountBootstrapService(session_factory)
+    service = HostedWorkspaceSiteService(session_factory)
+
+    try:
+        bootstrap_service.bootstrap_account_workspace(
+            supabase_user_id="owner-123",
+            owner_email="owner1@sezzions.com",
+        )
+
+        service.create_site(supabase_user_id="owner-123", name="Charlie Casino")
+        service.create_site(supabase_user_id="owner-123", name="Alpha Slots")
+        service.create_site(supabase_user_id="owner-123", name="Bravo Bets")
+
+        page = service.list_sites_page(supabase_user_id="owner-123", limit=2, offset=1)
+    finally:
+        engine.dispose()
+
+    assert [site.name for site in page["sites"]] == ["Bravo Bets", "Charlie Casino"]
+    assert page["offset"] == 1
+    assert page["limit"] == 2
+    assert page["next_offset"] == 3
+    assert page["total_count"] == 3
+    assert page["has_more"] is False
+
+
+def test_create_site_rejects_blank_name_without_persisting_record() -> None:
+    engine, session_factory = _session_factory()
+    bootstrap_service = HostedAccountBootstrapService(session_factory)
+    service = HostedWorkspaceSiteService(session_factory)
+
+    try:
+        bootstrap_service.bootstrap_account_workspace(
+            supabase_user_id="owner-123",
+            owner_email="owner@sezzions.com",
+        )
+
+        try:
+            service.create_site(supabase_user_id="owner-123", name="   ")
+        except ValueError as exc:
+            assert str(exc) == "Site name is required"
+        else:
+            raise AssertionError("Expected blank site name to fail validation")
+
+        sites = service.list_sites(supabase_user_id="owner-123")
+    finally:
+        engine.dispose()
+
+    assert sites == []
+
+
+def test_create_site_rejects_negative_sc_rate() -> None:
+    engine, session_factory = _session_factory()
+    bootstrap_service = HostedAccountBootstrapService(session_factory)
+    service = HostedWorkspaceSiteService(session_factory)
+
+    try:
+        bootstrap_service.bootstrap_account_workspace(
+            supabase_user_id="owner-123",
+            owner_email="owner@sezzions.com",
+        )
+
+        try:
+            service.create_site(supabase_user_id="owner-123", name="Bad Site", sc_rate=-1.0)
+        except ValueError as exc:
+            assert str(exc) == "SC rate must be non-negative"
+        else:
+            raise AssertionError("Expected negative SC rate to fail validation")
+    finally:
+        engine.dispose()
+
+
+def test_create_site_rejects_negative_playthrough_requirement() -> None:
+    engine, session_factory = _session_factory()
+    bootstrap_service = HostedAccountBootstrapService(session_factory)
+    service = HostedWorkspaceSiteService(session_factory)
+
+    try:
+        bootstrap_service.bootstrap_account_workspace(
+            supabase_user_id="owner-123",
+            owner_email="owner@sezzions.com",
+        )
+
+        try:
+            service.create_site(supabase_user_id="owner-123", name="Bad Site", playthrough_requirement=-0.5)
+        except ValueError as exc:
+            assert str(exc) == "Playthrough requirement must be non-negative"
+        else:
+            raise AssertionError("Expected negative playthrough requirement to fail validation")
+    finally:
+        engine.dispose()
+
+
+def test_update_site_updates_workspace_owned_business_site() -> None:
+    engine, session_factory = _session_factory()
+    bootstrap_service = HostedAccountBootstrapService(session_factory)
+    service = HostedWorkspaceSiteService(session_factory)
+
+    try:
+        bootstrap_service.bootstrap_account_workspace(
+            supabase_user_id="owner-123",
+            owner_email="owner@sezzions.com",
+        )
+        created_site = service.create_site(supabase_user_id="owner-123", name="Alpha Slots")
+
+        updated_site = service.update_site(
+            supabase_user_id="owner-123",
+            site_id=created_site.id,
+            name="Alpha Slots Updated",
+            url="https://alphaslots.com",
+            sc_rate=5.0,
+            playthrough_requirement=2.0,
+            notes="Updated notes",
+            is_active=False,
+        )
+    finally:
+        engine.dispose()
+
+    assert updated_site.id == created_site.id
+    assert updated_site.name == "Alpha Slots Updated"
+    assert updated_site.url == "https://alphaslots.com"
+    assert updated_site.sc_rate == 5.0
+    assert updated_site.playthrough_requirement == 2.0
+    assert updated_site.notes == "Updated notes"
+    assert updated_site.is_active is False
+
+
+def test_update_site_rejects_cross_workspace_access() -> None:
+    engine, session_factory = _session_factory()
+    bootstrap_service = HostedAccountBootstrapService(session_factory)
+    service = HostedWorkspaceSiteService(session_factory)
+
+    try:
+        bootstrap_service.bootstrap_account_workspace(
+            supabase_user_id="owner-123",
+            owner_email="owner1@sezzions.com",
+        )
+        bootstrap_service.bootstrap_account_workspace(
+            supabase_user_id="owner-456",
+            owner_email="owner2@sezzions.com",
+        )
+        created_site = service.create_site(supabase_user_id="owner-456", name="Other Workspace Site")
+
+        try:
+            service.update_site(
+                supabase_user_id="owner-123",
+                site_id=created_site.id,
+                name="Should Fail",
+                url=None,
+                sc_rate=1.0,
+                playthrough_requirement=1.0,
+                notes=None,
+                is_active=True,
+            )
+        except LookupError as exc:
+            assert str(exc) == "Hosted site was not found in the authenticated workspace."
+        else:
+            raise AssertionError("Expected cross-workspace update to fail")
+    finally:
+        engine.dispose()
+
+
+def test_delete_site_removes_workspace_owned_business_site() -> None:
+    engine, session_factory = _session_factory()
+    bootstrap_service = HostedAccountBootstrapService(session_factory)
+    service = HostedWorkspaceSiteService(session_factory)
+
+    try:
+        bootstrap_service.bootstrap_account_workspace(
+            supabase_user_id="owner-123",
+            owner_email="owner@sezzions.com",
+        )
+        created_site = service.create_site(supabase_user_id="owner-123", name="Delete Me")
+
+        service.delete_site(
+            supabase_user_id="owner-123",
+            site_id=created_site.id,
+        )
+
+        sites = service.list_sites(supabase_user_id="owner-123")
+    finally:
+        engine.dispose()
+
+    assert sites == []
+
+
+def test_delete_site_rejects_cross_workspace_access() -> None:
+    engine, session_factory = _session_factory()
+    bootstrap_service = HostedAccountBootstrapService(session_factory)
+    service = HostedWorkspaceSiteService(session_factory)
+
+    try:
+        bootstrap_service.bootstrap_account_workspace(
+            supabase_user_id="owner-123",
+            owner_email="owner1@sezzions.com",
+        )
+        bootstrap_service.bootstrap_account_workspace(
+            supabase_user_id="owner-456",
+            owner_email="owner2@sezzions.com",
+        )
+        created_site = service.create_site(supabase_user_id="owner-456", name="Other Workspace Site")
+
+        try:
+            service.delete_site(
+                supabase_user_id="owner-123",
+                site_id=created_site.id,
+            )
+        except LookupError as exc:
+            assert str(exc) == "Hosted site was not found in the authenticated workspace."
+        else:
+            raise AssertionError("Expected cross-workspace delete to fail")
+    finally:
+        engine.dispose()
+
+
+def test_delete_sites_removes_multiple_workspace_owned_business_sites() -> None:
+    engine, session_factory = _session_factory()
+    bootstrap_service = HostedAccountBootstrapService(session_factory)
+    service = HostedWorkspaceSiteService(session_factory)
+
+    try:
+        bootstrap_service.bootstrap_account_workspace(
+            supabase_user_id="owner-123",
+            owner_email="owner@sezzions.com",
+        )
+        created_one = service.create_site(supabase_user_id="owner-123", name="Delete Me 1")
+        created_two = service.create_site(supabase_user_id="owner-123", name="Delete Me 2")
+        service.create_site(supabase_user_id="owner-123", name="Keep Me")
+
+        deleted_count = service.delete_sites(
+            supabase_user_id="owner-123",
+            site_ids=[created_one.id, created_two.id],
+        )
+
+        sites = service.list_sites(supabase_user_id="owner-123")
+    finally:
+        engine.dispose()
+
+    assert deleted_count == 2
+    assert [site.name for site in sites] == ["Keep Me"]
+
+
+def test_delete_sites_rejects_missing_or_cross_workspace_ids_atomically() -> None:
+    engine, session_factory = _session_factory()
+    bootstrap_service = HostedAccountBootstrapService(session_factory)
+    service = HostedWorkspaceSiteService(session_factory)
+
+    try:
+        bootstrap_service.bootstrap_account_workspace(
+            supabase_user_id="owner-123",
+            owner_email="owner1@sezzions.com",
+        )
+        bootstrap_service.bootstrap_account_workspace(
+            supabase_user_id="owner-456",
+            owner_email="owner2@sezzions.com",
+        )
+        own_site = service.create_site(supabase_user_id="owner-123", name="Own Site")
+        other_site = service.create_site(supabase_user_id="owner-456", name="Other Workspace Site")
+
+        try:
+            service.delete_sites(
+                supabase_user_id="owner-123",
+                site_ids=[own_site.id, other_site.id],
+            )
+        except LookupError as exc:
+            assert str(exc) == "One or more hosted sites were not found in the authenticated workspace."
+        else:
+            raise AssertionError("Expected mixed-workspace batch delete to fail")
+
+        sites = service.list_sites(supabase_user_id="owner-123")
+    finally:
+        engine.dispose()
+
+    assert [site.name for site in sites] == ["Own Site"]

--- a/web/src/components/AppShell.jsx
+++ b/web/src/components/AppShell.jsx
@@ -6,10 +6,11 @@ import NotificationsModal from "./common/NotificationsModal";
 import AccountModal from "./common/AccountModal";
 import SettingsModal from "./common/SettingsModal";
 import UsersTab from "./UsersTab/UsersTab";
+import SitesTab from "./SitesTab/SitesTab";
 
 const setupTabs = [
   { key: "users", label: "Users", icon: "users", enabled: true },
-  { key: "sites", label: "Sites", icon: "sites", enabled: false },
+  { key: "sites", label: "Sites", icon: "sites", enabled: true },
   { key: "cards", label: "Cards", icon: "cards", enabled: false },
   { key: "method-types", label: "Method Types", icon: "methodTypes", enabled: false },
   { key: "redemption-methods", label: "Redemption Methods", icon: "redemptionMethods", enabled: false },
@@ -184,6 +185,12 @@ export default function AppShell({ auth }) {
       <main className="workspace-shell">
         {setupTab === "users" ? (
           <UsersTab
+            apiBaseUrl={auth.apiBaseUrl}
+            hostedWorkspaceReady={auth.hostedWorkspaceReady}
+          />
+        ) : null}
+        {setupTab === "sites" ? (
+          <SitesTab
             apiBaseUrl={auth.apiBaseUrl}
             hostedWorkspaceReady={auth.hostedWorkspaceReady}
           />

--- a/web/src/components/SitesTab/SiteModal.jsx
+++ b/web/src/components/SitesTab/SiteModal.jsx
@@ -1,0 +1,199 @@
+import { initialSiteForm } from "./sitesConstants";
+
+export default function SiteModal({
+  mode,
+  site,
+  form,
+  setForm,
+  onClose,
+  onSubmit,
+  onRequestEdit,
+  onRequestDelete,
+  submitError,
+  suggestions
+}) {
+  const readOnly = mode === "view";
+  const title = mode === "create" ? "Add Site" : mode === "edit" ? "Edit Site" : "View Site";
+  const nameInvalid = !form.name.trim();
+  const scRateValue = parseFloat(form.sc_rate);
+  const scRateInvalid = isNaN(scRateValue) || scRateValue < 0;
+  const playthroughValue = parseFloat(form.playthrough_requirement);
+  const playthroughInvalid = isNaN(playthroughValue) || playthroughValue < 0;
+  const closeLabel = readOnly ? "Close" : "Cancel";
+
+  if (readOnly && site) {
+    return (
+      <div className="modal-backdrop" role="presentation" onClick={onClose}>
+        <section
+          className="modal-card site-modal"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="site-modal-title"
+          onClick={(event) => event.stopPropagation()}
+        >
+          <div className="modal-header">
+            <div>
+              <h2 id="site-modal-title">View Site</h2>
+            </div>
+            <button className="ghost-button" type="button" onClick={onClose}>{closeLabel}</button>
+          </div>
+
+          <div className="user-detail-body">
+            <dl className="detail-grid user-detail-grid">
+              <div><dt>Name</dt><dd>{site.name}</dd></div>
+              <div><dt>URL</dt><dd>{site.url || "-"}</dd></div>
+              <div><dt>SC Rate</dt><dd>{site.sc_rate}</dd></div>
+              <div><dt>Playthrough</dt><dd>{site.playthrough_requirement}</dd></div>
+              <div>
+                <dt>Status</dt>
+                <dd>
+                  <span className={site.is_active ? "status-chip active" : "status-chip inactive"}>
+                    {site.is_active ? "Active" : "Inactive"}
+                  </span>
+                </dd>
+              </div>
+            </dl>
+
+            <div className="user-detail-notes">
+              <p className="detail-label">Notes</p>
+              <div className="notes-display">{site.notes || "-"}</div>
+            </div>
+          </div>
+
+          <div className="modal-actions modal-actions-split">
+            <div className="toolbar-row">
+              <button className="ghost-button" type="button" onClick={onRequestDelete}>Delete</button>
+            </div>
+            <div className="toolbar-row">
+              <button className="primary-button" type="button" onClick={onRequestEdit}>Edit Site</button>
+            </div>
+          </div>
+        </section>
+      </div>
+    );
+  }
+
+  return (
+    <div className="modal-backdrop" role="presentation" onClick={onClose}>
+      <section
+        className="modal-card site-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="site-modal-title"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="modal-header">
+          <div>
+            <h2 id="site-modal-title">{title}</h2>
+          </div>
+          <button className="ghost-button" type="button" onClick={onClose}>
+            {closeLabel}
+          </button>
+        </div>
+
+        <div className="form-grid">
+          <label className="field-label" htmlFor="site-name-input">Name</label>
+          <div>
+            <input
+              id="site-name-input"
+              className={nameInvalid ? "text-input invalid" : "text-input"}
+              type="text"
+              list="site-name-suggestions"
+              placeholder="Required"
+              value={form.name}
+              readOnly={readOnly}
+              onChange={(event) => setForm((current) => ({ ...current, name: event.target.value }))}
+            />
+            <datalist id="site-name-suggestions">
+              {suggestions.names.map((name) => (
+                <option key={name} value={name} />
+              ))}
+            </datalist>
+            {nameInvalid ? <p className="field-error">Name is required.</p> : null}
+          </div>
+
+          <label className="field-label" htmlFor="site-url-input">URL</label>
+          <div>
+            <input
+              id="site-url-input"
+              className="text-input"
+              type="url"
+              placeholder="Optional"
+              value={form.url}
+              readOnly={readOnly}
+              onChange={(event) => setForm((current) => ({ ...current, url: event.target.value }))}
+            />
+          </div>
+
+          <label className="field-label" htmlFor="site-sc-rate-input">SC Rate</label>
+          <div>
+            <input
+              id="site-sc-rate-input"
+              className={scRateInvalid ? "text-input invalid" : "text-input"}
+              type="number"
+              step="any"
+              min="0"
+              placeholder="1.0"
+              value={form.sc_rate}
+              readOnly={readOnly}
+              onChange={(event) => setForm((current) => ({ ...current, sc_rate: event.target.value }))}
+            />
+            {scRateInvalid ? <p className="field-error">SC rate must be a non-negative number.</p> : null}
+          </div>
+
+          <label className="field-label" htmlFor="site-playthrough-input">Playthrough</label>
+          <div>
+            <input
+              id="site-playthrough-input"
+              className={playthroughInvalid ? "text-input invalid" : "text-input"}
+              type="number"
+              step="any"
+              min="0"
+              placeholder="1.0"
+              value={form.playthrough_requirement}
+              readOnly={readOnly}
+              onChange={(event) => setForm((current) => ({ ...current, playthrough_requirement: event.target.value }))}
+            />
+            {playthroughInvalid ? <p className="field-error">Playthrough must be a non-negative number.</p> : null}
+          </div>
+
+          <label className="field-label" htmlFor="site-active-input">Active</label>
+          <label className="toggle-row" htmlFor="site-active-input">
+            <input
+              id="site-active-input"
+              type="checkbox"
+              checked={form.is_active}
+              disabled={readOnly}
+              onChange={(event) => setForm((current) => ({ ...current, is_active: event.target.checked }))}
+            />
+            <span>{form.is_active ? "Active" : "Inactive"}</span>
+          </label>
+
+          <label className="field-label field-label-top" htmlFor="site-notes-input">Notes</label>
+          <textarea
+            id="site-notes-input"
+            className="notes-input"
+            placeholder="Optional"
+            rows={5}
+            value={form.notes}
+            readOnly={readOnly}
+            onChange={(event) => setForm((current) => ({ ...current, notes: event.target.value }))}
+          />
+        </div>
+
+        {submitError ? <p className="submit-error">{submitError}</p> : null}
+
+        <div className="modal-actions modal-actions-end">
+          <button
+            className="primary-button"
+            type="button"
+            onClick={onSubmit}
+            disabled={nameInvalid || scRateInvalid || playthroughInvalid}
+          >
+            Save Site
+          </button>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/web/src/components/SitesTab/SitesTab.jsx
+++ b/web/src/components/SitesTab/SitesTab.jsx
@@ -1,0 +1,1379 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+
+import { authHeaders, describeFetchFailure, getAccessToken } from "../../services/api";
+import Icon from "../common/Icon";
+import HighlightMatch from "../common/HighlightMatch";
+import ConfirmationModal from "../common/ConfirmationModal";
+import SiteModal from "./SiteModal";
+import ExportModal from "../UsersTab/ExportModal";
+import UserHeaderFilterMenu from "../UsersTab/UserHeaderFilterMenu";
+import TableContextMenu from "../UsersTab/TableContextMenu";
+import {
+  initialSiteForm,
+  initialSiteColumnFilters,
+  siteTableColumns,
+  sitesPageSize,
+  sitesFallbackPageSize
+} from "./sitesConstants";
+import {
+  normalizeSiteForm,
+  isTextEntryElement,
+  computeCellStats,
+  getCellDisplayValue,
+  downloadSitesCsv,
+  getSiteColumnValue,
+  buildSiteFilterOptions,
+  mergeSitesById
+} from "./sitesUtils";
+
+export default function SitesTab({ apiBaseUrl, hostedWorkspaceReady }) {
+  const sitesScrollGateRef = useRef({ armed: false, lastScrollTop: 0 });
+  const sitesPagingRequestRef = useRef(false);
+  const sitesTableViewportRef = useRef(null);
+  const siteNavCursorRef = useRef(null);
+  const [sites, setSites] = useState([]);
+  const [sitesStatus, setSitesStatus] = useState("Sign in to load hosted sites.");
+  const [sitesSearch, setSitesSearch] = useState("");
+  const [siteColumnFilters, setSiteColumnFilters] = useState(initialSiteColumnFilters);
+  const [sitesSort, setSitesSort] = useState({ column: null, direction: "asc" });
+  const [openSiteHeaderMenu, setOpenSiteHeaderMenu] = useState(null);
+  const [selectedSiteIds, setSelectedSiteIds] = useState([]);
+  const [selectionAnchorSiteId, setSelectionAnchorSiteId] = useState(null);
+  const [selectedColumnKeys, setSelectedColumnKeys] = useState(new Set());
+  const [selectedCells, setSelectedCells] = useState(new Set());
+  const cellAnchorRef = useRef(null);
+  const [sitesTotalCount, setSitesTotalCount] = useState(null);
+  const [sitesNextOffset, setSitesNextOffset] = useState(0);
+  const [sitesHasMore, setSitesHasMore] = useState(false);
+  const [sitesLoadingInitial, setSitesLoadingInitial] = useState(false);
+  const [sitesLoadingMore, setSitesLoadingMore] = useState(false);
+  const [showBackToTop, setShowBackToTop] = useState(false);
+  const [contextMenu, setContextMenu] = useState(null);
+  const [columnWidths, setColumnWidths] = useState(null);
+  const columnResizeRef = useRef(null);
+  const headerRef = useRef(null);
+  const [exportModalOpen, setExportModalOpen] = useState(false);
+  const [siteModalMode, setSiteModalMode] = useState(null);
+  const [siteForm, setSiteForm] = useState(initialSiteForm);
+  const [siteFormBaseline, setSiteFormBaseline] = useState(initialSiteForm);
+  const [siteSubmitError, setSiteSubmitError] = useState(null);
+  const [confirmationState, setConfirmationState] = useState(null);
+
+  const filteredSites = useMemo(() => {
+    const searchText = sitesSearch.trim().toLowerCase();
+    const searchFiltered = !searchText
+      ? sites
+      : sites.filter((site) =>
+          site.name.toLowerCase().includes(searchText)
+          || (site.url || "").toLowerCase().includes(searchText)
+          || (site.notes || "").toLowerCase().includes(searchText)
+        );
+
+    const columnFiltered = searchFiltered.filter((site) => {
+      for (const col of siteTableColumns) {
+        const filterValues = siteColumnFilters[col.key];
+        if (filterValues && filterValues.length && !filterValues.includes(getSiteColumnValue(site, col.key))) {
+          return false;
+        }
+      }
+      return true;
+    });
+
+    if (!sitesSort.column) {
+      return columnFiltered;
+    }
+
+    const sortedSites = [...columnFiltered].sort((left, right) => {
+      const leftValue = getSiteColumnValue(left, sitesSort.column);
+      const rightValue = getSiteColumnValue(right, sitesSort.column);
+
+      // Numeric sort for numeric columns
+      if (sitesSort.column === "sc_rate" || sitesSort.column === "playthrough_requirement") {
+        const leftNum = parseFloat(leftValue) || 0;
+        const rightNum = parseFloat(rightValue) || 0;
+        return leftNum - rightNum;
+      }
+
+      return leftValue.localeCompare(rightValue, undefined, { sensitivity: "base" });
+    });
+
+    return sitesSort.direction === "desc" ? sortedSites.reverse() : sortedSites;
+  }, [siteColumnFilters, sites, sitesSearch, sitesSort]);
+
+  const siteFilterOptions = useMemo(() => {
+    const options = {};
+    for (const col of siteTableColumns) {
+      if (col.key === "status") {
+        options[col.key] = [
+          { value: "Active", label: "Active", path: ["Active"], searchValue: "Active" },
+          { value: "Inactive", label: "Inactive", path: ["Inactive"], searchValue: "Inactive" }
+        ];
+      } else {
+        options[col.key] = buildSiteFilterOptions(sites, col.key);
+      }
+    }
+    return options;
+  }, [sites]);
+
+  const filteredSiteCount = filteredSites.length;
+  const totalSiteCount = sitesTotalCount ?? sites.length;
+
+  const selectedSites = sites.filter((site) => selectedSiteIds.includes(site.id));
+  const selectedSite = selectedSites.length === 1 ? selectedSites[0] : null;
+  const siteModalDirty = siteModalMode && siteModalMode !== "view"
+    ? JSON.stringify(normalizeSiteForm(siteForm)) !== JSON.stringify(normalizeSiteForm(siteFormBaseline))
+    : false;
+
+  const sitesFiltersActive = Boolean(
+    sitesSearch
+    || Object.values(siteColumnFilters).some((values) => values.length)
+    || sitesSort.column
+  );
+
+  const siteSuggestions = useMemo(() => ({
+    names: [...new Set(sites.map((site) => site.name).filter(Boolean))]
+  }), [sites]);
+
+  function clearSiteSelection() {
+    setSelectedSiteIds([]);
+    setSelectionAnchorSiteId(null);
+    setSelectedCells(new Set());
+    setSelectedColumnKeys(new Set());
+    cellAnchorRef.current = null;
+  }
+
+  function closeSiteModalImmediately() {
+    setSiteModalMode(null);
+    setSiteSubmitError(null);
+    setSiteForm(initialSiteForm);
+    setSiteFormBaseline(initialSiteForm);
+  }
+
+  function openConfirmation(options) {
+    setConfirmationState(options);
+  }
+
+  function requestCloseSiteModal() {
+    if (!siteModalDirty) {
+      closeSiteModalImmediately();
+      return;
+    }
+
+    openConfirmation({
+      title: "Discard unsaved changes?",
+      message: "You have changes in this form that have not been saved.",
+      confirmLabel: "Discard Changes",
+      cancelLabel: "Keep Editing",
+      tone: "danger",
+      onConfirm: () => {
+        setConfirmationState(null);
+        closeSiteModalImmediately();
+      }
+    });
+  }
+
+  // --- Data loading ---
+
+  async function loadSites(accessToken, { append = false } = {}) {
+    if (!accessToken) {
+      setSites([]);
+      setSitesTotalCount(null);
+      setSitesNextOffset(0);
+      setSitesHasMore(false);
+      clearSiteSelection();
+      setSitesStatus("Sign in to load hosted sites.");
+      return;
+    }
+
+    if (!apiBaseUrl) {
+      setSites([]);
+      setSitesTotalCount(null);
+      setSitesNextOffset(0);
+      setSitesHasMore(false);
+      clearSiteSelection();
+      setSitesStatus("Set VITE_API_BASE_URL to enable hosted sites.");
+      return;
+    }
+
+    const requestOffset = append ? sitesNextOffset : 0;
+    if (append) {
+      setSitesLoadingMore(true);
+    } else {
+      setSitesLoadingInitial(true);
+      setSitesStatus("Loading hosted sites...");
+    }
+
+    try {
+      const response = await fetch(`${apiBaseUrl}/v1/workspace/sites?limit=${sitesPageSize}&offset=${requestOffset}`, {
+        headers: authHeaders(accessToken)
+      });
+      const payload = await response.json();
+
+      if (!response.ok) {
+        setSites([]);
+        setSitesTotalCount(null);
+        setSitesNextOffset(0);
+        setSitesHasMore(false);
+        clearSiteSelection();
+        setSitesStatus(payload.detail || `Hosted sites failed to load (${response.status}).`);
+        return;
+      }
+
+      const payloadSites = Array.isArray(payload.sites) ? payload.sites : [];
+      let loadedSites = payloadSites.slice(0, sitesPageSize);
+      let mergedSites = append ? mergeSitesById(sites, loadedSites) : loadedSites;
+      let reportedTotalCount = Number.isFinite(payload.total_count) ? payload.total_count : null;
+      let nextOffset = requestOffset + loadedSites.length;
+      let inferredHasMore = loadedSites.length === sitesPageSize;
+      let hasMore = Boolean(payload.has_more) || nextOffset < (reportedTotalCount ?? 0) || inferredHasMore;
+
+      if (append && loadedSites.length && mergedSites.length === sites.length) {
+        const fallbackResponse = await fetch(`${apiBaseUrl}/v1/workspace/sites?limit=${sitesFallbackPageSize}&offset=0`, {
+          headers: authHeaders(accessToken)
+        });
+        const fallbackPayload = await fallbackResponse.json();
+
+        if (fallbackResponse.ok) {
+          const fallbackSites = Array.isArray(fallbackPayload.sites)
+            ? fallbackPayload.sites.slice(0, sitesFallbackPageSize)
+            : [];
+          const fallbackMergedSites = mergeSitesById(sites, fallbackSites);
+
+          if (fallbackMergedSites.length > sites.length) {
+            loadedSites = fallbackSites;
+            mergedSites = fallbackMergedSites;
+            reportedTotalCount = Number.isFinite(fallbackPayload.total_count)
+              ? fallbackPayload.total_count
+              : reportedTotalCount;
+            nextOffset = mergedSites.length;
+            inferredHasMore = fallbackSites.length === sitesFallbackPageSize;
+            hasMore = Boolean(fallbackPayload.has_more)
+              || nextOffset < (reportedTotalCount ?? 0)
+              || inferredHasMore;
+          } else {
+            hasMore = false;
+          }
+        } else {
+          hasMore = false;
+        }
+      }
+
+      const totalCount = Math.max(reportedTotalCount ?? 0, mergedSites.length);
+
+      if (!append) {
+        sitesScrollGateRef.current = {
+          armed: false,
+          lastScrollTop: sitesTableViewportRef.current?.scrollTop || 0,
+        };
+      }
+
+      setSites(mergedSites);
+      setSitesTotalCount(totalCount);
+      setSitesNextOffset(nextOffset);
+      setSitesHasMore(hasMore);
+      setSelectedSiteIds((current) => current.filter((siteId) => mergedSites.some((site) => site.id === siteId)));
+
+      if (!mergedSites.length) {
+        setSitesStatus("No hosted sites yet. Add your first site to get started.");
+      } else if (hasMore) {
+        setSitesStatus(`Loaded ${mergedSites.length} of ${totalCount} hosted sites.`);
+      } else {
+        setSitesStatus("Hosted sites ready.");
+      }
+    } catch (error) {
+      setSites([]);
+      setSitesTotalCount(null);
+      setSitesNextOffset(0);
+      setSitesHasMore(false);
+      clearSiteSelection();
+      setSitesStatus(describeFetchFailure(error, "Hosted sites failed to load."));
+    } finally {
+      setSitesLoadingInitial(false);
+      setSitesLoadingMore(false);
+    }
+  }
+
+  // --- Load sites when workspace becomes ready ---
+
+  useEffect(() => {
+    if (!hostedWorkspaceReady || !apiBaseUrl) {
+      return;
+    }
+
+    (async () => {
+      try {
+        const accessToken = await getAccessToken();
+        if (accessToken) {
+          await loadSites(accessToken);
+        }
+      } catch (error) {
+        setSitesStatus(describeFetchFailure(error, "Hosted sites failed to load."));
+      }
+    })();
+  }, [hostedWorkspaceReady]);
+
+  // --- Header menu close on outside click ---
+
+  useEffect(() => {
+    if (!openSiteHeaderMenu) {
+      return undefined;
+    }
+
+    function handlePointerDown(event) {
+      if (event.target instanceof Element && event.target.closest(".table-header-menu-wrap, .table-header-menu")) {
+        return;
+      }
+      setOpenSiteHeaderMenu(null);
+    }
+
+    function handleViewportChange() {
+      setOpenSiteHeaderMenu(null);
+    }
+
+    document.addEventListener("mousedown", handlePointerDown);
+    window.addEventListener("resize", handleViewportChange);
+    return () => {
+      document.removeEventListener("mousedown", handlePointerDown);
+      window.removeEventListener("resize", handleViewportChange);
+    };
+  }, [openSiteHeaderMenu]);
+
+  // --- Escape key handler ---
+
+  useEffect(() => {
+    const anyModalOpen = Boolean(
+      openSiteHeaderMenu
+      || siteModalMode
+      || confirmationState
+      || exportModalOpen
+    );
+
+    if (!anyModalOpen) {
+      return undefined;
+    }
+
+    function handleKeyDown(event) {
+      if (event.key !== "Escape") {
+        return;
+      }
+
+      const activeElement = document.activeElement;
+      const blurActiveTextFieldWithin = (selector) => {
+        if (!isTextEntryElement(activeElement)) {
+          return false;
+        }
+        if (!(activeElement instanceof Element) || !activeElement.closest(selector)) {
+          return false;
+        }
+        activeElement.blur();
+        return true;
+      };
+
+      event.preventDefault();
+      event.stopImmediatePropagation();
+
+      if (confirmationState) {
+        setConfirmationState(null);
+        return;
+      }
+
+      if (openSiteHeaderMenu) {
+        if (blurActiveTextFieldWithin(".table-header-menu")) {
+          return;
+        }
+        setOpenSiteHeaderMenu(null);
+        return;
+      }
+
+      if (siteModalMode) {
+        if (blurActiveTextFieldWithin(".modal-card")) {
+          return;
+        }
+        requestCloseSiteModal();
+        return;
+      }
+
+      if (exportModalOpen) {
+        setExportModalOpen(false);
+      }
+    }
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [confirmationState, exportModalOpen, openSiteHeaderMenu, siteModalMode, siteModalDirty]);
+
+  // --- Keyboard navigation ---
+
+  useEffect(() => {
+    function handleArrowNav(event) {
+      if (event.key === "c" && (event.metaKey || event.ctrlKey) && !event.shiftKey) {
+        if (isTextEntryElement(document.activeElement)) return;
+        if (selectedCells.size) {
+          event.preventDefault();
+          copyCellsAsTSV();
+          return;
+        }
+        if (selectedSiteIds.length) {
+          event.preventDefault();
+          copyRowsAsTSV();
+          return;
+        }
+        return;
+      }
+
+      if (event.key === "a" && (event.metaKey || event.ctrlKey) && !event.shiftKey) {
+        if (isTextEntryElement(document.activeElement)) return;
+        if (confirmationState || siteModalMode || openSiteHeaderMenu) return;
+        if (!filteredSites.length) return;
+        event.preventDefault();
+        if (selectedSiteIds.length === filteredSites.length && filteredSites.every((s) => selectedSiteIds.includes(s.id))) {
+          setSelectedSiteIds([]);
+          setSelectionAnchorSiteId(null);
+          siteNavCursorRef.current = null;
+        } else {
+          setSelectedSiteIds(filteredSites.map((s) => s.id));
+          setSelectionAnchorSiteId(filteredSites[0].id);
+          siteNavCursorRef.current = filteredSites[filteredSites.length - 1].id;
+        }
+        return;
+      }
+
+      if (event.key === "f" && (event.metaKey || event.ctrlKey) && !event.shiftKey) {
+        if (confirmationState || siteModalMode || openSiteHeaderMenu) return;
+        event.preventDefault();
+        const searchInput = document.getElementById("sites-search-input");
+        if (searchInput) searchInput.focus();
+        return;
+      }
+
+      if (event.key === "Escape") {
+        const searchInput = document.getElementById("sites-search-input");
+        if (document.activeElement === searchInput) {
+          event.preventDefault();
+          if (sitesSearch) {
+            setSitesSearch("");
+          } else {
+            searchInput.blur();
+          }
+          return;
+        }
+      }
+
+      if (event.key !== "ArrowUp" && event.key !== "ArrowDown" && event.key !== "Enter") return;
+      if (isTextEntryElement(document.activeElement)) return;
+      if (confirmationState || siteModalMode || openSiteHeaderMenu) return;
+
+      if (event.key === "Enter") {
+        if (selectedSiteIds.length === 1) {
+          const site = filteredSites.find((s) => s.id === selectedSiteIds[0]);
+          if (site) openSiteModal("view", site);
+        }
+        return;
+      }
+
+      if (!filteredSites.length || !selectedSiteIds.length) return;
+
+      event.preventDefault();
+      const orderedIds = filteredSites.map((s) => s.id);
+      const cursorId = siteNavCursorRef.current ?? selectedSiteIds[selectedSiteIds.length - 1];
+      const currentIndex = orderedIds.indexOf(cursorId);
+      if (currentIndex === -1) return;
+
+      const nextIndex = event.key === "ArrowDown"
+        ? Math.min(currentIndex + 1, orderedIds.length - 1)
+        : Math.max(currentIndex - 1, 0);
+      const nextId = orderedIds[nextIndex];
+      siteNavCursorRef.current = nextId;
+
+      if (event.shiftKey) {
+        setSelectedSiteIds(() => {
+          const anchor = selectionAnchorSiteId && orderedIds.includes(selectionAnchorSiteId)
+            ? orderedIds.indexOf(selectionAnchorSiteId)
+            : currentIndex;
+          const [start, end] = anchor < nextIndex ? [anchor, nextIndex] : [nextIndex, anchor];
+          return orderedIds.slice(start, end + 1);
+        });
+      } else {
+        setSelectedSiteIds([nextId]);
+        setSelectionAnchorSiteId(nextId);
+      }
+
+      const viewport = sitesTableViewportRef.current;
+      if (viewport) {
+        requestAnimationFrame(() => {
+          const row = viewport.querySelector(`tbody tr:nth-child(${nextIndex + 1})`);
+          if (row) row.scrollIntoView({ block: "nearest" });
+        });
+      }
+    }
+
+    window.addEventListener("keydown", handleArrowNav);
+    return () => window.removeEventListener("keydown", handleArrowNav);
+  }, [confirmationState, filteredSites, openSiteHeaderMenu, selectedCells, selectedSiteIds, selectionAnchorSiteId, siteModalMode]);
+
+  // --- Sort / filter ---
+
+  function toggleSiteSort(column) {
+    setSitesSort((current) => {
+      if (current.column !== column) {
+        return { column, direction: "asc" };
+      }
+      if (current.direction === "asc") {
+        return { column, direction: "desc" };
+      }
+      return { column: null, direction: "asc" };
+    });
+  }
+
+  function clearAllSiteFilters() {
+    setSitesSearch("");
+    setSiteColumnFilters(initialSiteColumnFilters);
+    setSitesSort({ column: null, direction: "asc" });
+    setOpenSiteHeaderMenu(null);
+    clearSiteSelection();
+  }
+
+  // --- Row / cell selection ---
+
+  function handleSiteRowSelection(event, siteId) {
+    event.preventDefault();
+    setSelectedCells(new Set());
+    setSelectedColumnKeys(new Set());
+    cellAnchorRef.current = null;
+    const orderedIds = filteredSites.map((site) => site.id);
+
+    if (event.shiftKey && selectionAnchorSiteId && orderedIds.includes(selectionAnchorSiteId)) {
+      const anchorIndex = orderedIds.indexOf(selectionAnchorSiteId);
+      const targetIndex = orderedIds.indexOf(siteId);
+      const [start, end] = anchorIndex < targetIndex ? [anchorIndex, targetIndex] : [targetIndex, anchorIndex];
+      const rangeIds = orderedIds.slice(start, end + 1);
+      setSelectedSiteIds((current) => (event.metaKey || event.ctrlKey ? [...new Set([...current, ...rangeIds])] : rangeIds));
+      return;
+    }
+
+    if (event.metaKey || event.ctrlKey) {
+      setSelectedSiteIds((current) => (
+        current.includes(siteId)
+          ? current.filter((candidate) => candidate !== siteId)
+          : [...current, siteId]
+      ));
+      setSelectionAnchorSiteId(siteId);
+      return;
+    }
+
+    setSelectedSiteIds([siteId]);
+    setSelectionAnchorSiteId(siteId);
+    siteNavCursorRef.current = siteId;
+  }
+
+  function handleCellClick(event, siteId, columnKey) {
+    if (!event.altKey) return false;
+    event.stopPropagation();
+    event.preventDefault();
+
+    setSelectedSiteIds([]);
+    setSelectionAnchorSiteId(null);
+
+    const cellId = `${siteId}:${columnKey}`;
+    const columnKeys = siteTableColumns.map((c) => c.key);
+
+    if (event.shiftKey && cellAnchorRef.current) {
+      const anchor = cellAnchorRef.current;
+      const orderedIds = filteredSites.map((s) => s.id);
+      const anchorRowIdx = orderedIds.indexOf(anchor.siteId);
+      const targetRowIdx = orderedIds.indexOf(siteId);
+      const anchorColIdx = columnKeys.indexOf(anchor.columnKey);
+      const targetColIdx = columnKeys.indexOf(columnKey);
+      if (anchorRowIdx === -1 || targetRowIdx === -1) return true;
+
+      const [rowStart, rowEnd] = anchorRowIdx < targetRowIdx ? [anchorRowIdx, targetRowIdx] : [targetRowIdx, anchorRowIdx];
+      const [colStart, colEnd] = anchorColIdx < targetColIdx ? [anchorColIdx, targetColIdx] : [targetColIdx, anchorColIdx];
+
+      const next = new Set();
+      for (let r = rowStart; r <= rowEnd; r++) {
+        for (let c = colStart; c <= colEnd; c++) {
+          next.add(`${orderedIds[r]}:${columnKeys[c]}`);
+        }
+      }
+      setSelectedCells(next);
+      setSelectedColumnKeys(new Set());
+    } else {
+      if (event.metaKey || event.ctrlKey) {
+        setSelectedCells((current) => {
+          const next = new Set(current);
+          if (next.has(cellId)) next.delete(cellId); else next.add(cellId);
+          return next;
+        });
+      } else {
+        setSelectedCells((current) => current.size === 1 && current.has(cellId) ? new Set() : new Set([cellId]));
+      }
+      setSelectedColumnKeys(new Set());
+      cellAnchorRef.current = { siteId, columnKey };
+    }
+    return true;
+  }
+
+  // --- Copy ---
+
+  function copyCellsAsTSV() {
+    const columnKeys = siteTableColumns.map((c) => c.key);
+    const orderedIds = filteredSites.map((s) => s.id);
+    const rows = [];
+    for (const sid of orderedIds) {
+      const row = [];
+      let hasCell = false;
+      for (const col of columnKeys) {
+        if (selectedCells.has(`${sid}:${col}`)) {
+          const s = filteredSites.find((x) => x.id === sid);
+          row.push(s ? getCellDisplayValue(s, col) : "");
+          hasCell = true;
+        } else {
+          row.push("");
+        }
+      }
+      if (hasCell) rows.push(row);
+    }
+    const usedCols = columnKeys.map((_, ci) => rows.some((r) => r[ci] !== ""));
+    const tsv = rows.map((r) => r.filter((_, ci) => usedCols[ci]).join("\t")).join("\n");
+    navigator.clipboard.writeText(tsv).catch(() => {});
+  }
+
+  function copyRowsAsTSV() {
+    const columnKeys = siteTableColumns.map((c) => c.key);
+    const orderedIds = filteredSites.map((s) => s.id);
+    const rows = [];
+    for (const sid of orderedIds) {
+      if (!selectedSiteIds.includes(sid)) continue;
+      const s = filteredSites.find((x) => x.id === sid);
+      if (!s) continue;
+      rows.push(columnKeys.map((col) => getCellDisplayValue(s, col)));
+    }
+    const tsv = rows.map((r) => r.join("\t")).join("\n");
+    navigator.clipboard.writeText(tsv).catch(() => {});
+  }
+
+  // --- Context menu ---
+
+  function handleTableContextMenu(event, site) {
+    event.preventDefault();
+    setContextMenu(null);
+
+    let td = event.target;
+    while (td && td.tagName !== "TD") td = td.parentElement;
+    const clickedColumnKey = td?.dataset?.col || null;
+
+    const items = [];
+    const isRowSelected = selectedSiteIds.includes(site.id);
+    const hasCellSelection = selectedCells.size > 0;
+    const hasRowSelection = selectedSiteIds.length > 0;
+
+    if (clickedColumnKey) {
+      const cellValue = getCellDisplayValue(site, clickedColumnKey);
+      const truncated = cellValue.length > 30 ? `${cellValue.slice(0, 27)}…` : cellValue;
+      items.push({ label: `Copy "${truncated}"`, action: () => { navigator.clipboard.writeText(cellValue).catch(() => {}); }});
+    }
+
+    if (hasCellSelection) {
+      items.push({ label: `Copy ${selectedCells.size} cell${selectedCells.size > 1 ? "s" : ""}`, action: copyCellsAsTSV });
+    }
+
+    if (hasRowSelection) {
+      const count = selectedSiteIds.length;
+      items.push({ label: count > 1 ? `Copy ${count} rows` : "Copy row", action: copyRowsAsTSV });
+    }
+
+    items.push({ divider: true });
+
+    if (!isRowSelected) {
+      items.push({ label: "Select row", action: () => { setSelectedSiteIds([site.id]); setSelectionAnchorSiteId(site.id); }});
+      items.push({ divider: true });
+    }
+
+    const targetSites = isRowSelected ? selectedSites : [site];
+    const targetCount = targetSites.length;
+
+    items.push({ label: "View", action: () => openSiteModal("view", targetCount === 1 ? targetSites[0] : site), disabled: targetCount !== 1 });
+    items.push({ label: "Edit", action: () => openSiteModal("edit", targetCount === 1 ? targetSites[0] : site), disabled: targetCount !== 1 });
+    items.push({ divider: true });
+
+    if (hasCellSelection) {
+      items.push({ label: "Clear cell selection", action: () => { setSelectedCells(new Set()); setSelectedColumnKeys(new Set()); cellAnchorRef.current = null; }});
+    }
+
+    items.push({
+      label: targetCount > 1 ? `Delete ${targetCount} sites` : "Delete",
+      danger: true,
+      action: () => handleDeleteSite(targetSites),
+      disabled: !hostedWorkspaceReady
+    });
+
+    setContextMenu({ x: event.clientX, y: event.clientY, items });
+  }
+
+  // --- Column resize ---
+
+  function getComputedColumnWidths() {
+    const header = headerRef.current;
+    if (!header) return null;
+    const cells = header.querySelectorAll(".users-table-header-cell");
+    const widths = [];
+    for (let i = 1; i < cells.length; i++) {
+      widths.push(cells[i].getBoundingClientRect().width);
+    }
+    return widths.length === siteTableColumns.length ? widths : null;
+  }
+
+  function getColumnMinWidth(colIndex) {
+    const header = headerRef.current;
+    if (!header) return 80;
+    const cells = header.querySelectorAll(".users-table-header-cell");
+    const cell = cells[colIndex + 1];
+    if (!cell) return 80;
+    const label = cell.querySelector(".users-table-header-label");
+    const canvas = document.createElement("canvas");
+    const ctx = canvas.getContext("2d");
+    ctx.font = "0.71rem -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif";
+    const labelW = label ? ctx.measureText(label.textContent || "").width : 30;
+    return Math.ceil(labelW + 57);
+  }
+
+  function handleColumnResizeStart(event, colIndex) {
+    event.preventDefault();
+    event.stopPropagation();
+    const startX = event.clientX;
+    let widths = columnWidths || getComputedColumnWidths();
+    if (!widths) return;
+    widths = [...widths];
+    const startWidth = widths[colIndex];
+
+    const minWidths = widths.map((_, i) => getColumnMinWidth(i));
+
+    function ensureViewportFill(w) {
+      const viewport = sitesTableViewportRef.current;
+      if (!viewport) return w;
+      const available = viewport.clientWidth - 36;
+      const total = w.reduce((a, b) => a + b, 0);
+      if (total < available) {
+        const result = [...w];
+        result[result.length - 1] += available - total;
+        return result;
+      }
+      return w;
+    }
+
+    function onMouseMove(moveEvent) {
+      const delta = moveEvent.clientX - startX;
+      widths[colIndex] = Math.max(minWidths[colIndex], startWidth + delta);
+      setColumnWidths(ensureViewportFill([...widths]));
+    }
+
+    function onMouseUp() {
+      document.removeEventListener("mousemove", onMouseMove);
+      document.removeEventListener("mouseup", onMouseUp);
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+      columnResizeRef.current = null;
+    }
+
+    document.body.style.cursor = "col-resize";
+    document.body.style.userSelect = "none";
+    columnResizeRef.current = true;
+    document.addEventListener("mousemove", onMouseMove);
+    document.addEventListener("mouseup", onMouseUp);
+  }
+
+  function handleColumnAutoFit(colIndex) {
+    let widths = columnWidths || getComputedColumnWidths();
+    if (!widths) return;
+    widths = [...widths];
+
+    const columnKey = siteTableColumns[colIndex]?.key;
+    if (!columnKey) return;
+
+    const canvas = document.createElement("canvas");
+    const ctx = canvas.getContext("2d");
+    ctx.font = "0.84rem -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif";
+
+    let maxWidth = 60;
+
+    const header = headerRef.current;
+    if (header) {
+      const headerCells = header.querySelectorAll(".users-table-header-cell");
+      if (headerCells[colIndex + 1]) {
+        const label = headerCells[colIndex + 1].querySelector(".users-table-header-label");
+        if (label) {
+          const textWidth = ctx.measureText(label.textContent || "").width;
+          maxWidth = Math.max(maxWidth, textWidth + 52);
+        }
+      }
+    }
+
+    for (const site of filteredSites) {
+      const value = getCellDisplayValue(site, columnKey);
+      const textWidth = ctx.measureText(value).width;
+      maxWidth = Math.max(maxWidth, textWidth + 24);
+    }
+
+    widths[colIndex] = Math.min(Math.ceil(maxWidth), 600);
+
+    const viewport = sitesTableViewportRef.current;
+    if (viewport) {
+      const available = viewport.clientWidth - 36;
+      const total = widths.reduce((a, b) => a + b, 0);
+      if (total < available) {
+        widths[widths.length - 1] += available - total;
+      }
+    }
+    setColumnWidths([...widths]);
+  }
+
+  // --- Paging ---
+
+  async function loadNextSitesPage() {
+    if (sitesPagingRequestRef.current || sitesLoadingInitial || sitesLoadingMore || !sitesHasMore || sitesFiltersActive) {
+      return;
+    }
+
+    sitesPagingRequestRef.current = true;
+
+    try {
+      const accessToken = await getAccessToken();
+      if (accessToken) {
+        await loadSites(accessToken, { append: true });
+      }
+    } catch (error) {
+      setSitesStatus(describeFetchFailure(error, "Hosted sites failed to load."));
+    } finally {
+      sitesPagingRequestRef.current = false;
+    }
+  }
+
+  useEffect(() => {
+    if (!sitesHasMore || sitesFiltersActive || sitesLoadingInitial || sitesLoadingMore || !hostedWorkspaceReady) {
+      return undefined;
+    }
+
+    const viewport = sitesTableViewportRef.current;
+    if (!viewport) {
+      return undefined;
+    }
+
+    function handleViewportScroll() {
+      const scrollTop = viewport.scrollTop || 0;
+      const scrollGate = sitesScrollGateRef.current;
+
+      if (!scrollGate.armed) {
+        if (scrollTop <= scrollGate.lastScrollTop) {
+          return;
+        }
+        scrollGate.armed = true;
+      }
+
+      scrollGate.lastScrollTop = scrollTop;
+      const viewportBottom = scrollTop + viewport.clientHeight;
+      const documentHeight = viewport.scrollHeight;
+
+      if (documentHeight - viewportBottom <= 220) {
+        loadNextSitesPage();
+      }
+    }
+
+    viewport.addEventListener("scroll", handleViewportScroll, { passive: true });
+    return () => viewport.removeEventListener("scroll", handleViewportScroll);
+  }, [hostedWorkspaceReady, sitesFiltersActive, sitesHasMore, sitesLoadingInitial, sitesLoadingMore, sitesNextOffset]);
+
+  // --- Header menu ---
+
+  function openSiteHeaderOptions(event, columnKey) {
+    const buttonRect = event.currentTarget.getBoundingClientRect();
+    const menuWidth = 296;
+    const left = Math.max(16, Math.min(buttonRect.right - menuWidth, window.innerWidth - menuWidth - 16));
+    const top = Math.min(buttonRect.bottom + 8, window.innerHeight - 24);
+
+    setOpenSiteHeaderMenu((current) => current?.key === columnKey ? null : { key: columnKey, left, top });
+  }
+
+  // --- Site CRUD ---
+
+  function openSiteModal(mode, site = null) {
+    setSiteModalMode(mode);
+    setSiteSubmitError(null);
+
+    if (site) {
+      const nextForm = {
+        name: site.name || "",
+        url: site.url || "",
+        sc_rate: String(site.sc_rate ?? "1"),
+        playthrough_requirement: String(site.playthrough_requirement ?? "1"),
+        notes: site.notes || "",
+        is_active: Boolean(site.is_active)
+      };
+      setSiteForm(nextForm);
+      setSiteFormBaseline(nextForm);
+      setSelectedSiteIds([site.id]);
+      setSelectionAnchorSiteId(site.id);
+      return;
+    }
+
+    setSiteForm(initialSiteForm);
+    setSiteFormBaseline(initialSiteForm);
+  }
+
+  async function submitSiteModal() {
+    const accessToken = await getAccessToken();
+    if (!accessToken) {
+      setSiteSubmitError("Google sign-in is required before managing hosted sites.");
+      return;
+    }
+
+    if (!apiBaseUrl) {
+      setSiteSubmitError("Set VITE_API_BASE_URL to enable hosted sites.");
+      return;
+    }
+
+    const payload = {
+      name: siteForm.name,
+      url: siteForm.url || null,
+      sc_rate: parseFloat(siteForm.sc_rate) || 1.0,
+      playthrough_requirement: parseFloat(siteForm.playthrough_requirement) || 1.0,
+      notes: siteForm.notes || null,
+      ...(siteModalMode === "edit" ? { is_active: siteForm.is_active } : {})
+    };
+    const url = siteModalMode === "edit" && selectedSite
+      ? `${apiBaseUrl}/v1/workspace/sites/${selectedSite.id}`
+      : `${apiBaseUrl}/v1/workspace/sites`;
+    const method = siteModalMode === "edit" ? "PATCH" : "POST";
+
+    try {
+      const response = await fetch(url, {
+        method,
+        headers: {
+          ...authHeaders(accessToken),
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify(payload)
+      });
+      const data = await response.json();
+
+      if (!response.ok) {
+        setSiteSubmitError(data.detail || `Hosted sites save failed (${response.status}).`);
+        return;
+      }
+
+      setSites((current) => mergeSitesById(current, [data]));
+      setSitesTotalCount((current) => (method === "POST" && current !== null ? current + 1 : current));
+      setSelectedSiteIds([data.id]);
+      setSelectionAnchorSiteId(data.id);
+      setSitesStatus("Hosted sites ready.");
+      closeSiteModalImmediately();
+    } catch (error) {
+      setSiteSubmitError(describeFetchFailure(error, "Hosted sites save failed."));
+    }
+  }
+
+  async function handleSitesRefresh() {
+    try {
+      const accessToken = await getAccessToken();
+      clearSiteSelection();
+      await loadSites(accessToken, { append: false });
+    } catch (error) {
+      setSitesStatus(describeFetchFailure(error, "Hosted sites failed to load."));
+    }
+  }
+
+  async function handleDeleteSite(sitesToDelete = selectedSites) {
+    const accessToken = await getAccessToken();
+    if (!sitesToDelete.length || !accessToken) {
+      setSitesStatus("Google sign-in is required before managing hosted sites.");
+      return;
+    }
+    if (!apiBaseUrl) {
+      setSitesStatus("Set VITE_API_BASE_URL to enable hosted sites.");
+      return;
+    }
+    const prompt = sitesToDelete.length === 1
+      ? `Delete site '${sitesToDelete[0].name}'? This cannot be undone.`
+      : `Delete ${sitesToDelete.length} sites? This cannot be undone.`;
+
+    openConfirmation({
+      title: sitesToDelete.length === 1 ? "Delete site?" : "Delete sites?",
+      message: prompt,
+      confirmLabel: sitesToDelete.length === 1 ? "Delete Site" : `Delete ${sitesToDelete.length} Sites`,
+      cancelLabel: "Cancel",
+      tone: "danger",
+      onConfirm: async () => {
+        setConfirmationState(null);
+
+        try {
+          setSitesStatus(`Deleting ${sitesToDelete.length} hosted ${sitesToDelete.length === 1 ? "site" : "sites"}...`);
+
+          const response = await fetch(`${apiBaseUrl}/v1/workspace/sites/batch-delete`, {
+            method: "POST",
+            headers: {
+              ...authHeaders(accessToken),
+              "Content-Type": "application/json"
+            },
+            body: JSON.stringify({
+              site_ids: sitesToDelete.map((site) => site.id)
+            })
+          });
+
+          if (!response.ok) {
+            const detail = response.headers.get("content-type")?.includes("application/json")
+              ? (await response.json()).detail
+              : `Hosted sites delete failed (${response.status}).`;
+            setSitesStatus(detail || `Hosted sites delete failed (${response.status}).`);
+            return;
+          }
+
+          const deletedIds = new Set(sitesToDelete.map((site) => site.id));
+          setSites((current) => current.filter((candidate) => !deletedIds.has(candidate.id)));
+          setSitesTotalCount((current) => (current === null ? null : Math.max(0, current - sitesToDelete.length)));
+          clearSiteSelection();
+          closeSiteModalImmediately();
+          setSitesStatus("Hosted sites ready.");
+        } catch (error) {
+          setSitesStatus(describeFetchFailure(error, "Hosted sites delete failed."));
+        }
+      }
+    });
+  }
+
+  // --- Render ---
+
+  return (
+    <section className="workspace-panel setup-panel users-page" aria-label="Setup Sites">
+      <div className="users-surface">
+        <div className="users-toolbar">
+          <div className="users-toolbar-top">
+            <nav className="users-breadcrumb" aria-label="Breadcrumb">
+              <span className="breadcrumb-segment">Setup</span>
+              <span className="breadcrumb-separator" aria-hidden="true">›</span>
+              <h2 className="breadcrumb-segment current" title="Manage workspace sites, inspect individual records, and export the current filtered view.">Sites</h2>
+            </nav>
+            <div className="toolbar-row wrap-toolbar users-toolbar-actions">
+              <button className="primary-button" type="button" onClick={() => openSiteModal("create")} disabled={!hostedWorkspaceReady}>Add Site</button>
+              <button className="ghost-button" type="button" onClick={() => selectedSite && openSiteModal("view", selectedSite)} disabled={!hostedWorkspaceReady || selectedSiteIds.length !== 1}>View</button>
+              <button className="ghost-button" type="button" onClick={() => selectedSite && openSiteModal("edit", selectedSite)} disabled={!hostedWorkspaceReady || selectedSiteIds.length !== 1}>Edit</button>
+              <button className="ghost-button" type="button" onClick={() => handleDeleteSite()} disabled={!hostedWorkspaceReady || !selectedSiteIds.length}>Delete</button>
+              <button className="ghost-button" type="button" onClick={() => setExportModalOpen(true)} disabled={!filteredSites.length}>Export CSV</button>
+              <button className="ghost-button" type="button" onClick={handleSitesRefresh} disabled={!hostedWorkspaceReady}>Refresh</button>
+            </div>
+          </div>
+          <div className="users-search-bar">
+            <label className="users-search-field" htmlFor="sites-search-input">
+              <span className="users-search-icon" aria-hidden="true"><Icon name="search" className="app-icon" /></span>
+              <input
+                id="sites-search-input"
+                className="text-input hero-search-input"
+                type="text"
+                placeholder="Search sites..."
+                value={sitesSearch}
+                disabled={!hostedWorkspaceReady}
+                onChange={(event) => setSitesSearch(event.target.value)}
+              />
+            </label>
+            <div className="toolbar-row users-search-actions">
+              <button className="ghost-button" type="button" onClick={() => { setSitesSearch(""); clearSiteSelection(); }}>Clear Search</button>
+              <button className="ghost-button" type="button" onClick={clearAllSiteFilters}>Clear All Filters</button>
+            </div>
+          </div>
+        </div>
+
+        <div className="users-table-scroll-area table-viewport" ref={sitesTableViewportRef} onScroll={(e) => setShowBackToTop(e.currentTarget.scrollTop > 120)}>
+          <div className="users-table-header" ref={headerRef} style={columnWidths ? { gridTemplateColumns: `36px ${columnWidths.map((w) => `${w}px`).join(" ")}`, minWidth: `${36 + columnWidths.reduce((a, b) => a + b, 0)}px` } : undefined}>
+            <div className="users-table-header-cell users-checkbox-cell">
+              <input
+                type="checkbox"
+                className="row-select-checkbox"
+                aria-label="Select all rows"
+                checked={filteredSites.length > 0 && selectedSiteIds.length === filteredSites.length}
+                ref={(el) => { if (el) el.indeterminate = selectedSiteIds.length > 0 && selectedSiteIds.length < filteredSites.length; }}
+                onChange={() => {
+                  if (selectedSiteIds.length === filteredSites.length) {
+                    setSelectedSiteIds([]);
+                    setSelectionAnchorSiteId(null);
+                    siteNavCursorRef.current = null;
+                  } else {
+                    setSelectedSiteIds(filteredSites.map((s) => s.id));
+                    setSelectionAnchorSiteId(filteredSites[0]?.id ?? null);
+                    siteNavCursorRef.current = filteredSites[filteredSites.length - 1]?.id ?? null;
+                  }
+                }}
+                disabled={!filteredSites.length}
+              />
+            </div>
+            {siteTableColumns.map((column, colIndex) => {
+              const sortDirection = sitesSort.column === column.key ? sitesSort.direction : null;
+              const filterValues = siteColumnFilters[column.key];
+              return (
+                <div key={column.key} className={`users-table-header-cell${selectedColumnKeys.has(column.key) ? " selected-column" : ""}`} onClick={(event) => {
+                  setSelectedSiteIds([]);
+                  setSelectionAnchorSiteId(null);
+
+                  const columnKeys = siteTableColumns.map((c) => c.key);
+                  let nextCols;
+                  if (event.shiftKey && selectedColumnKeys.size) {
+                    const lastKey = [...selectedColumnKeys].pop();
+                    const lastIdx = columnKeys.indexOf(lastKey);
+                    const curIdx = columnKeys.indexOf(column.key);
+                    const [start, end] = lastIdx < curIdx ? [lastIdx, curIdx] : [curIdx, lastIdx];
+                    nextCols = new Set(columnKeys.slice(start, end + 1));
+                  } else if (event.metaKey || event.ctrlKey) {
+                    nextCols = new Set(selectedColumnKeys);
+                    if (nextCols.has(column.key)) nextCols.delete(column.key); else nextCols.add(column.key);
+                  } else {
+                    nextCols = selectedColumnKeys.size === 1 && selectedColumnKeys.has(column.key) ? new Set() : new Set([column.key]);
+                  }
+                  setSelectedColumnKeys(nextCols);
+
+                  const next = new Set();
+                  for (const site of filteredSites) {
+                    for (const col of nextCols) {
+                      next.add(`${site.id}:${col}`);
+                    }
+                  }
+                  setSelectedCells(next);
+                  cellAnchorRef.current = null;
+                }} onContextMenu={(event) => { event.preventDefault(); openSiteHeaderOptions(event, column.key); }}>
+                  <span className="users-table-header-label">{column.label}</span>
+                  <button
+                    className={sortDirection || filterValues.length ? "table-sort-button active" : "table-sort-button"}
+                    type="button"
+                    aria-label={`${column.label} options`}
+                    onClick={(event) => { event.stopPropagation(); openSiteHeaderOptions(event, column.key); }}
+                  >
+                    <span className="table-sort-indicator" aria-hidden="true">
+                      {sortDirection === "asc"
+                        ? "↑"
+                        : sortDirection === "desc"
+                          ? "↓"
+                          : filterValues.length
+                            ? filterValues.length
+                            : <Icon name="filterMenu" className="app-icon table-filter-icon" />}
+                    </span>
+                  </button>
+
+                  {openSiteHeaderMenu?.key === column.key ? (
+                    <UserHeaderFilterMenu
+                        column={column}
+                        options={siteFilterOptions[column.key]}
+                        selectedValues={filterValues}
+                        sortDirection={sortDirection}
+                        onClearFilter={() => {
+                          setSiteColumnFilters((current) => ({ ...current, [column.key]: [] }));
+                          setOpenSiteHeaderMenu(null);
+                        }}
+                        onSortAsc={() => {
+                          setSitesSort({ column: column.key, direction: "asc" });
+                          setOpenSiteHeaderMenu(null);
+                        }}
+                        onSortDesc={() => {
+                          setSitesSort({ column: column.key, direction: "desc" });
+                          setOpenSiteHeaderMenu(null);
+                        }}
+                        onClearSort={() => {
+                          setSitesSort({ column: null, direction: "asc" });
+                          setOpenSiteHeaderMenu(null);
+                        }}
+                        onApplyFilter={(values) => {
+                          setSiteColumnFilters((current) => ({ ...current, [column.key]: values }));
+                        }}
+                      onClose={() => setOpenSiteHeaderMenu(null)}
+                      style={openSiteHeaderMenu}
+                    />
+                  ) : null}
+                  <div
+                    className="column-resize-handle"
+                    onMouseDown={(event) => handleColumnResizeStart(event, colIndex)}
+                    onDoubleClick={(event) => { event.stopPropagation(); handleColumnAutoFit(colIndex); }}
+                    onClick={(event) => event.stopPropagation()}
+                  />
+                </div>
+              );
+            })}
+          </div>
+
+          <table className="data-table users-data-table" style={columnWidths ? { tableLayout: "fixed" } : undefined}>
+            <colgroup>
+              <col style={{ width: "36px" }} />
+              {columnWidths
+                ? columnWidths.map((w, i) => <col key={i} style={{ width: `${w}px` }} />)
+                : <>
+                    <col style={{ width: "18%" }} />
+                    <col style={{ width: "22%" }} />
+                    <col style={{ width: "10%" }} />
+                    <col style={{ width: "12%" }} />
+                    <col style={{ width: "10%" }} />
+                    <col />
+                  </>
+              }
+            </colgroup>
+            <tbody>
+              {filteredSites.length ? filteredSites.map((site) => (
+                <tr
+                  key={site.id}
+                  className={selectedSiteIds.includes(site.id) ? "selected-row" : undefined}
+                  aria-selected={selectedSiteIds.includes(site.id)}
+                  onMouseDown={(event) => {
+                    if (event.shiftKey || event.metaKey || event.ctrlKey) {
+                      event.preventDefault();
+                    }
+                  }}
+                  onClick={(event) => handleSiteRowSelection(event, site.id)}
+                  onDoubleClick={() => openSiteModal("view", site)}
+                  onContextMenu={(event) => handleTableContextMenu(event, site)}
+                >
+                  <td className="row-checkbox-cell" onClick={(event) => event.stopPropagation()}>
+                    <input
+                      type="checkbox"
+                      className="row-select-checkbox"
+                      aria-label={`Select ${site.name}`}
+                      checked={selectedSiteIds.includes(site.id)}
+                      onChange={() => {
+                        setSelectedSiteIds((current) =>
+                          current.includes(site.id)
+                            ? current.filter((id) => id !== site.id)
+                            : [...current, site.id]
+                        );
+                        setSelectionAnchorSiteId(site.id);
+                      }}
+                    />
+                  </td>
+                  <td data-col="name" className={selectedCells.has(`${site.id}:name`) ? "selected-cell" : selectedColumnKeys.has("name") ? "selected-column-cell" : undefined} onClick={(event) => { if (handleCellClick(event, site.id, "name")) return; }}><HighlightMatch text={site.name} query={sitesSearch} /></td>
+                  <td data-col="url" className={selectedCells.has(`${site.id}:url`) ? "selected-cell" : selectedColumnKeys.has("url") ? "selected-column-cell" : undefined} onClick={(event) => { if (handleCellClick(event, site.id, "url")) return; }}><HighlightMatch text={site.url || ""} query={sitesSearch} /></td>
+                  <td data-col="sc_rate" className={selectedCells.has(`${site.id}:sc_rate`) ? "selected-cell" : selectedColumnKeys.has("sc_rate") ? "selected-column-cell" : undefined} onClick={(event) => { if (handleCellClick(event, site.id, "sc_rate")) return; }}>{site.sc_rate}</td>
+                  <td data-col="playthrough_requirement" className={selectedCells.has(`${site.id}:playthrough_requirement`) ? "selected-cell" : selectedColumnKeys.has("playthrough_requirement") ? "selected-column-cell" : undefined} onClick={(event) => { if (handleCellClick(event, site.id, "playthrough_requirement")) return; }}>{site.playthrough_requirement}</td>
+                  <td data-col="status" className={selectedCells.has(`${site.id}:status`) ? "selected-cell" : selectedColumnKeys.has("status") ? "selected-column-cell" : undefined} onClick={(event) => { if (handleCellClick(event, site.id, "status")) return; }}>
+                    <span className={site.is_active ? "status-chip active" : "status-chip inactive"}>
+                      {site.is_active ? "Active" : "Inactive"}
+                    </span>
+                  </td>
+                  <td data-col="notes" className={`notes-cell${selectedCells.has(`${site.id}:notes`) ? " selected-cell" : selectedColumnKeys.has("notes") ? " selected-column-cell" : ""}`} onClick={(event) => { if (handleCellClick(event, site.id, "notes")) return; }} title={(site.notes || "").length > 100 ? site.notes : undefined}><HighlightMatch text={(site.notes || "").slice(0, 100) || "-"} query={sitesSearch} /></td>
+                </tr>
+              )) : (
+                <tr>
+                  <td colSpan={siteTableColumns.length + 1} className="empty-state-cell">
+                    <div className="empty-state-graphic">
+                      <svg width="64" height="64" viewBox="0 0 64 64" fill="none" aria-hidden="true">
+                        <rect x="8" y="16" width="48" height="36" rx="4" stroke="rgba(255,255,255,0.12)" strokeWidth="1.5" />
+                        <line x1="8" y1="28" x2="56" y2="28" stroke="rgba(255,255,255,0.08)" strokeWidth="1" />
+                        <line x1="8" y1="38" x2="56" y2="38" stroke="rgba(255,255,255,0.06)" strokeWidth="1" />
+                        <line x1="28" y1="16" x2="28" y2="52" stroke="rgba(255,255,255,0.06)" strokeWidth="1" />
+                        <circle cx="32" cy="40" r="8" stroke="rgba(126,195,172,0.25)" strokeWidth="1.5" />
+                        <line x1="38" y1="46" x2="44" y2="52" stroke="rgba(126,195,172,0.25)" strokeWidth="1.5" strokeLinecap="round" />
+                      </svg>
+                      <p>{hostedWorkspaceReady
+                        ? (sitesSearch
+                          ? <>No results for &ldquo;{sitesSearch}&rdquo;. <button className="inline-link-button" type="button" onClick={() => { setSitesSearch(""); clearSiteSelection(); }}>Clear search</button></>
+                          : "No sites match the current view.")
+                        : "Connect the hosted workspace to load sites."
+                      }</p>
+                    </div>
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+
+        <div className="users-summary-rail users-summary-rail-bottom" aria-label="Site summary">
+          <div className="users-page-metrics">
+            <span className="users-metric-chip">{filteredSiteCount} shown</span>
+            <span className="users-metric-chip subdued">{totalSiteCount} total</span>
+            {selectedSiteIds.length ? <span className="users-metric-chip accent">{selectedSiteIds.length} selected</span> : null}
+            {sitesFiltersActive ? <span className="users-metric-chip subdued">Filtered view</span> : null}
+            {selectedCells.size ? (() => {
+              const cellValues = [];
+              for (const cellId of selectedCells) {
+                const [siteId, colKey] = cellId.split(":");
+                const site = filteredSites.find((s) => s.id === siteId);
+                if (site) cellValues.push(getCellDisplayValue(site, colKey));
+              }
+              const stats = computeCellStats(cellValues);
+              return (
+                <>
+                  <span className="users-metric-chip column-agg">Count: {stats.count}</span>
+                  {stats.numericCount > 0 ? (
+                    <>
+                      <span className="users-metric-chip column-agg">Sum: {stats.sum.toLocaleString(undefined, { minimumFractionDigits: 0, maximumFractionDigits: 2 })}</span>
+                      <span className="users-metric-chip column-agg">Avg: {stats.avg.toLocaleString(undefined, { minimumFractionDigits: 0, maximumFractionDigits: 2 })}</span>
+                      <span className="users-metric-chip column-agg">Min: {stats.min}</span>
+                      <span className="users-metric-chip column-agg">Max: {stats.max}</span>
+                    </>
+                  ) : null}
+                  {stats.numericCount === 0 ? <span className="users-metric-chip column-agg">{new Set(cellValues).size} unique</span> : null}
+                </>
+              );
+            })() : null}
+          </div>
+          <div className="users-summary-actions">
+            {sitesHasMore && !sitesFiltersActive ? (
+              <button className="ghost-button" type="button" onClick={loadNextSitesPage} disabled={sitesLoadingMore}>
+                {sitesLoadingMore ? "Loading..." : "Load More Sites"}
+              </button>
+            ) : null}
+          </div>
+        </div>
+
+        <button
+          className={`back-to-top-button${showBackToTop ? " visible" : ""}`}
+          type="button"
+          aria-label="Back to top"
+          onClick={() => {
+            const viewport = sitesTableViewportRef.current;
+            if (viewport) viewport.scrollTo({ top: 0, behavior: "smooth" });
+          }}
+        >
+          ↑
+        </button>
+      </div>
+
+      {contextMenu ? (
+        <TableContextMenu
+          position={{ x: contextMenu.x, y: contextMenu.y }}
+          items={contextMenu.items}
+          onClose={() => setContextMenu(null)}
+        />
+      ) : null}
+
+      {exportModalOpen ? (
+        <ExportModal
+          filteredUsers={filteredSites}
+          selectedUsers={selectedSites}
+          selectedCells={selectedCells}
+          allColumns={siteTableColumns}
+          onExport={(data, columns) => downloadSitesCsv(data, columns)}
+          onClose={() => setExportModalOpen(false)}
+        />
+      ) : null}
+
+      {confirmationState ? (
+        <ConfirmationModal
+          title={confirmationState.title}
+          message={confirmationState.message}
+          confirmLabel={confirmationState.confirmLabel}
+          cancelLabel={confirmationState.cancelLabel}
+          tone={confirmationState.tone}
+          onCancel={() => setConfirmationState(null)}
+          onConfirm={confirmationState.onConfirm}
+        />
+      ) : null}
+
+      {siteModalMode ? (
+        <SiteModal
+          mode={siteModalMode}
+          site={selectedSite}
+          form={siteForm}
+          setForm={setSiteForm}
+          submitError={siteSubmitError}
+          suggestions={siteSuggestions}
+          onClose={requestCloseSiteModal}
+          onRequestEdit={() => selectedSite && openSiteModal("edit", selectedSite)}
+          onRequestDelete={() => selectedSite && handleDeleteSite([selectedSite])}
+          onSubmit={submitSiteModal}
+        />
+      ) : null}
+    </section>
+  );
+}

--- a/web/src/components/SitesTab/SitesTab.jsx
+++ b/web/src/components/SitesTab/SitesTab.jsx
@@ -1081,7 +1081,7 @@ export default function SitesTab({ apiBaseUrl, hostedWorkspaceReady }) {
         </div>
 
         <div className="users-table-scroll-area table-viewport" ref={sitesTableViewportRef} onScroll={(e) => setShowBackToTop(e.currentTarget.scrollTop > 120)}>
-          <div className="users-table-header" ref={headerRef} style={columnWidths ? { gridTemplateColumns: `36px ${columnWidths.map((w) => `${w}px`).join(" ")}`, minWidth: `${36 + columnWidths.reduce((a, b) => a + b, 0)}px` } : undefined}>
+          <div className="users-table-header" ref={headerRef} style={columnWidths ? { gridTemplateColumns: `36px ${columnWidths.map((w) => `${w}px`).join(" ")}`, minWidth: `${36 + columnWidths.reduce((a, b) => a + b, 0)}px` } : { gridTemplateColumns: "36px 18% 22% 10% 12% 10% 1fr" }}>
             <div className="users-table-header-cell users-checkbox-cell">
               <input
                 type="checkbox"

--- a/web/src/components/SitesTab/sitesConstants.js
+++ b/web/src/components/SitesTab/sitesConstants.js
@@ -1,0 +1,29 @@
+export const initialSiteForm = {
+  name: "",
+  url: "",
+  sc_rate: "1",
+  playthrough_requirement: "1",
+  notes: "",
+  is_active: true
+};
+
+export const initialSiteColumnFilters = {
+  name: [],
+  url: [],
+  sc_rate: [],
+  playthrough_requirement: [],
+  status: [],
+  notes: []
+};
+
+export const siteTableColumns = [
+  { key: "name", label: "Name", sortable: true },
+  { key: "url", label: "URL", sortable: true },
+  { key: "sc_rate", label: "SC Rate", sortable: true },
+  { key: "playthrough_requirement", label: "Playthrough", sortable: true },
+  { key: "status", label: "Status", sortable: true },
+  { key: "notes", label: "Notes", sortable: true }
+];
+
+export const sitesPageSize = 100;
+export const sitesFallbackPageSize = 500;

--- a/web/src/components/SitesTab/sitesUtils.js
+++ b/web/src/components/SitesTab/sitesUtils.js
@@ -1,0 +1,189 @@
+import { siteTableColumns } from "./sitesConstants";
+
+export function normalizeSiteForm(form) {
+  return {
+    name: form.name || "",
+    url: form.url || "",
+    sc_rate: String(form.sc_rate ?? "1"),
+    playthrough_requirement: String(form.playthrough_requirement ?? "1"),
+    notes: form.notes || "",
+    is_active: Boolean(form.is_active)
+  };
+}
+
+export function isTextEntryElement(element) {
+  if (!(element instanceof HTMLElement)) {
+    return false;
+  }
+
+  if (element instanceof HTMLTextAreaElement) {
+    return !element.readOnly && !element.disabled;
+  }
+
+  if (element instanceof HTMLInputElement) {
+    const textLikeTypes = new Set(["text", "search", "email", "url", "tel", "password", "number"]);
+    return textLikeTypes.has(element.type) && !element.readOnly && !element.disabled;
+  }
+
+  return element.isContentEditable;
+}
+
+export function parseNumericValue(text) {
+  if (!text || typeof text !== "string") return null;
+  const trimmed = text.trim();
+  if (!trimmed || ["n/a", "na", "-", "\u2014", "\u2013"].includes(trimmed.toLowerCase())) return null;
+  let cleaned = trimmed.replace(/[$\u20ac\u00a3\u00a5,\s]/g, "");
+  if (cleaned.startsWith("(") && cleaned.endsWith(")")) cleaned = "-" + cleaned.slice(1, -1);
+  if (cleaned.endsWith("%")) cleaned = cleaned.slice(0, -1);
+  const num = Number(cleaned);
+  return Number.isFinite(num) ? num : null;
+}
+
+export function computeCellStats(values) {
+  const count = values.length;
+  const nums = values.map(parseNumericValue).filter((v) => v !== null);
+  if (!nums.length) return { count, numericCount: 0, sum: 0, avg: 0, min: null, max: null };
+  const sum = nums.reduce((a, b) => a + b, 0);
+  return {
+    count,
+    numericCount: nums.length,
+    sum,
+    avg: sum / nums.length,
+    min: Math.min(...nums),
+    max: Math.max(...nums)
+  };
+}
+
+export function getCellDisplayValue(site, columnKey) {
+  if (columnKey === "status") return site.is_active ? "Active" : "Inactive";
+  if (columnKey === "sc_rate") return String(site.sc_rate ?? "");
+  if (columnKey === "playthrough_requirement") return String(site.playthrough_requirement ?? "");
+  return String(site[columnKey] || "");
+}
+
+export function downloadSitesCsv(sites, columns) {
+  const activeColumns = columns || siteTableColumns;
+  const rows = [
+    activeColumns.map((c) => c.label),
+    ...sites.map((site) => activeColumns.map((c) => getCellDisplayValue(site, c.key)))
+  ];
+  const csv = rows
+    .map((row) => row.map((value) => `"${String(value).replaceAll('"', '""')}"`).join(","))
+    .join("\n");
+  const blob = new Blob([csv], { type: "text/csv;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = `sites_${new Date().toISOString().slice(0, 10)}.csv`;
+  link.click();
+  URL.revokeObjectURL(url);
+}
+
+export function getSiteColumnValue(site, columnKey) {
+  if (columnKey === "status") {
+    return site.is_active ? "Active" : "Inactive";
+  }
+  if (columnKey === "sc_rate") return String(site.sc_rate ?? "");
+  if (columnKey === "playthrough_requirement") return String(site.playthrough_requirement ?? "");
+  return String(site[columnKey] || "");
+}
+
+export function buildSiteFilterOptions(sites, columnKey) {
+  const values = [...new Set(sites.map((site) => getSiteColumnValue(site, columnKey)))].sort((left, right) => left.localeCompare(right, undefined, { sensitivity: "base" }));
+
+  return values.map((value) => ({
+    value,
+    label: value || "(Blank)",
+    path: [value || "(Blank)"],
+    searchValue: value
+  }));
+}
+
+export function collectLeafValues(nodes) {
+  return nodes.flatMap((node) => (node.children?.length ? collectLeafValues(node.children) : [node.value]));
+}
+
+export function buildFilterTree(options) {
+  const tree = [];
+
+  options.forEach((option) => {
+    let currentLevel = tree;
+    option.path.forEach((segment, index) => {
+      const isLeaf = index === option.path.length - 1;
+      const nodeId = isLeaf
+        ? `leaf:${option.value}`
+        : `group:${option.path.slice(0, index + 1).join("/")}`;
+      let node = currentLevel.find((entry) => entry.id === nodeId);
+
+      if (!node) {
+        node = {
+          id: nodeId,
+          label: isLeaf ? option.label : segment,
+          value: isLeaf ? option.value : null,
+          children: []
+        };
+        currentLevel.push(node);
+      }
+
+      currentLevel = node.children;
+    });
+  });
+
+  return tree;
+}
+
+export function mergeSitesById(existingSites, incomingSites) {
+  const nextSites = [...existingSites];
+  const existingIds = new Set(existingSites.map((site) => site.id));
+
+  incomingSites.forEach((site) => {
+    if (existingIds.has(site.id)) {
+      const existingIndex = nextSites.findIndex((candidate) => candidate.id === site.id);
+      nextSites[existingIndex] = site;
+      return;
+    }
+    nextSites.push(site);
+  });
+
+  return nextSites.sort((left, right) => left.name.localeCompare(right.name, undefined, { sensitivity: "base" }));
+}
+
+export function filterTreeNodes(nodes, searchText) {
+  if (!searchText) {
+    return nodes;
+  }
+
+  const normalizedSearch = searchText.trim().toLowerCase();
+
+  return nodes.flatMap((node) => {
+    if (!node.children.length) {
+      return node.label.toLowerCase().includes(normalizedSearch) ? [node] : [];
+    }
+
+    const filteredChildren = filterTreeNodes(node.children, normalizedSearch);
+    if (node.label.toLowerCase().includes(normalizedSearch) || filteredChildren.length) {
+      return [{ ...node, children: filteredChildren }];
+    }
+
+    return [];
+  });
+}
+
+export function getNodeSelectionState(node, selectedValues) {
+  if (!node.children.length) {
+    return selectedValues.has(node.value) ? "checked" : "unchecked";
+  }
+
+  const descendantValues = collectLeafValues(node.children);
+  const selectedCount = descendantValues.filter((value) => selectedValues.has(value)).length;
+
+  if (!selectedCount) {
+    return "unchecked";
+  }
+
+  if (selectedCount === descendantValues.length) {
+    return "checked";
+  }
+
+  return "mixed";
+}


### PR DESCRIPTION
## Summary

Ports Setup > Sites CRUD to the hosted web app, matching the existing Users pattern end-to-end.

Also fixes a critical FK cascade bug in the desktop schema migration that was silently nulling `redemption_method_id` on all redemptions.

Closes #242

## Changes

### Backend
- **Model**: Added `HostedSite` dataclass to `services/hosted/models.py` with validation (name required, sc_rate >= 0, playthrough_requirement >= 0)
- **Repository**: New `repositories/hosted_site_repository.py` -- full CRUD (list, count, create, update, delete, delete_many)
- **Service**: New `services/hosted/workspace_site_service.py` -- business logic with workspace isolation
- **API**: 5 new endpoints in `api/app.py`:
  - `GET /v1/workspace/sites` (paginated list)
  - `POST /v1/workspace/sites` (create)
  - `PATCH /v1/workspace/sites/{site_id}` (update)
  - `DELETE /v1/workspace/sites/{site_id}` (delete, 204)
  - `POST /v1/workspace/sites/batch-delete` (bulk delete)

### Frontend
- **SitesTab**: New component set (`SitesTab.jsx`, `SiteModal.jsx`, `sitesConstants.js`, `sitesUtils.js`)
- **AppShell**: Sites tab enabled, renders SitesTab when selected
- Reuses generic components from UsersTab (ExportModal, TableContextMenu, UserHeaderFilterMenu, FilterTreeNode)
- 6-column table: Name, URL, SC Rate, Playthrough, Status, Notes
- Full feature parity with Users: search, sort, column filters, cell/row/column selection, keyboard navigation, resize, context menus, export CSV, infinite scroll pagination

### Bugfix: FK cascade migration
- `_migrate_user_fk_cascade()` and `_migrate_redemption_methods_table()` in `repositories/database.py` ran `DROP TABLE` with `PRAGMA foreign_keys=ON`, triggering `ON DELETE SET NULL` on `redemptions.redemption_method_id` and silently nulling 288 method assignments
- Fixed by wrapping all table-rebuild migrations with `PRAGMA foreign_keys=OFF/ON`
- Affected data restored from the 3/30 auto-backup

### Documentation
- Added DRY/reusability design principles to `docs/PROJECT_SPEC.md`, `.github/copilot-instructions.md`, and `AGENTS.md`
- Changelog entries for Sites CRUD and FK migration fix

### Tests
- 12 API tests (`tests/api/test_workspace_sites.py`): all CRUD + auth + error cases
- 13 service integration tests (`tests/services/hosted/test_workspace_site_service.py`): happy path, edge cases, cross-workspace isolation, atomic batch delete
- 19 existing web tests pass with no regressions
- 1195 backend tests pass (1 pre-existing unrelated UI autocomplete failure)

## Test Matrix

| Category | Test | Status |
|----------|------|--------|
| Happy path | Create site with full fields | PASS |
| Happy path | List sites (paginated) | PASS |
| Happy path | Update all fields | PASS |
| Happy path | Delete single + batch | PASS |
| Edge case | Reject blank name | PASS |
| Edge case | Reject negative sc_rate | PASS |
| Edge case | Reject negative playthrough | PASS |
| Edge case | Cross-workspace isolation | PASS |
| Failure injection | Batch delete with invalid ID (atomic rollback) | PASS |
| Invariant | Only workspace-scoped sites affected | PASS |

## Pitfalls / Follow-ups

- ExportModal imports `userTableColumns` but only uses `allColumns` prop -- works fine but the dead import could be cleaned up in a shared-components refactor
- UserHeaderFilterMenu / FilterTreeNode names are user-specific but the components are generic -- consider renaming to shared names in a future refactor (tracked in design principles)
- SiteModal does not yet have a "seed demo sites" dev tool (Users has one) -- could add if useful
- Sites with URLs could eventually support click-to-open behavior in the table
- URL-based routing for tab navigation tracked as Issue #244
