### PR TITLE
feat: Add URL-based routing with React Router (#244)

### DIFF
--- a/docs/PROJECT_SPEC.md
+++ b/docs/PROJECT_SPEC.md
@@ -162,7 +162,7 @@ Hosted backend foundation (Issue #203):
 - The first protected hosted API endpoint is `GET /v1/session`.
 - `GET /v1/session` must require a bearer token, verify the Supabase access token against Supabase JWKS, and return the authenticated session identity summary.
 - After successful Google sign-in, the web shell should call `GET /v1/session` with the Supabase access token and reflect the protected API handshake status in the UI.
-- When Google sign-in is initiated from a staged hash-routed page such as `/#/migration`, the OAuth redirect target must preserve that current URL so the browser returns to the same page after authentication.
+- When Google sign-in is initiated from a routed page such as `/migration`, the OAuth return route must be preserved locally (via sessionStorage) so the app restores the same page after authentication.
 - The first hosted persistence slice after auth is `POST /v1/account/bootstrap`.
 - `POST /v1/account/bootstrap` must require a bearer token and idempotently create or return the hosted account/workspace records for the authenticated Supabase user.
 - Hosted account identity is keyed by Supabase user id and tracks the owner email plus auth provider separately from the legacy SQLite business-domain `users` table.
@@ -188,7 +188,7 @@ Hosted backend foundation (Issue #203):
 - Deleting a hosted workspace user must require explicit user intent in the UI and must reject cross-workspace access.
 - After hosted bootstrap succeeds, the signed-in web app should transition from the temporary marketing shell into a real hosted application shell with Setup navigation.
 - After Google sign-in succeeds, the hosted web app should keep the signed-in application shell visible even if the protected API handshake or hosted bootstrap cannot be reached, and it should expose retryable status instead of hiding Setup behind a successful bootstrap.
-- Because Supabase OAuth redirect allow-list validation may reject hash-routed URLs, the hosted web app must preserve hash-route return targets locally and use an allowlist-safe origin redirect for Google sign-in.
+- Because Supabase OAuth redirect allow-list validation may reject non-origin URLs, the hosted web app must preserve return route targets locally (via sessionStorage) and use an allowlist-safe origin redirect for Google sign-in.
 - The first real hosted app shell slice is `Setup -> Users`, and it should preserve desktop-style behaviors where practical: search, refresh, CSV export, add/view/edit/delete workflows, visible active/inactive state, and highlighted validation for required fields.
 - The hosted web shell should follow the desktop information architecture where practical: primary sections presented as top-level tabs, with Setup sub-tabs rendered beneath the active primary section rather than in a permanent left navigation rail.
 - Hosted account ownership, workspace metadata, sign-out, and migration-entry actions should be accessible through compact account/settings utilities instead of large always-visible header blocks.
@@ -211,8 +211,8 @@ Hosted backend foundation (Issue #203):
 - `POST /v1/workspace/import-upload-plan` must require a bearer token and accept a browser-uploaded SQLite file as multipart form data for read-only inspection.
 - The upload-planning endpoint must write the uploaded file to a temporary location only long enough to inspect it, return a read-only inventory summary, and delete the temporary file afterward.
 - Invalid, empty, or unreadable uploads must fail safely with an actionable `400` response and must not create hosted business-domain records.
-- The staged web frontend may expose this as a temporary authenticated migration page, but on static hosting without SPA rewrites it should use a hash route such as `/#/migration` rather than relying on a direct server path.
-- Hash-routed staged pages must react to hash changes client-side rather than only reading the route once at initial page load.
+- The staged web frontend may expose this as a temporary authenticated migration page at `/migration` using React Router pathname-based routing.
+- Client-side routing uses React Router v6 (BrowserRouter) with pathname-based routes; the Vite dev server and production deployment must support SPA history-API fallback.
 - The hosted API must permit CORS preflight and authenticated browser requests from `https://dev.sezzions.com` and `http://localhost:5173` by default, with environment override support for additional origins.
 - If direct local JWT decoding is not compatible with the live Supabase token format, the API may validate the bearer token through Supabase's `/auth/v1/user` endpoint before returning `401`.
 - The `/auth/v1/user` validation fallback must include a Supabase publishable/anon key, either from hosted backend configuration or from the web client's protected handshake request.

--- a/docs/status/CHANGELOG.md
+++ b/docs/status/CHANGELOG.md
@@ -12,6 +12,33 @@ Rules:
 ## 2026-03-31
 
 ```yaml
+id: 2026-03-31-03
+type: feature
+areas: [web]
+issue: "#244"
+summary: "Add URL-based routing with React Router for Setup tabs"
+details: >
+  Replaced hash-based routing (/#/migration, manual hashchange listeners)
+  with React Router v6 (BrowserRouter, Routes, useParams, useNavigate, Link).
+  Setup tabs are now at /setup/:tabKey, migration at /migration. useAuth uses
+  React Router's useLocation() for OAuth return route persistence instead of
+  reading window.location directly. Vite dev server configured with SPA
+  historyApiFallback. All 19 tests updated to use MemoryRouter wrapper.
+
+files_changed:
+  - web/src/main.jsx
+  - web/src/App.jsx
+  - web/src/App.test.jsx
+  - web/src/components/AppShell.jsx
+  - web/src/components/MarketingShell.jsx
+  - web/src/components/MigrationShell.jsx
+  - web/src/hooks/useAuth.js
+  - web/src/services/routing.js
+  - web/vite.config.js
+  - web/package.json
+```
+
+```yaml
 id: 2026-03-31-02
 type: bugfix
 areas: [backend, database]

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "@supabase/supabase-js": "^2.100.1",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "react-router-dom": "^7.13.2"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.6.3",
@@ -1796,6 +1797,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/css.escape": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
@@ -2391,6 +2405,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.13.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.2.tgz",
+      "integrity": "sha512-tX1Aee+ArlKQP+NIUd7SE6Li+CiGKwQtbS+FfRxPX6Pe4vHOo6nr9d++u5cwg+Z8K/x8tP+7qLmujDtfrAoUJA==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.13.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.13.2.tgz",
+      "integrity": "sha512-aR7SUORwTqAW0JDeiWF07e9SBE9qGpByR9I8kJT5h/FrBKxPMS6TiC7rmVO+gC0q52Bx7JnjWe8Z1sR9faN4YA==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.13.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -2495,6 +2547,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/siginfo": {
       "version": "2.0.0",

--- a/web/package.json
+++ b/web/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "@supabase/supabase-js": "^2.100.1",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^7.13.2"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.6.3",

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -1,38 +1,26 @@
-import { useEffect, useState } from "react";
+import { Navigate, Route, Routes } from "react-router-dom";
 
 import { useAuth } from "./hooks/useAuth";
-import { readCurrentRoute } from "./services/routing";
 import AppShell from "./components/AppShell";
 import MarketingShell from "./components/MarketingShell";
 import MigrationShell from "./components/MigrationShell";
 import "./styles.css";
 
 export default function App() {
-  const [currentRoute, setCurrentRoute] = useState(() => readCurrentRoute());
   const auth = useAuth();
 
-  useEffect(() => {
-    function syncRoute() {
-      setCurrentRoute(readCurrentRoute());
-    }
-
-    window.addEventListener("hashchange", syncRoute);
-    window.addEventListener("popstate", syncRoute);
-    return () => {
-      window.removeEventListener("hashchange", syncRoute);
-      window.removeEventListener("popstate", syncRoute);
-    };
-  }, []);
-
-  const isMigrationPage = currentRoute === "/migration";
-
-  if (isMigrationPage) {
-    return <MigrationShell auth={auth} />;
-  }
-
-  if (!auth.sessionEmail) {
-    return <MarketingShell auth={auth} />;
-  }
-
-  return <AppShell auth={auth} />;
+  return (
+    <Routes>
+      <Route path="/migration" element={<MigrationShell auth={auth} />} />
+      <Route
+        path="/setup/:tabKey"
+        element={auth.sessionEmail ? <AppShell auth={auth} /> : <MarketingShell auth={auth} />}
+      />
+      <Route
+        path="/"
+        element={auth.sessionEmail ? <Navigate to="/setup/users" replace /> : <MarketingShell auth={auth} />}
+      />
+      <Route path="*" element={<Navigate to="/" replace />} />
+    </Routes>
+  );
 }

--- a/web/src/App.test.jsx
+++ b/web/src/App.test.jsx
@@ -1,5 +1,6 @@
 import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
 
 import App from "./App";
 
@@ -36,6 +37,14 @@ vi.mock("./lib/supabaseClient", () => ({
 }));
 
 describe("App", () => {
+  function renderApp(initialRoute = "/") {
+    return render(
+      <MemoryRouter initialEntries={[initialRoute]}>
+        <App />
+      </MemoryRouter>
+    );
+  }
+
   afterEach(() => {
     cleanup();
     window.sessionStorage.clear();
@@ -43,7 +52,6 @@ describe("App", () => {
   });
 
   beforeEach(() => {
-    window.history.pushState({}, "", "/#/");
     window.sessionStorage.clear();
     vi.stubEnv("VITE_API_BASE_URL", "https://api.sezzions.test");
     vi.stubEnv("VITE_SUPABASE_ANON_KEY", "");
@@ -141,7 +149,7 @@ describe("App", () => {
   }
 
   it("shows the Sezzions web heading", async () => {
-    render(<App />);
+    renderApp();
 
     expect(
       screen.getByRole("heading", { name: /sezzions for the web/i })
@@ -155,7 +163,7 @@ describe("App", () => {
   });
 
   it("starts Google sign-in when the button is clicked", async () => {
-    render(<App />);
+    renderApp();
 
     fireEvent.click(screen.getAllByRole("button", { name: /continue with google/i })[0]);
 
@@ -170,10 +178,8 @@ describe("App", () => {
     expect(window.sessionStorage.getItem("sezzions.oauthReturnRoute")).toBe("/");
   });
 
-  it("preserves a hash-routed return target before Google sign-in", async () => {
-    window.history.pushState({}, "", "/#/migration");
-
-    render(<App />);
+  it("preserves a return target before Google sign-in", async () => {
+    renderApp("/migration");
 
     fireEvent.click(screen.getByRole("button", { name: /continue with google/i }));
 
@@ -201,7 +207,7 @@ describe("App", () => {
       error: null
     });
 
-    render(<App />);
+    renderApp();
 
     expect(await screen.findByRole("heading", { name: /sezzions - sweepstakes session tracker/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /open my account/i })).toBeInTheDocument();
@@ -298,7 +304,7 @@ describe("App", () => {
         })
       });
 
-    render(<App />);
+    renderApp();
 
     await waitFor(() => {
       expect(global.fetch).toHaveBeenNthCalledWith(
@@ -373,7 +379,7 @@ describe("App", () => {
       })
       .mockRejectedValueOnce(new TypeError("Failed to fetch"));
 
-    render(<App />);
+    renderApp();
 
     expect(await screen.findByRole("heading", { name: /sezzions - sweepstakes session tracker/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /open my account/i })).toHaveAttribute("title", "owner@sezzions.com");
@@ -397,7 +403,7 @@ describe("App", () => {
       error: null
     });
 
-    render(<App />);
+    renderApp();
 
     fireEvent.click(await screen.findByRole("button", { name: /open settings/i }));
     const dialog = await screen.findByRole("dialog", { name: /settings/i });
@@ -481,7 +487,7 @@ describe("App", () => {
           ])
       });
 
-    render(<App />);
+    renderApp();
 
     const elliotCell = await findUserCell("Elliot");
     fireEvent.doubleClick(elliotCell);
@@ -569,7 +575,7 @@ describe("App", () => {
         })
       });
 
-    render(<App />);
+    renderApp();
 
     fireEvent.click(await screen.findByRole("button", { name: /add user/i }));
     const createDialog = await screen.findByRole("dialog", { name: /add user/i });
@@ -687,7 +693,7 @@ describe("App", () => {
         })
       });
 
-    render(<App />);
+    renderApp();
 
     const elliotCell = await findUserCell("Elliot");
     fireEvent.click(elliotCell);
@@ -801,7 +807,7 @@ describe("App", () => {
         text: async () => ""
       });
 
-    render(<App />);
+    renderApp();
 
     const elliotCell = await findUserCell("Elliot");
     fireEvent.click(elliotCell);
@@ -902,7 +908,7 @@ describe("App", () => {
         ])
       });
 
-    render(<App />);
+    renderApp();
 
     await findUserCell("Elliot");
     fireEvent.click(screen.getByRole("button", { name: /add user/i }));
@@ -1007,7 +1013,7 @@ describe("App", () => {
         ])
       });
 
-    render(<App />);
+    renderApp();
 
     await findUserCell("Zelda");
     fireEvent.click(screen.getByRole("button", { name: /status options/i }));
@@ -1110,7 +1116,7 @@ describe("App", () => {
           ])
       });
 
-    render(<App />);
+    renderApp();
 
     await findUserCell("Zelda");
 
@@ -1214,7 +1220,7 @@ describe("App", () => {
       throw new Error(`Unexpected fetch ${normalizedUrl} ${options?.method || "GET"}`);
     });
 
-    render(<App />);
+    renderApp();
 
     expect(await findUserCell("Alpha")).toBeInTheDocument();
     expect(within(await screen.findByRole("table")).queryByText("Beta")).not.toBeInTheDocument();
@@ -1321,7 +1327,7 @@ describe("App", () => {
         })
       });
 
-    render(<App />);
+    renderApp();
 
     expect(await findUserCell("User 001")).toBeInTheDocument();
     expect(screen.getByText("100 shown")).toBeInTheDocument();
@@ -1404,7 +1410,7 @@ describe("App", () => {
         })
       });
 
-    render(<App />);
+    renderApp();
 
     expect(await findUserCell("User 001")).toBeInTheDocument();
     expect(screen.getByText("100 shown")).toBeInTheDocument();
@@ -1507,7 +1513,7 @@ describe("App", () => {
         })
       });
 
-    render(<App />);
+    renderApp();
 
     expect(await findUserCell("User 001")).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: /load more users/i }));
@@ -1526,7 +1532,6 @@ describe("App", () => {
   });
 
   it("uploads a sqlite file from the migration page and renders the inventory summary", async () => {
-    window.history.pushState({}, "", "/#/migration");
     authMocks.getSession.mockResolvedValue({
       data: {
         session: {
@@ -1605,7 +1610,7 @@ describe("App", () => {
         })
       });
 
-    render(<App />);
+    renderApp("/migration");
 
     const uploadInput = await screen.findByLabelText(/sqlite database file/i);
     const file = new File(["sqlite"], "sezzions.db", { type: "application/octet-stream" });

--- a/web/src/components/AppShell.jsx
+++ b/web/src/components/AppShell.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { Link, useNavigate, useParams } from "react-router-dom";
 
 import Icon from "./common/Icon";
 import StatusModal from "./common/StatusModal";
@@ -19,10 +20,15 @@ const setupTabs = [
   { key: "tools", label: "Tools", icon: "tools", enabled: false }
 ];
 
+const validTabKeys = new Set(setupTabs.map((t) => t.key));
+
 export default function AppShell({ auth }) {
+  const { tabKey } = useParams();
+  const navigate = useNavigate();
+  const setupTab = validTabKeys.has(tabKey) ? tabKey : "users";
+
   const [railCollapsed, setRailCollapsed] = useState(false);
   const [setupNavOpen, setSetupNavOpen] = useState(false);
-  const [setupTab, setSetupTab] = useState("users");
   const [notificationsModalOpen, setNotificationsModalOpen] = useState(false);
   const [settingsModalOpen, setSettingsModalOpen] = useState(false);
   const [accountModalOpen, setAccountModalOpen] = useState(false);
@@ -156,7 +162,7 @@ export default function AppShell({ auth }) {
                   aria-label={tab.label}
                   title={tab.label}
                   disabled={!tab.enabled}
-                  onClick={() => setSetupTab(tab.key)}
+                  onClick={() => navigate(`/setup/${tab.key}`)}
                 >
                   <span className="rail-nav-main">
                     <span className="rail-item-icon" aria-hidden="true"><Icon name={tab.icon} className="app-icon" /></span>
@@ -172,11 +178,11 @@ export default function AppShell({ auth }) {
         <div className="rail-footer-group">
           <div className="rail-footer">
             {railCollapsed ? (
-              <a className="header-utility-button rail-footer-icon" href="/#/migration" aria-label="Open migration upload" title="Migration Upload">
+              <Link className="header-utility-button rail-footer-icon" to="/migration" aria-label="Open migration upload" title="Migration Upload">
                 <span aria-hidden="true"><Icon name="upload" className="app-icon" /></span>
-              </a>
+              </Link>
             ) : (
-              <a className="ghost-button full-width" href="/#/migration">Migration Upload</a>
+              <Link className="ghost-button full-width" to="/migration">Migration Upload</Link>
             )}
           </div>
         </div>

--- a/web/src/components/MarketingShell.jsx
+++ b/web/src/components/MarketingShell.jsx
@@ -1,3 +1,5 @@
+import { Link } from "react-router-dom";
+
 export default function MarketingShell({ auth }) {
   return (
     <div className="marketing-shell">
@@ -10,7 +12,7 @@ export default function MarketingShell({ auth }) {
           </p>
           <div className="toolbar-row">
             <button className="primary-button" type="button" onClick={auth.handleGoogleSignIn}>Continue With Google</button>
-            <a className="ghost-button" href="/#/migration">Open Migration Upload</a>
+            <Link className="ghost-button" to="/migration">Open Migration Upload</Link>
           </div>
         </div>
 

--- a/web/src/components/MigrationShell.jsx
+++ b/web/src/components/MigrationShell.jsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { Link } from "react-router-dom";
 
 import { authHeaders, describeFetchFailure, getAccessToken } from "../services/api";
 
@@ -66,7 +67,7 @@ export default function MigrationShell({ auth }) {
           </p>
         </div>
         <div className="migration-actions">
-          <a className="ghost-button" href="/#/">Back to Hosted App</a>
+          <Link className="ghost-button" to="/">Back to Hosted App</Link>
           {auth.sessionEmail ? (
             <button className="ghost-button" type="button" onClick={auth.handleSignOut}>Sign Out</button>
           ) : (

--- a/web/src/hooks/useAuth.js
+++ b/web/src/hooks/useAuth.js
@@ -1,10 +1,12 @@
 import { useEffect, useMemo, useState } from "react";
+import { useLocation } from "react-router-dom";
 
 import { supabase, supabaseConfigError, supabaseConfigured } from "../lib/supabaseClient";
 import { authHeaders, classifyStatusTone, describeFetchFailure } from "../services/api";
-import { applyRoute, consumeOAuthReturnRoute, readCurrentRoute, rememberOAuthReturnRoute } from "../services/routing";
+import { applyRoute, consumeOAuthReturnRoute, rememberOAuthReturnRoute } from "../services/routing";
 
 export function useAuth() {
+  const location = useLocation();
   const apiBaseUrl = import.meta.env.VITE_API_BASE_URL?.trim() || null;
 
   const [sessionEmail, setSessionEmail] = useState(null);
@@ -206,7 +208,7 @@ export function useAuth() {
       const email = data.session?.user?.email || null;
       if (data.session?.access_token) {
         const pendingRoute = consumeOAuthReturnRoute();
-        if (pendingRoute && pendingRoute !== readCurrentRoute()) {
+        if (pendingRoute && pendingRoute !== location.pathname) {
           applyRoute(pendingRoute);
         }
       }
@@ -225,7 +227,7 @@ export function useAuth() {
       const email = nextSession?.user?.email || null;
       if (nextSession?.access_token) {
         const pendingRoute = consumeOAuthReturnRoute();
-        if (pendingRoute && pendingRoute !== readCurrentRoute()) {
+        if (pendingRoute && pendingRoute !== location.pathname) {
           applyRoute(pendingRoute);
         }
       }
@@ -252,7 +254,7 @@ export function useAuth() {
       return;
     }
 
-    rememberOAuthReturnRoute(readCurrentRoute());
+    rememberOAuthReturnRoute(location.pathname);
 
     const { error } = await supabase.auth.signInWithOAuth({
       provider: "google",

--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -1,10 +1,13 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
+import { BrowserRouter } from "react-router-dom";
 
 import App from "./App";
 
 ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </React.StrictMode>
 );

--- a/web/src/services/routing.js
+++ b/web/src/services/routing.js
@@ -1,9 +1,8 @@
 export const oauthReturnRouteStorageKey = "sezzions.oauthReturnRoute";
 
 export function readCurrentRoute() {
-  const hashRoute = window.location.hash.replace(/^#/, "").replace(/\/+$/, "") || "";
-  const pathRoute = window.location.pathname.replace(/\/+$/, "") || "/";
-  return hashRoute || pathRoute;
+  const pathname = window.location.pathname.replace(/\/+$/, "") || "/";
+  return pathname;
 }
 
 export function rememberOAuthReturnRoute(route) {
@@ -29,8 +28,8 @@ export function applyRoute(route) {
     return;
   }
   const normalizedRoute = route === "/" ? "/" : route.replace(/\/+$/, "");
-  const nextHash = normalizedRoute === "/" ? "#/" : `#${normalizedRoute}`;
-  if (window.location.hash !== nextHash) {
-    window.location.hash = nextHash;
+  if (window.location.pathname !== normalizedRoute) {
+    window.history.replaceState(null, "", normalizedRoute);
+    window.dispatchEvent(new PopStateEvent("popstate"));
   }
 }

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -3,6 +3,9 @@ import react from "@vitejs/plugin-react";
 
 export default defineConfig({
   plugins: [react()],
+  server: {
+    historyApiFallback: true
+  },
   test: {
     environment: "jsdom",
     setupFiles: "./src/test/setup.js"


### PR DESCRIPTION
Closes #244

## Summary

Replace hash-based routing (`/#/migration`, `hashchange` listeners) with React Router v6 pathname-based routing.

## Changes

### Routing infrastructure
- Installed `react-router-dom` v6
- Wrapped `<App>` in `<BrowserRouter>` in `main.jsx`
- Replaced manual hash routing in `App.jsx` with `<Routes>` / `<Route>` components
- Routes: `/setup/:tabKey` (Setup tabs), `/migration` (migration page), `/` (redirect), `*` (catch-all)

### Component updates
- `AppShell.jsx`: `useParams()` for `tabKey`, `useNavigate()` for tab clicks, `<Link>` for migration
- `MarketingShell.jsx`: `<Link to="/migration">` replaces `<a href="/#/migration">`
- `MigrationShell.jsx`: `<Link to="/">` replaces `<a href="/#/">`

### Auth integration
- `useAuth.js`: Uses React Router's `useLocation()` for OAuth return route persistence instead of `window.location.pathname`
- Removed `readCurrentRoute()` dependency from useAuth

### Dev/build
- `vite.config.js`: Added `server: { historyApiFallback: true }` for SPA fallback
- `routing.js`: Simplified to pathname-based (`readCurrentRoute` reads `pathname`, `applyRoute` uses `replaceState`)

### Tests
- All 19 tests updated with `MemoryRouter` wrapper via `renderApp()` helper
- Migration-specific tests use `renderApp("/migration")` for route context
- Renamed "hash-routed return target" test to "return target" (no longer hash-specific)

## Test matrix

- **Happy paths**: Landing page renders, Google sign-in works, Setup tabs navigate, migration page loads
- **Edge cases**: Invalid tab key falls back to "users", catch-all route redirects to `/`
- **Failure injection**: Bootstrap fetch fails but shell stays visible
- **Invariants**: OAuth return route preserved in sessionStorage, auth state unchanged across route changes

## Verification

- `npx vitest run`: 19/19 pass
- `npx vite build`: clean production build (106 modules, 473KB JS)

## Pitfalls / Follow-ups

- **Production SPA fallback**: Render (or other hosting) needs `_redirects` or equivalent fallback rule so `/setup/users` doesn't 404 on direct load. This is a deploy config concern, not a code issue.
- **`readCurrentRoute()` in routing.js**: Still exported but no longer imported anywhere. Could be removed in a cleanup pass.
