### PR TITLE
feat(cards): port Cards CRUD to hosted web app

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -13,6 +13,7 @@ from services.hosted.persistence import get_hosted_session_factory
 from services.hosted.uploaded_sqlite_inspection_service import (
     HostedUploadedSQLiteInspectionService,
 )
+from services.hosted.workspace_card_service import HostedWorkspaceCardService
 from services.hosted.workspace_site_service import HostedWorkspaceSiteService
 from services.hosted.workspace_user_service import HostedWorkspaceUserService
 from services.hosted.workspace_import_planning_service import (
@@ -59,6 +60,28 @@ class HostedWorkspaceSiteUpdateRequest(BaseModel):
 
 class HostedWorkspaceSiteBatchDeleteRequest(BaseModel):
     site_ids: list[str]
+
+
+class HostedWorkspaceCardCreateRequest(BaseModel):
+    name: str
+    user_id: str
+    last_four: str | None = None
+    cashback_rate: float = 0.0
+    notes: str | None = None
+
+
+class HostedWorkspaceCardUpdateRequest(BaseModel):
+    name: str
+    user_id: str
+    last_four: str | None = None
+    cashback_rate: float = 0.0
+    notes: str | None = None
+    is_active: bool = True
+
+
+class HostedWorkspaceCardBatchDeleteRequest(BaseModel):
+    card_ids: list[str]
+
 
 cors_config = load_hosted_backend_config(required=False, require_db_password=False)
 app.add_middleware(
@@ -111,6 +134,16 @@ def get_hosted_workspace_site_service() -> HostedWorkspaceSiteService:
 
     session_factory = get_hosted_session_factory(config.sqlalchemy_url)
     return HostedWorkspaceSiteService(session_factory)
+
+
+def get_hosted_workspace_card_service() -> HostedWorkspaceCardService:
+    try:
+        config = load_hosted_backend_config(require_db_password=True)
+    except HostedConfigurationError as exc:
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(exc)) from exc
+
+    session_factory = get_hosted_session_factory(config.sqlalchemy_url)
+    return HostedWorkspaceCardService(session_factory)
 
 
 def get_hosted_uploaded_sqlite_inspection_service() -> HostedUploadedSQLiteInspectionService:
@@ -371,6 +404,119 @@ def workspace_sites_batch_delete(
         deleted_count = service.delete_sites(
             supabase_user_id=session.user_id,
             site_ids=payload.site_ids,
+        )
+    except LookupError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+    return {"deleted_count": deleted_count}
+
+
+# ── Cards ────────────────────────────────────────────────────────────────
+
+@app.get("/v1/workspace/cards")
+def workspace_cards_list(
+    limit: int = Query(100, ge=1, le=500),
+    offset: int = Query(0, ge=0),
+    session: AuthenticatedSession = Depends(get_authenticated_session),
+    service: HostedWorkspaceCardService = Depends(get_hosted_workspace_card_service),
+) -> dict[str, object]:
+    try:
+        page = service.list_cards_page(
+            supabase_user_id=session.user_id,
+            limit=limit,
+            offset=offset,
+        )
+    except LookupError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+
+    return {
+        "cards": [card.as_dict() if hasattr(card, "as_dict") else card for card in page["cards"]],
+        "offset": page["offset"],
+        "limit": page["limit"],
+        "next_offset": page["next_offset"],
+        "total_count": page["total_count"],
+        "has_more": page["has_more"],
+    }
+
+
+@app.post("/v1/workspace/cards")
+def workspace_cards_create(
+    payload: HostedWorkspaceCardCreateRequest = Body(...),
+    session: AuthenticatedSession = Depends(get_authenticated_session),
+    service: HostedWorkspaceCardService = Depends(get_hosted_workspace_card_service),
+) -> dict[str, object]:
+    try:
+        card = service.create_card(
+            supabase_user_id=session.user_id,
+            name=payload.name,
+            user_id=payload.user_id,
+            last_four=payload.last_four,
+            cashback_rate=payload.cashback_rate,
+            notes=payload.notes,
+        )
+    except LookupError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+    return card.as_dict() if hasattr(card, "as_dict") else card
+
+
+@app.patch("/v1/workspace/cards/{card_id}")
+def workspace_cards_update(
+    card_id: str = Path(...),
+    payload: HostedWorkspaceCardUpdateRequest = Body(...),
+    session: AuthenticatedSession = Depends(get_authenticated_session),
+    service: HostedWorkspaceCardService = Depends(get_hosted_workspace_card_service),
+) -> dict[str, object]:
+    try:
+        card = service.update_card(
+            supabase_user_id=session.user_id,
+            card_id=card_id,
+            name=payload.name,
+            user_id=payload.user_id,
+            last_four=payload.last_four,
+            cashback_rate=payload.cashback_rate,
+            notes=payload.notes,
+            is_active=payload.is_active,
+        )
+    except LookupError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+    return card.as_dict() if hasattr(card, "as_dict") else card
+
+
+@app.delete("/v1/workspace/cards/{card_id}", status_code=status.HTTP_204_NO_CONTENT)
+def workspace_cards_delete(
+    card_id: str = Path(...),
+    session: AuthenticatedSession = Depends(get_authenticated_session),
+    service: HostedWorkspaceCardService = Depends(get_hosted_workspace_card_service),
+) -> Response:
+    try:
+        service.delete_card(
+            supabase_user_id=session.user_id,
+            card_id=card_id,
+        )
+    except LookupError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@app.post("/v1/workspace/cards/batch-delete")
+def workspace_cards_batch_delete(
+    payload: HostedWorkspaceCardBatchDeleteRequest = Body(...),
+    session: AuthenticatedSession = Depends(get_authenticated_session),
+    service: HostedWorkspaceCardService = Depends(get_hosted_workspace_card_service),
+) -> dict[str, int]:
+    try:
+        deleted_count = service.delete_cards(
+            supabase_user_id=session.user_id,
+            card_ids=payload.card_ids,
         )
     except LookupError as exc:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc

--- a/repositories/hosted_card_repository.py
+++ b/repositories/hosted_card_repository.py
@@ -1,0 +1,165 @@
+"""Persistence helpers for hosted workspace-owned business cards."""
+
+from __future__ import annotations
+
+from sqlalchemy import delete, func, select
+from sqlalchemy.orm import aliased
+
+from services.hosted.models import HostedCard
+from services.hosted.persistence import HostedCardRecord, HostedUserRecord
+
+
+class HostedCardRepository:
+    def list_by_workspace_id(
+        self,
+        session,
+        workspace_id: str,
+        *,
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> list[HostedCard]:
+        user_alias = aliased(HostedUserRecord)
+        query = (
+            select(HostedCardRecord, user_alias.name.label("user_name"))
+            .outerjoin(user_alias, HostedCardRecord.user_id == user_alias.id)
+            .where(HostedCardRecord.workspace_id == workspace_id)
+            .order_by(HostedCardRecord.name.asc(), HostedCardRecord.id.asc())
+            .offset(offset)
+        )
+        if limit is not None:
+            query = query.limit(limit)
+
+        rows = session.execute(query).all()
+        return [self._row_to_model(row) for row in rows]
+
+    def count_by_workspace_id(self, session, workspace_id: str) -> int:
+        return session.scalar(
+            select(func.count())
+            .select_from(HostedCardRecord)
+            .where(HostedCardRecord.workspace_id == workspace_id)
+        ) or 0
+
+    def get_by_id_and_workspace_id(
+        self,
+        session,
+        *,
+        card_id: str,
+        workspace_id: str,
+    ) -> HostedCard | None:
+        user_alias = aliased(HostedUserRecord)
+        row = session.execute(
+            select(HostedCardRecord, user_alias.name.label("user_name"))
+            .outerjoin(user_alias, HostedCardRecord.user_id == user_alias.id)
+            .where(
+                HostedCardRecord.id == card_id,
+                HostedCardRecord.workspace_id == workspace_id,
+            )
+        ).first()
+        if row is None:
+            return None
+        return self._row_to_model(row)
+
+    def create(
+        self,
+        session,
+        *,
+        workspace_id: str,
+        user_id: str,
+        name: str,
+        last_four: str | None = None,
+        cashback_rate: float = 0.0,
+        is_active: bool = True,
+        notes: str | None = None,
+    ) -> HostedCard:
+        record = HostedCardRecord(
+            workspace_id=workspace_id,
+            user_id=user_id,
+            name=name,
+            last_four=last_four,
+            cashback_rate=cashback_rate,
+            is_active=is_active,
+            notes=notes,
+        )
+        session.add(record)
+        session.flush()
+        # Re-query to get joined user_name
+        return self.get_by_id_and_workspace_id(
+            session, card_id=record.id, workspace_id=workspace_id
+        )
+
+    def update(
+        self,
+        session,
+        *,
+        card_id: str,
+        workspace_id: str,
+        user_id: str,
+        name: str,
+        last_four: str | None,
+        cashback_rate: float,
+        is_active: bool,
+        notes: str | None,
+    ) -> HostedCard | None:
+        record = session.scalar(
+            select(HostedCardRecord).where(
+                HostedCardRecord.id == card_id,
+                HostedCardRecord.workspace_id == workspace_id,
+            )
+        )
+        if record is None:
+            return None
+
+        record.user_id = user_id
+        record.name = name
+        record.last_four = last_four
+        record.cashback_rate = cashback_rate
+        record.is_active = is_active
+        record.notes = notes
+        session.flush()
+        return self.get_by_id_and_workspace_id(
+            session, card_id=record.id, workspace_id=workspace_id
+        )
+
+    def delete(self, session, *, card_id: str, workspace_id: str) -> bool:
+        record = session.scalar(
+            select(HostedCardRecord).where(
+                HostedCardRecord.id == card_id,
+                HostedCardRecord.workspace_id == workspace_id,
+            )
+        )
+        if record is None:
+            return False
+
+        session.delete(record)
+        session.flush()
+        return True
+
+    def delete_many(self, session, *, card_ids: list[str], workspace_id: str) -> int:
+        normalized_ids = list(dict.fromkeys(card_ids))
+        if not normalized_ids:
+            return 0
+
+        result = session.execute(
+            delete(HostedCardRecord).where(
+                HostedCardRecord.workspace_id == workspace_id,
+                HostedCardRecord.id.in_(normalized_ids),
+            )
+        )
+        session.flush()
+        return int(result.rowcount or 0)
+
+    @staticmethod
+    def _row_to_model(row) -> HostedCard:
+        record = row[0] if hasattr(row, "__getitem__") else row
+        user_name = row.user_name if hasattr(row, "user_name") else None
+        return HostedCard(
+            id=record.id,
+            workspace_id=record.workspace_id,
+            user_id=record.user_id,
+            name=record.name,
+            last_four=record.last_four,
+            cashback_rate=record.cashback_rate,
+            is_active=record.is_active,
+            notes=record.notes,
+            user_name=user_name,
+        )

--- a/services/hosted/models.py
+++ b/services/hosted/models.py
@@ -118,3 +118,50 @@ class HostedSite:
             "is_active": self.is_active,
             "notes": self.notes,
         }
+
+
+@dataclass
+class HostedCard:
+    """Payment card owned by a hosted workspace user."""
+
+    name: str
+    user_id: str
+    workspace_id: Optional[str] = None
+    last_four: Optional[str] = None
+    cashback_rate: float = 0.0
+    is_active: bool = True
+    notes: Optional[str] = None
+    id: Optional[str] = None
+    user_name: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        self.name = self.name.strip()
+        if not self.name:
+            raise ValueError("Card name is required")
+
+        if not self.user_id:
+            raise ValueError("User is required")
+
+        if self.last_four is not None:
+            self.last_four = self.last_four.strip() or None
+            if self.last_four and len(self.last_four) != 4:
+                raise ValueError("Last four must be exactly 4 characters")
+
+        if self.cashback_rate < 0 or self.cashback_rate > 100:
+            raise ValueError("Cashback rate must be between 0 and 100")
+
+        if self.notes is not None:
+            self.notes = self.notes.strip() or None
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "id": self.id,
+            "workspace_id": self.workspace_id,
+            "user_id": self.user_id,
+            "user_name": self.user_name,
+            "name": self.name,
+            "last_four": self.last_four,
+            "cashback_rate": self.cashback_rate,
+            "is_active": self.is_active,
+            "notes": self.notes,
+        }

--- a/services/hosted/workspace_card_service.py
+++ b/services/hosted/workspace_card_service.py
@@ -1,0 +1,173 @@
+"""Hosted workspace-managed card directory service."""
+
+from __future__ import annotations
+
+from repositories.hosted_account_repository import HostedAccountRepository
+from repositories.hosted_card_repository import HostedCardRepository
+from repositories.hosted_workspace_repository import HostedWorkspaceRepository
+from services.hosted.models import HostedCard, HostedWorkspace
+
+
+class HostedWorkspaceCardService:
+    def __init__(self, session_factory) -> None:
+        self.session_factory = session_factory
+        self.account_repository = HostedAccountRepository()
+        self.workspace_repository = HostedWorkspaceRepository()
+        self.card_repository = HostedCardRepository()
+
+    def list_cards(self, *, supabase_user_id: str) -> list[HostedCard]:
+        with self.session_factory() as session:
+            workspace = self._require_workspace(session, supabase_user_id)
+            return self.card_repository.list_by_workspace_id(session, workspace.id)
+
+    def list_cards_page(
+        self,
+        *,
+        supabase_user_id: str,
+        limit: int,
+        offset: int = 0,
+    ) -> dict[str, object]:
+        with self.session_factory() as session:
+            workspace = self._require_workspace(session, supabase_user_id)
+            total_count = self.card_repository.count_by_workspace_id(session, workspace.id)
+            cards = self.card_repository.list_by_workspace_id(
+                session,
+                workspace.id,
+                limit=limit,
+                offset=offset,
+            )
+            next_offset = offset + len(cards)
+            has_more = next_offset < total_count
+            return {
+                "cards": cards,
+                "offset": offset,
+                "limit": limit,
+                "next_offset": next_offset,
+                "total_count": total_count,
+                "has_more": has_more,
+            }
+
+    def create_card(
+        self,
+        *,
+        supabase_user_id: str,
+        name: str,
+        user_id: str,
+        last_four: str | None = None,
+        cashback_rate: float = 0.0,
+        notes: str | None = None,
+    ) -> HostedCard:
+        candidate = HostedCard(
+            name=name,
+            user_id=user_id,
+            last_four=last_four,
+            cashback_rate=cashback_rate,
+            notes=notes,
+        )
+
+        with self.session_factory() as session:
+            workspace = self._require_workspace(session, supabase_user_id)
+            created_card = self.card_repository.create(
+                session,
+                workspace_id=workspace.id,
+                user_id=candidate.user_id,
+                name=candidate.name,
+                last_four=candidate.last_four,
+                cashback_rate=candidate.cashback_rate,
+                notes=candidate.notes,
+                is_active=candidate.is_active,
+            )
+            session.commit()
+            return created_card
+
+    def update_card(
+        self,
+        *,
+        supabase_user_id: str,
+        card_id: str,
+        name: str,
+        user_id: str,
+        last_four: str | None = None,
+        cashback_rate: float = 0.0,
+        notes: str | None = None,
+        is_active: bool = True,
+    ) -> HostedCard:
+        candidate = HostedCard(
+            name=name,
+            user_id=user_id,
+            last_four=last_four,
+            cashback_rate=cashback_rate,
+            notes=notes,
+            is_active=is_active,
+        )
+
+        with self.session_factory() as session:
+            workspace = self._require_workspace(session, supabase_user_id)
+            updated_card = self.card_repository.update(
+                session,
+                card_id=card_id,
+                workspace_id=workspace.id,
+                user_id=candidate.user_id,
+                name=candidate.name,
+                last_four=candidate.last_four,
+                cashback_rate=candidate.cashback_rate,
+                notes=candidate.notes,
+                is_active=candidate.is_active,
+            )
+            if updated_card is None:
+                raise LookupError("Hosted card was not found in the authenticated workspace.")
+
+            session.commit()
+            return updated_card
+
+    def delete_card(
+        self,
+        *,
+        supabase_user_id: str,
+        card_id: str,
+    ) -> None:
+        with self.session_factory() as session:
+            workspace = self._require_workspace(session, supabase_user_id)
+            deleted = self.card_repository.delete(
+                session,
+                card_id=card_id,
+                workspace_id=workspace.id,
+            )
+            if not deleted:
+                raise LookupError("Hosted card was not found in the authenticated workspace.")
+
+            session.commit()
+
+    def delete_cards(
+        self,
+        *,
+        supabase_user_id: str,
+        card_ids: list[str],
+    ) -> int:
+        normalized_ids = list(dict.fromkeys(card_ids))
+        if not normalized_ids:
+            raise ValueError("At least one hosted card id is required.")
+
+        with self.session_factory() as session:
+            workspace = self._require_workspace(session, supabase_user_id)
+            deleted_count = self.card_repository.delete_many(
+                session,
+                card_ids=normalized_ids,
+                workspace_id=workspace.id,
+            )
+            if deleted_count != len(normalized_ids):
+                raise LookupError("One or more hosted cards were not found in the authenticated workspace.")
+
+            session.commit()
+            return deleted_count
+
+    def _require_workspace(self, session, supabase_user_id: str) -> HostedWorkspace:
+        account = self.account_repository.get_by_supabase_user_id(session, supabase_user_id)
+        if account is None:
+            raise LookupError("Hosted workspace bootstrap must complete before managing workspace cards.")
+
+        workspace = self.workspace_repository.get_by_account_id(session, account.id)
+        if workspace is None:
+            raise LookupError("Hosted workspace bootstrap must complete before managing workspace cards.")
+
+        return workspace

--- a/web/src/components/AppShell.jsx
+++ b/web/src/components/AppShell.jsx
@@ -8,11 +8,12 @@ import AccountModal from "./common/AccountModal";
 import SettingsModal from "./common/SettingsModal";
 import UsersTab from "./UsersTab/UsersTab";
 import SitesTab from "./SitesTab/SitesTab";
+import CardsTab from "./CardsTab/CardsTab";
 
 const setupTabs = [
   { key: "users", label: "Users", icon: "users", enabled: true },
   { key: "sites", label: "Sites", icon: "sites", enabled: true },
-  { key: "cards", label: "Cards", icon: "cards", enabled: false },
+  { key: "cards", label: "Cards", icon: "cards", enabled: true },
   { key: "method-types", label: "Method Types", icon: "methodTypes", enabled: false },
   { key: "redemption-methods", label: "Redemption Methods", icon: "redemptionMethods", enabled: false },
   { key: "game-types", label: "Game Types", icon: "gameTypes", enabled: false },
@@ -197,6 +198,12 @@ export default function AppShell({ auth }) {
         ) : null}
         {setupTab === "sites" ? (
           <SitesTab
+            apiBaseUrl={auth.apiBaseUrl}
+            hostedWorkspaceReady={auth.hostedWorkspaceReady}
+          />
+        ) : null}
+        {setupTab === "cards" ? (
+          <CardsTab
             apiBaseUrl={auth.apiBaseUrl}
             hostedWorkspaceReady={auth.hostedWorkspaceReady}
           />

--- a/web/src/components/CardsTab/CardModal.jsx
+++ b/web/src/components/CardsTab/CardModal.jsx
@@ -1,0 +1,205 @@
+import { initialCardForm } from "./cardsConstants";
+
+export default function CardModal({
+  mode,
+  card,
+  form,
+  setForm,
+  onClose,
+  onSubmit,
+  onRequestEdit,
+  onRequestDelete,
+  submitError,
+  suggestions,
+  users
+}) {
+  const readOnly = mode === "view";
+  const title = mode === "create" ? "Add Card" : mode === "edit" ? "Edit Card" : "View Card";
+  const nameInvalid = !form.name.trim();
+  const userIdInvalid = !form.user_id;
+  const lastFourValue = form.last_four.trim();
+  const lastFourInvalid = lastFourValue.length > 0 && lastFourValue.length !== 4;
+  const cashbackValue = parseFloat(form.cashback_rate);
+  const cashbackInvalid = form.cashback_rate !== "" && (isNaN(cashbackValue) || cashbackValue < 0 || cashbackValue > 100);
+  const closeLabel = readOnly ? "Close" : "Cancel";
+
+  if (readOnly && card) {
+    return (
+      <div className="modal-backdrop" role="presentation" onClick={onClose}>
+        <section
+          className="modal-card site-modal"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="card-modal-title"
+          onClick={(event) => event.stopPropagation()}
+        >
+          <div className="modal-header">
+            <div>
+              <h2 id="card-modal-title">View Card</h2>
+            </div>
+            <button className="ghost-button" type="button" onClick={onClose}>{closeLabel}</button>
+          </div>
+
+          <div className="user-detail-body">
+            <dl className="detail-grid user-detail-grid">
+              <div><dt>Name</dt><dd>{card.name}</dd></div>
+              <div><dt>User</dt><dd>{card.user_name || "\u2014"}</dd></div>
+              <div><dt>Last Four</dt><dd>{card.last_four || "\u2014"}</dd></div>
+              <div><dt>Cashback Rate</dt><dd>{Number(card.cashback_rate).toFixed(2)}%</dd></div>
+              <div>
+                <dt>Status</dt>
+                <dd>
+                  <span className={card.is_active ? "status-chip active" : "status-chip inactive"}>
+                    {card.is_active ? "Active" : "Inactive"}
+                  </span>
+                </dd>
+              </div>
+            </dl>
+
+            <div className="user-detail-notes">
+              <p className="detail-label">Notes</p>
+              <div className="notes-display">{card.notes || "-"}</div>
+            </div>
+          </div>
+
+          <div className="modal-actions modal-actions-split">
+            <div className="toolbar-row">
+              <button className="ghost-button" type="button" onClick={onRequestDelete}>Delete</button>
+            </div>
+            <div className="toolbar-row">
+              <button className="primary-button" type="button" onClick={onRequestEdit}>Edit Card</button>
+            </div>
+          </div>
+        </section>
+      </div>
+    );
+  }
+
+  return (
+    <div className="modal-backdrop" role="presentation" onClick={onClose}>
+      <section
+        className="modal-card site-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="card-modal-title"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="modal-header">
+          <div>
+            <h2 id="card-modal-title">{title}</h2>
+          </div>
+          <button className="ghost-button" type="button" onClick={onClose}>
+            {closeLabel}
+          </button>
+        </div>
+
+        <div className="form-grid">
+          <label className="field-label" htmlFor="card-name-input">Name</label>
+          <div>
+            <input
+              id="card-name-input"
+              className={nameInvalid ? "text-input invalid" : "text-input"}
+              type="text"
+              list="card-name-suggestions"
+              placeholder="Required"
+              value={form.name}
+              readOnly={readOnly}
+              onChange={(event) => setForm((current) => ({ ...current, name: event.target.value }))}
+            />
+            <datalist id="card-name-suggestions">
+              {suggestions.names.map((name) => (
+                <option key={name} value={name} />
+              ))}
+            </datalist>
+            {nameInvalid ? <p className="field-error">Name is required.</p> : null}
+          </div>
+
+          <label className="field-label" htmlFor="card-user-input">User</label>
+          <div>
+            <select
+              id="card-user-input"
+              className={userIdInvalid ? "text-input invalid" : "text-input"}
+              value={form.user_id}
+              disabled={readOnly}
+              onChange={(event) => setForm((current) => ({ ...current, user_id: event.target.value }))}
+            >
+              <option value="">Select a user...</option>
+              {users.map((user) => (
+                <option key={user.id} value={user.id}>{user.display_name || user.email || user.id}</option>
+              ))}
+            </select>
+            {userIdInvalid ? <p className="field-error">User is required.</p> : null}
+          </div>
+
+          <label className="field-label" htmlFor="card-last-four-input">Last Four</label>
+          <div>
+            <input
+              id="card-last-four-input"
+              className={lastFourInvalid ? "text-input invalid" : "text-input"}
+              type="text"
+              maxLength={4}
+              placeholder="Optional (4 digits)"
+              value={form.last_four}
+              readOnly={readOnly}
+              onChange={(event) => setForm((current) => ({ ...current, last_four: event.target.value }))}
+            />
+            {lastFourInvalid ? <p className="field-error">Must be exactly 4 characters.</p> : null}
+          </div>
+
+          <label className="field-label" htmlFor="card-cashback-input">Cashback Rate</label>
+          <div>
+            <input
+              id="card-cashback-input"
+              className={cashbackInvalid ? "text-input invalid" : "text-input"}
+              type="number"
+              step="any"
+              min="0"
+              max="100"
+              placeholder="0.00"
+              value={form.cashback_rate}
+              readOnly={readOnly}
+              onChange={(event) => setForm((current) => ({ ...current, cashback_rate: event.target.value }))}
+            />
+            {cashbackInvalid ? <p className="field-error">Cashback rate must be 0–100.</p> : null}
+          </div>
+
+          <label className="field-label" htmlFor="card-active-input">Active</label>
+          <label className="toggle-row" htmlFor="card-active-input">
+            <input
+              id="card-active-input"
+              type="checkbox"
+              checked={form.is_active}
+              disabled={readOnly}
+              onChange={(event) => setForm((current) => ({ ...current, is_active: event.target.checked }))}
+            />
+            <span>{form.is_active ? "Active" : "Inactive"}</span>
+          </label>
+
+          <label className="field-label field-label-top" htmlFor="card-notes-input">Notes</label>
+          <textarea
+            id="card-notes-input"
+            className="notes-input"
+            placeholder="Optional"
+            rows={5}
+            value={form.notes}
+            readOnly={readOnly}
+            onChange={(event) => setForm((current) => ({ ...current, notes: event.target.value }))}
+          />
+        </div>
+
+        {submitError ? <p className="submit-error">{submitError}</p> : null}
+
+        <div className="modal-actions modal-actions-end">
+          <button
+            className="primary-button"
+            type="button"
+            onClick={onSubmit}
+            disabled={nameInvalid || userIdInvalid || lastFourInvalid || cashbackInvalid}
+          >
+            Save Card
+          </button>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/web/src/components/CardsTab/CardModal.jsx
+++ b/web/src/components/CardsTab/CardModal.jsx
@@ -1,4 +1,5 @@
 import { initialCardForm } from "./cardsConstants";
+import TypeaheadSelect from "../common/TypeaheadSelect";
 
 export default function CardModal({
   mode,
@@ -116,18 +117,18 @@ export default function CardModal({
 
           <label className="field-label" htmlFor="card-user-input">User</label>
           <div>
-            <select
+            <TypeaheadSelect
               id="card-user-input"
-              className={userIdInvalid ? "text-input invalid" : "text-input"}
+              options={users.map((user) => ({
+                value: user.id,
+                label: user.name || user.email || user.id
+              }))}
               value={form.user_id}
+              onChange={(userId) => setForm((current) => ({ ...current, user_id: userId }))}
+              placeholder="Search users..."
               disabled={readOnly}
-              onChange={(event) => setForm((current) => ({ ...current, user_id: event.target.value }))}
-            >
-              <option value="">Select a user...</option>
-              {users.map((user) => (
-                <option key={user.id} value={user.id}>{user.display_name || user.email || user.id}</option>
-              ))}
-            </select>
+              invalid={userIdInvalid}
+            />
             {userIdInvalid ? <p className="field-error">User is required.</p> : null}
           </div>
 

--- a/web/src/components/CardsTab/CardsTab.jsx
+++ b/web/src/components/CardsTab/CardsTab.jsx
@@ -1,0 +1,1396 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+
+import { authHeaders, describeFetchFailure, getAccessToken } from "../../services/api";
+import Icon from "../common/Icon";
+import HighlightMatch from "../common/HighlightMatch";
+import ConfirmationModal from "../common/ConfirmationModal";
+import CardModal from "./CardModal";
+import ExportModal from "../UsersTab/ExportModal";
+import UserHeaderFilterMenu from "../UsersTab/UserHeaderFilterMenu";
+import TableContextMenu from "../UsersTab/TableContextMenu";
+import {
+  initialCardForm,
+  initialCardColumnFilters,
+  cardTableColumns,
+  cardsPageSize,
+  cardsFallbackPageSize
+} from "./cardsConstants";
+import {
+  normalizeCardForm,
+  isTextEntryElement,
+  computeCellStats,
+  getCellDisplayValue,
+  downloadCardsCsv,
+  getCardColumnValue,
+  buildCardFilterOptions,
+  mergeCardsById
+} from "./cardsUtils";
+
+export default function CardsTab({ apiBaseUrl, hostedWorkspaceReady }) {
+  const cardsScrollGateRef = useRef({ armed: false, lastScrollTop: 0 });
+  const cardsPagingRequestRef = useRef(false);
+  const cardsTableViewportRef = useRef(null);
+  const cardNavCursorRef = useRef(null);
+  const [cards, setCards] = useState([]);
+  const [cardsStatus, setCardsStatus] = useState("Sign in to load hosted cards.");
+  const [cardsSearch, setCardsSearch] = useState("");
+  const [cardColumnFilters, setCardColumnFilters] = useState(initialCardColumnFilters);
+  const [cardsSort, setCardsSort] = useState({ column: null, direction: "asc" });
+  const [openCardHeaderMenu, setOpenCardHeaderMenu] = useState(null);
+  const [selectedCardIds, setSelectedCardIds] = useState([]);
+  const [selectionAnchorCardId, setSelectionAnchorCardId] = useState(null);
+  const [selectedColumnKeys, setSelectedColumnKeys] = useState(new Set());
+  const [selectedCells, setSelectedCells] = useState(new Set());
+  const cellAnchorRef = useRef(null);
+  const [cardsTotalCount, setCardsTotalCount] = useState(null);
+  const [cardsNextOffset, setCardsNextOffset] = useState(0);
+  const [cardsHasMore, setCardsHasMore] = useState(false);
+  const [cardsLoadingInitial, setCardsLoadingInitial] = useState(false);
+  const [cardsLoadingMore, setCardsLoadingMore] = useState(false);
+  const [showBackToTop, setShowBackToTop] = useState(false);
+  const [contextMenu, setContextMenu] = useState(null);
+  const [columnWidths, setColumnWidths] = useState(null);
+  const columnResizeRef = useRef(null);
+  const headerRef = useRef(null);
+  const [exportModalOpen, setExportModalOpen] = useState(false);
+  const [cardModalMode, setCardModalMode] = useState(null);
+  const [cardForm, setCardForm] = useState(initialCardForm);
+  const [cardFormBaseline, setCardFormBaseline] = useState(initialCardForm);
+  const [cardSubmitError, setCardSubmitError] = useState(null);
+  const [confirmationState, setConfirmationState] = useState(null);
+  const [users, setUsers] = useState([]);
+
+  const filteredCards = useMemo(() => {
+    const searchText = cardsSearch.trim().toLowerCase();
+    const searchFiltered = !searchText
+      ? cards
+      : cards.filter((card) =>
+          card.name.toLowerCase().includes(searchText)
+          || (card.user_name || "").toLowerCase().includes(searchText)
+          || (card.last_four || "").toLowerCase().includes(searchText)
+          || (card.notes || "").toLowerCase().includes(searchText)
+        );
+
+    const columnFiltered = searchFiltered.filter((card) => {
+      for (const col of cardTableColumns) {
+        const filterValues = cardColumnFilters[col.key];
+        if (filterValues && filterValues.length && !filterValues.includes(getCardColumnValue(card, col.key))) {
+          return false;
+        }
+      }
+      return true;
+    });
+
+    if (!cardsSort.column) {
+      return columnFiltered;
+    }
+
+    const sortedCards = [...columnFiltered].sort((left, right) => {
+      const leftValue = getCardColumnValue(left, cardsSort.column);
+      const rightValue = getCardColumnValue(right, cardsSort.column);
+
+      if (cardsSort.column === "cashback_rate") {
+        const leftNum = parseFloat(leftValue) || 0;
+        const rightNum = parseFloat(rightValue) || 0;
+        return leftNum - rightNum;
+      }
+
+      return leftValue.localeCompare(rightValue, undefined, { sensitivity: "base" });
+    });
+
+    return cardsSort.direction === "desc" ? sortedCards.reverse() : sortedCards;
+  }, [cardColumnFilters, cards, cardsSearch, cardsSort]);
+
+  const cardFilterOptions = useMemo(() => {
+    const options = {};
+    for (const col of cardTableColumns) {
+      if (col.key === "status") {
+        options[col.key] = [
+          { value: "Active", label: "Active", path: ["Active"], searchValue: "Active" },
+          { value: "Inactive", label: "Inactive", path: ["Inactive"], searchValue: "Inactive" }
+        ];
+      } else {
+        options[col.key] = buildCardFilterOptions(cards, col.key);
+      }
+    }
+    return options;
+  }, [cards]);
+
+  const filteredCardCount = filteredCards.length;
+  const totalCardCount = cardsTotalCount ?? cards.length;
+
+  const selectedCards = cards.filter((card) => selectedCardIds.includes(card.id));
+  const selectedCard = selectedCards.length === 1 ? selectedCards[0] : null;
+  const cardModalDirty = cardModalMode && cardModalMode !== "view"
+    ? JSON.stringify(normalizeCardForm(cardForm)) !== JSON.stringify(normalizeCardForm(cardFormBaseline))
+    : false;
+
+  const cardsFiltersActive = Boolean(
+    cardsSearch
+    || Object.values(cardColumnFilters).some((values) => values.length)
+    || cardsSort.column
+  );
+
+  const cardSuggestions = useMemo(() => ({
+    names: [...new Set(cards.map((card) => card.name).filter(Boolean))]
+  }), [cards]);
+
+  function clearCardSelection() {
+    setSelectedCardIds([]);
+    setSelectionAnchorCardId(null);
+    setSelectedCells(new Set());
+    setSelectedColumnKeys(new Set());
+    cellAnchorRef.current = null;
+  }
+
+  function closeCardModalImmediately() {
+    setCardModalMode(null);
+    setCardSubmitError(null);
+    setCardForm(initialCardForm);
+    setCardFormBaseline(initialCardForm);
+  }
+
+  function openConfirmation(options) {
+    setConfirmationState(options);
+  }
+
+  function requestCloseCardModal() {
+    if (!cardModalDirty) {
+      closeCardModalImmediately();
+      return;
+    }
+
+    openConfirmation({
+      title: "Discard unsaved changes?",
+      message: "You have changes in this form that have not been saved.",
+      confirmLabel: "Discard Changes",
+      cancelLabel: "Keep Editing",
+      tone: "danger",
+      onConfirm: () => {
+        setConfirmationState(null);
+        closeCardModalImmediately();
+      }
+    });
+  }
+
+  // --- Data loading ---
+
+  async function loadUsers(accessToken) {
+    if (!accessToken || !apiBaseUrl) return;
+    try {
+      const response = await fetch(`${apiBaseUrl}/v1/workspace/users?limit=500&offset=0`, {
+        headers: authHeaders(accessToken)
+      });
+      if (response.ok) {
+        const payload = await response.json();
+        setUsers(Array.isArray(payload.users) ? payload.users : []);
+      }
+    } catch {
+      // Users list is supplementary; silent failure is acceptable
+    }
+  }
+
+  async function loadCards(accessToken, { append = false } = {}) {
+    if (!accessToken) {
+      setCards([]);
+      setCardsTotalCount(null);
+      setCardsNextOffset(0);
+      setCardsHasMore(false);
+      clearCardSelection();
+      setCardsStatus("Sign in to load hosted cards.");
+      return;
+    }
+
+    if (!apiBaseUrl) {
+      setCards([]);
+      setCardsTotalCount(null);
+      setCardsNextOffset(0);
+      setCardsHasMore(false);
+      clearCardSelection();
+      setCardsStatus("Set VITE_API_BASE_URL to enable hosted cards.");
+      return;
+    }
+
+    const requestOffset = append ? cardsNextOffset : 0;
+    if (append) {
+      setCardsLoadingMore(true);
+    } else {
+      setCardsLoadingInitial(true);
+      setCardsStatus("Loading hosted cards...");
+    }
+
+    try {
+      const response = await fetch(`${apiBaseUrl}/v1/workspace/cards?limit=${cardsPageSize}&offset=${requestOffset}`, {
+        headers: authHeaders(accessToken)
+      });
+      const payload = await response.json();
+
+      if (!response.ok) {
+        setCards([]);
+        setCardsTotalCount(null);
+        setCardsNextOffset(0);
+        setCardsHasMore(false);
+        clearCardSelection();
+        setCardsStatus(payload.detail || `Hosted cards failed to load (${response.status}).`);
+        return;
+      }
+
+      const payloadCards = Array.isArray(payload.cards) ? payload.cards : [];
+      let loadedCards = payloadCards.slice(0, cardsPageSize);
+      let mergedCards = append ? mergeCardsById(cards, loadedCards) : loadedCards;
+      let reportedTotalCount = Number.isFinite(payload.total_count) ? payload.total_count : null;
+      let nextOffset = requestOffset + loadedCards.length;
+      let inferredHasMore = loadedCards.length === cardsPageSize;
+      let hasMore = Boolean(payload.has_more) || nextOffset < (reportedTotalCount ?? 0) || inferredHasMore;
+
+      if (append && loadedCards.length && mergedCards.length === cards.length) {
+        const fallbackResponse = await fetch(`${apiBaseUrl}/v1/workspace/cards?limit=${cardsFallbackPageSize}&offset=0`, {
+          headers: authHeaders(accessToken)
+        });
+        const fallbackPayload = await fallbackResponse.json();
+
+        if (fallbackResponse.ok) {
+          const fallbackCards = Array.isArray(fallbackPayload.cards)
+            ? fallbackPayload.cards.slice(0, cardsFallbackPageSize)
+            : [];
+          const fallbackMergedCards = mergeCardsById(cards, fallbackCards);
+
+          if (fallbackMergedCards.length > cards.length) {
+            loadedCards = fallbackCards;
+            mergedCards = fallbackMergedCards;
+            reportedTotalCount = Number.isFinite(fallbackPayload.total_count)
+              ? fallbackPayload.total_count
+              : reportedTotalCount;
+            nextOffset = mergedCards.length;
+            inferredHasMore = fallbackCards.length === cardsFallbackPageSize;
+            hasMore = Boolean(fallbackPayload.has_more)
+              || nextOffset < (reportedTotalCount ?? 0)
+              || inferredHasMore;
+          } else {
+            hasMore = false;
+          }
+        } else {
+          hasMore = false;
+        }
+      }
+
+      const totalCount = Math.max(reportedTotalCount ?? 0, mergedCards.length);
+
+      if (!append) {
+        cardsScrollGateRef.current = {
+          armed: false,
+          lastScrollTop: cardsTableViewportRef.current?.scrollTop || 0,
+        };
+      }
+
+      setCards(mergedCards);
+      setCardsTotalCount(totalCount);
+      setCardsNextOffset(nextOffset);
+      setCardsHasMore(hasMore);
+      setSelectedCardIds((current) => current.filter((cardId) => mergedCards.some((card) => card.id === cardId)));
+
+      if (!mergedCards.length) {
+        setCardsStatus("No hosted cards yet. Add your first card to get started.");
+      } else if (hasMore) {
+        setCardsStatus(`Loaded ${mergedCards.length} of ${totalCount} hosted cards.`);
+      } else {
+        setCardsStatus("Hosted cards ready.");
+      }
+    } catch (error) {
+      setCards([]);
+      setCardsTotalCount(null);
+      setCardsNextOffset(0);
+      setCardsHasMore(false);
+      clearCardSelection();
+      setCardsStatus(describeFetchFailure(error, "Hosted cards failed to load."));
+    } finally {
+      setCardsLoadingInitial(false);
+      setCardsLoadingMore(false);
+    }
+  }
+
+  // --- Load cards when workspace becomes ready ---
+
+  useEffect(() => {
+    if (!hostedWorkspaceReady || !apiBaseUrl) {
+      return;
+    }
+
+    (async () => {
+      try {
+        const accessToken = await getAccessToken();
+        if (accessToken) {
+          await Promise.all([loadCards(accessToken), loadUsers(accessToken)]);
+        }
+      } catch (error) {
+        setCardsStatus(describeFetchFailure(error, "Hosted cards failed to load."));
+      }
+    })();
+  }, [hostedWorkspaceReady]);
+
+  // --- Header menu close on outside click ---
+
+  useEffect(() => {
+    if (!openCardHeaderMenu) {
+      return undefined;
+    }
+
+    function handlePointerDown(event) {
+      if (event.target instanceof Element && event.target.closest(".table-header-menu-wrap, .table-header-menu")) {
+        return;
+      }
+      setOpenCardHeaderMenu(null);
+    }
+
+    function handleViewportChange() {
+      setOpenCardHeaderMenu(null);
+    }
+
+    document.addEventListener("mousedown", handlePointerDown);
+    window.addEventListener("resize", handleViewportChange);
+    return () => {
+      document.removeEventListener("mousedown", handlePointerDown);
+      window.removeEventListener("resize", handleViewportChange);
+    };
+  }, [openCardHeaderMenu]);
+
+  // --- Escape key handler ---
+
+  useEffect(() => {
+    const anyModalOpen = Boolean(
+      openCardHeaderMenu
+      || cardModalMode
+      || confirmationState
+      || exportModalOpen
+    );
+
+    if (!anyModalOpen) {
+      return undefined;
+    }
+
+    function handleKeyDown(event) {
+      if (event.key !== "Escape") {
+        return;
+      }
+
+      const activeElement = document.activeElement;
+      const blurActiveTextFieldWithin = (selector) => {
+        if (!isTextEntryElement(activeElement)) {
+          return false;
+        }
+        if (!(activeElement instanceof Element) || !activeElement.closest(selector)) {
+          return false;
+        }
+        activeElement.blur();
+        return true;
+      };
+
+      event.preventDefault();
+      event.stopImmediatePropagation();
+
+      if (confirmationState) {
+        setConfirmationState(null);
+        return;
+      }
+
+      if (openCardHeaderMenu) {
+        if (blurActiveTextFieldWithin(".table-header-menu")) {
+          return;
+        }
+        setOpenCardHeaderMenu(null);
+        return;
+      }
+
+      if (cardModalMode) {
+        if (blurActiveTextFieldWithin(".modal-card")) {
+          return;
+        }
+        requestCloseCardModal();
+        return;
+      }
+
+      if (exportModalOpen) {
+        setExportModalOpen(false);
+      }
+    }
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [confirmationState, exportModalOpen, openCardHeaderMenu, cardModalMode, cardModalDirty]);
+
+  // --- Keyboard navigation ---
+
+  useEffect(() => {
+    function handleArrowNav(event) {
+      if (event.key === "c" && (event.metaKey || event.ctrlKey) && !event.shiftKey) {
+        if (isTextEntryElement(document.activeElement)) return;
+        if (selectedCells.size) {
+          event.preventDefault();
+          copyCellsAsTSV();
+          return;
+        }
+        if (selectedCardIds.length) {
+          event.preventDefault();
+          copyRowsAsTSV();
+          return;
+        }
+        return;
+      }
+
+      if (event.key === "a" && (event.metaKey || event.ctrlKey) && !event.shiftKey) {
+        if (isTextEntryElement(document.activeElement)) return;
+        if (confirmationState || cardModalMode || openCardHeaderMenu) return;
+        if (!filteredCards.length) return;
+        event.preventDefault();
+        if (selectedCardIds.length === filteredCards.length && filteredCards.every((c) => selectedCardIds.includes(c.id))) {
+          setSelectedCardIds([]);
+          setSelectionAnchorCardId(null);
+          cardNavCursorRef.current = null;
+        } else {
+          setSelectedCardIds(filteredCards.map((c) => c.id));
+          setSelectionAnchorCardId(filteredCards[0].id);
+          cardNavCursorRef.current = filteredCards[filteredCards.length - 1].id;
+        }
+        return;
+      }
+
+      if (event.key === "f" && (event.metaKey || event.ctrlKey) && !event.shiftKey) {
+        if (confirmationState || cardModalMode || openCardHeaderMenu) return;
+        event.preventDefault();
+        const searchInput = document.getElementById("cards-search-input");
+        if (searchInput) searchInput.focus();
+        return;
+      }
+
+      if (event.key === "Escape") {
+        const searchInput = document.getElementById("cards-search-input");
+        if (document.activeElement === searchInput) {
+          event.preventDefault();
+          if (cardsSearch) {
+            setCardsSearch("");
+          } else {
+            searchInput.blur();
+          }
+          return;
+        }
+      }
+
+      if (event.key !== "ArrowUp" && event.key !== "ArrowDown" && event.key !== "Enter") return;
+      if (isTextEntryElement(document.activeElement)) return;
+      if (confirmationState || cardModalMode || openCardHeaderMenu) return;
+
+      if (event.key === "Enter") {
+        if (selectedCardIds.length === 1) {
+          const card = filteredCards.find((c) => c.id === selectedCardIds[0]);
+          if (card) openCardModal("view", card);
+        }
+        return;
+      }
+
+      if (!filteredCards.length || !selectedCardIds.length) return;
+
+      event.preventDefault();
+      const orderedIds = filteredCards.map((c) => c.id);
+      const cursorId = cardNavCursorRef.current ?? selectedCardIds[selectedCardIds.length - 1];
+      const currentIndex = orderedIds.indexOf(cursorId);
+      if (currentIndex === -1) return;
+
+      const nextIndex = event.key === "ArrowDown"
+        ? Math.min(currentIndex + 1, orderedIds.length - 1)
+        : Math.max(currentIndex - 1, 0);
+      const nextId = orderedIds[nextIndex];
+      cardNavCursorRef.current = nextId;
+
+      if (event.shiftKey) {
+        setSelectedCardIds(() => {
+          const anchor = selectionAnchorCardId && orderedIds.includes(selectionAnchorCardId)
+            ? orderedIds.indexOf(selectionAnchorCardId)
+            : currentIndex;
+          const [start, end] = anchor < nextIndex ? [anchor, nextIndex] : [nextIndex, anchor];
+          return orderedIds.slice(start, end + 1);
+        });
+      } else {
+        setSelectedCardIds([nextId]);
+        setSelectionAnchorCardId(nextId);
+      }
+
+      const viewport = cardsTableViewportRef.current;
+      if (viewport) {
+        requestAnimationFrame(() => {
+          const row = viewport.querySelector(`tbody tr:nth-child(${nextIndex + 1})`);
+          if (row) row.scrollIntoView({ block: "nearest" });
+        });
+      }
+    }
+
+    window.addEventListener("keydown", handleArrowNav);
+    return () => window.removeEventListener("keydown", handleArrowNav);
+  }, [confirmationState, filteredCards, openCardHeaderMenu, selectedCells, selectedCardIds, selectionAnchorCardId, cardModalMode]);
+
+  // --- Sort / filter ---
+
+  function toggleCardSort(column) {
+    setCardsSort((current) => {
+      if (current.column !== column) {
+        return { column, direction: "asc" };
+      }
+      if (current.direction === "asc") {
+        return { column, direction: "desc" };
+      }
+      return { column: null, direction: "asc" };
+    });
+  }
+
+  function clearAllCardFilters() {
+    setCardsSearch("");
+    setCardColumnFilters(initialCardColumnFilters);
+    setCardsSort({ column: null, direction: "asc" });
+    setOpenCardHeaderMenu(null);
+    clearCardSelection();
+  }
+
+  // --- Row / cell selection ---
+
+  function handleCardRowSelection(event, cardId) {
+    event.preventDefault();
+    setSelectedCells(new Set());
+    setSelectedColumnKeys(new Set());
+    cellAnchorRef.current = null;
+    const orderedIds = filteredCards.map((card) => card.id);
+
+    if (event.shiftKey && selectionAnchorCardId && orderedIds.includes(selectionAnchorCardId)) {
+      const anchorIndex = orderedIds.indexOf(selectionAnchorCardId);
+      const targetIndex = orderedIds.indexOf(cardId);
+      const [start, end] = anchorIndex < targetIndex ? [anchorIndex, targetIndex] : [targetIndex, anchorIndex];
+      const rangeIds = orderedIds.slice(start, end + 1);
+      setSelectedCardIds((current) => (event.metaKey || event.ctrlKey ? [...new Set([...current, ...rangeIds])] : rangeIds));
+      return;
+    }
+
+    if (event.metaKey || event.ctrlKey) {
+      setSelectedCardIds((current) => (
+        current.includes(cardId)
+          ? current.filter((candidate) => candidate !== cardId)
+          : [...current, cardId]
+      ));
+      setSelectionAnchorCardId(cardId);
+      return;
+    }
+
+    setSelectedCardIds([cardId]);
+    setSelectionAnchorCardId(cardId);
+    cardNavCursorRef.current = cardId;
+  }
+
+  function handleCellClick(event, cardId, columnKey) {
+    if (!event.altKey) return false;
+    event.stopPropagation();
+    event.preventDefault();
+
+    setSelectedCardIds([]);
+    setSelectionAnchorCardId(null);
+
+    const cellId = `${cardId}:${columnKey}`;
+    const columnKeys = cardTableColumns.map((c) => c.key);
+
+    if (event.shiftKey && cellAnchorRef.current) {
+      const anchor = cellAnchorRef.current;
+      const orderedIds = filteredCards.map((c) => c.id);
+      const anchorRowIdx = orderedIds.indexOf(anchor.cardId);
+      const targetRowIdx = orderedIds.indexOf(cardId);
+      const anchorColIdx = columnKeys.indexOf(anchor.columnKey);
+      const targetColIdx = columnKeys.indexOf(columnKey);
+      if (anchorRowIdx === -1 || targetRowIdx === -1) return true;
+
+      const [rowStart, rowEnd] = anchorRowIdx < targetRowIdx ? [anchorRowIdx, targetRowIdx] : [targetRowIdx, anchorRowIdx];
+      const [colStart, colEnd] = anchorColIdx < targetColIdx ? [anchorColIdx, targetColIdx] : [targetColIdx, anchorColIdx];
+
+      const next = new Set();
+      for (let r = rowStart; r <= rowEnd; r++) {
+        for (let c = colStart; c <= colEnd; c++) {
+          next.add(`${orderedIds[r]}:${columnKeys[c]}`);
+        }
+      }
+      setSelectedCells(next);
+      setSelectedColumnKeys(new Set());
+    } else {
+      if (event.metaKey || event.ctrlKey) {
+        setSelectedCells((current) => {
+          const next = new Set(current);
+          if (next.has(cellId)) next.delete(cellId); else next.add(cellId);
+          return next;
+        });
+      } else {
+        setSelectedCells((current) => current.size === 1 && current.has(cellId) ? new Set() : new Set([cellId]));
+      }
+      setSelectedColumnKeys(new Set());
+      cellAnchorRef.current = { cardId, columnKey };
+    }
+    return true;
+  }
+
+  // --- Copy ---
+
+  function copyCellsAsTSV() {
+    const columnKeys = cardTableColumns.map((c) => c.key);
+    const orderedIds = filteredCards.map((c) => c.id);
+    const rows = [];
+    for (const cid of orderedIds) {
+      const row = [];
+      let hasCell = false;
+      for (const col of columnKeys) {
+        if (selectedCells.has(`${cid}:${col}`)) {
+          const c = filteredCards.find((x) => x.id === cid);
+          row.push(c ? getCellDisplayValue(c, col) : "");
+          hasCell = true;
+        } else {
+          row.push("");
+        }
+      }
+      if (hasCell) rows.push(row);
+    }
+    const usedCols = columnKeys.map((_, ci) => rows.some((r) => r[ci] !== ""));
+    const tsv = rows.map((r) => r.filter((_, ci) => usedCols[ci]).join("\t")).join("\n");
+    navigator.clipboard.writeText(tsv).catch(() => {});
+  }
+
+  function copyRowsAsTSV() {
+    const columnKeys = cardTableColumns.map((c) => c.key);
+    const orderedIds = filteredCards.map((c) => c.id);
+    const rows = [];
+    for (const cid of orderedIds) {
+      if (!selectedCardIds.includes(cid)) continue;
+      const c = filteredCards.find((x) => x.id === cid);
+      if (!c) continue;
+      rows.push(columnKeys.map((col) => getCellDisplayValue(c, col)));
+    }
+    const tsv = rows.map((r) => r.join("\t")).join("\n");
+    navigator.clipboard.writeText(tsv).catch(() => {});
+  }
+
+  // --- Context menu ---
+
+  function handleTableContextMenu(event, card) {
+    event.preventDefault();
+    setContextMenu(null);
+
+    let td = event.target;
+    while (td && td.tagName !== "TD") td = td.parentElement;
+    const clickedColumnKey = td?.dataset?.col || null;
+
+    const items = [];
+    const isRowSelected = selectedCardIds.includes(card.id);
+    const hasCellSelection = selectedCells.size > 0;
+    const hasRowSelection = selectedCardIds.length > 0;
+
+    if (clickedColumnKey) {
+      const cellValue = getCellDisplayValue(card, clickedColumnKey);
+      const truncated = cellValue.length > 30 ? `${cellValue.slice(0, 27)}\u2026` : cellValue;
+      items.push({ label: `Copy "${truncated}"`, action: () => { navigator.clipboard.writeText(cellValue).catch(() => {}); }});
+    }
+
+    if (hasCellSelection) {
+      items.push({ label: `Copy ${selectedCells.size} cell${selectedCells.size > 1 ? "s" : ""}`, action: copyCellsAsTSV });
+    }
+
+    if (hasRowSelection) {
+      const count = selectedCardIds.length;
+      items.push({ label: count > 1 ? `Copy ${count} rows` : "Copy row", action: copyRowsAsTSV });
+    }
+
+    items.push({ divider: true });
+
+    if (!isRowSelected) {
+      items.push({ label: "Select row", action: () => { setSelectedCardIds([card.id]); setSelectionAnchorCardId(card.id); }});
+      items.push({ divider: true });
+    }
+
+    const targetCards = isRowSelected ? selectedCards : [card];
+    const targetCount = targetCards.length;
+
+    items.push({ label: "View", action: () => openCardModal("view", targetCount === 1 ? targetCards[0] : card), disabled: targetCount !== 1 });
+    items.push({ label: "Edit", action: () => openCardModal("edit", targetCount === 1 ? targetCards[0] : card), disabled: targetCount !== 1 });
+    items.push({ divider: true });
+
+    if (hasCellSelection) {
+      items.push({ label: "Clear cell selection", action: () => { setSelectedCells(new Set()); setSelectedColumnKeys(new Set()); cellAnchorRef.current = null; }});
+    }
+
+    items.push({
+      label: targetCount > 1 ? `Delete ${targetCount} cards` : "Delete",
+      danger: true,
+      action: () => handleDeleteCard(targetCards),
+      disabled: !hostedWorkspaceReady
+    });
+
+    setContextMenu({ x: event.clientX, y: event.clientY, items });
+  }
+
+  // --- Column resize ---
+
+  function getComputedColumnWidths() {
+    const header = headerRef.current;
+    if (!header) return null;
+    const cells = header.querySelectorAll(".users-table-header-cell");
+    const widths = [];
+    for (let i = 1; i < cells.length; i++) {
+      widths.push(cells[i].getBoundingClientRect().width);
+    }
+    return widths.length === cardTableColumns.length ? widths : null;
+  }
+
+  function getColumnMinWidth(colIndex) {
+    const header = headerRef.current;
+    if (!header) return 80;
+    const cells = header.querySelectorAll(".users-table-header-cell");
+    const cell = cells[colIndex + 1];
+    if (!cell) return 80;
+    const label = cell.querySelector(".users-table-header-label");
+    const canvas = document.createElement("canvas");
+    const ctx = canvas.getContext("2d");
+    ctx.font = "0.71rem -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif";
+    const labelW = label ? ctx.measureText(label.textContent || "").width : 30;
+    return Math.ceil(labelW + 57);
+  }
+
+  function handleColumnResizeStart(event, colIndex) {
+    event.preventDefault();
+    event.stopPropagation();
+    const startX = event.clientX;
+    let widths = columnWidths || getComputedColumnWidths();
+    if (!widths) return;
+    widths = [...widths];
+    const startWidth = widths[colIndex];
+
+    const minWidths = widths.map((_, i) => getColumnMinWidth(i));
+
+    function ensureViewportFill(w) {
+      const viewport = cardsTableViewportRef.current;
+      if (!viewport) return w;
+      const available = viewport.clientWidth - 36;
+      const total = w.reduce((a, b) => a + b, 0);
+      if (total < available) {
+        const result = [...w];
+        result[result.length - 1] += available - total;
+        return result;
+      }
+      return w;
+    }
+
+    function onMouseMove(moveEvent) {
+      const delta = moveEvent.clientX - startX;
+      widths[colIndex] = Math.max(minWidths[colIndex], startWidth + delta);
+      setColumnWidths(ensureViewportFill([...widths]));
+    }
+
+    function onMouseUp() {
+      document.removeEventListener("mousemove", onMouseMove);
+      document.removeEventListener("mouseup", onMouseUp);
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+      columnResizeRef.current = null;
+    }
+
+    document.body.style.cursor = "col-resize";
+    document.body.style.userSelect = "none";
+    columnResizeRef.current = true;
+    document.addEventListener("mousemove", onMouseMove);
+    document.addEventListener("mouseup", onMouseUp);
+  }
+
+  function handleColumnAutoFit(colIndex) {
+    let widths = columnWidths || getComputedColumnWidths();
+    if (!widths) return;
+    widths = [...widths];
+
+    const columnKey = cardTableColumns[colIndex]?.key;
+    if (!columnKey) return;
+
+    const canvas = document.createElement("canvas");
+    const ctx = canvas.getContext("2d");
+    ctx.font = "0.84rem -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif";
+
+    let maxWidth = 60;
+
+    const header = headerRef.current;
+    if (header) {
+      const headerCells = header.querySelectorAll(".users-table-header-cell");
+      if (headerCells[colIndex + 1]) {
+        const label = headerCells[colIndex + 1].querySelector(".users-table-header-label");
+        if (label) {
+          const textWidth = ctx.measureText(label.textContent || "").width;
+          maxWidth = Math.max(maxWidth, textWidth + 52);
+        }
+      }
+    }
+
+    for (const card of filteredCards) {
+      const value = getCellDisplayValue(card, columnKey);
+      const textWidth = ctx.measureText(value).width;
+      maxWidth = Math.max(maxWidth, textWidth + 24);
+    }
+
+    widths[colIndex] = Math.min(Math.ceil(maxWidth), 600);
+
+    const viewport = cardsTableViewportRef.current;
+    if (viewport) {
+      const available = viewport.clientWidth - 36;
+      const total = widths.reduce((a, b) => a + b, 0);
+      if (total < available) {
+        widths[widths.length - 1] += available - total;
+      }
+    }
+    setColumnWidths([...widths]);
+  }
+
+  // --- Paging ---
+
+  async function loadNextCardsPage() {
+    if (cardsPagingRequestRef.current || cardsLoadingInitial || cardsLoadingMore || !cardsHasMore || cardsFiltersActive) {
+      return;
+    }
+
+    cardsPagingRequestRef.current = true;
+
+    try {
+      const accessToken = await getAccessToken();
+      if (accessToken) {
+        await loadCards(accessToken, { append: true });
+      }
+    } catch (error) {
+      setCardsStatus(describeFetchFailure(error, "Hosted cards failed to load."));
+    } finally {
+      cardsPagingRequestRef.current = false;
+    }
+  }
+
+  useEffect(() => {
+    if (!cardsHasMore || cardsFiltersActive || cardsLoadingInitial || cardsLoadingMore || !hostedWorkspaceReady) {
+      return undefined;
+    }
+
+    const viewport = cardsTableViewportRef.current;
+    if (!viewport) {
+      return undefined;
+    }
+
+    function handleViewportScroll() {
+      const scrollTop = viewport.scrollTop || 0;
+      const scrollGate = cardsScrollGateRef.current;
+
+      if (!scrollGate.armed) {
+        if (scrollTop <= scrollGate.lastScrollTop) {
+          return;
+        }
+        scrollGate.armed = true;
+      }
+
+      scrollGate.lastScrollTop = scrollTop;
+      const viewportBottom = scrollTop + viewport.clientHeight;
+      const documentHeight = viewport.scrollHeight;
+
+      if (documentHeight - viewportBottom <= 220) {
+        loadNextCardsPage();
+      }
+    }
+
+    viewport.addEventListener("scroll", handleViewportScroll, { passive: true });
+    return () => viewport.removeEventListener("scroll", handleViewportScroll);
+  }, [hostedWorkspaceReady, cardsFiltersActive, cardsHasMore, cardsLoadingInitial, cardsLoadingMore, cardsNextOffset]);
+
+  // --- Header menu ---
+
+  function openCardHeaderOptions(event, columnKey) {
+    const buttonRect = event.currentTarget.getBoundingClientRect();
+    const menuWidth = 296;
+    const left = Math.max(16, Math.min(buttonRect.right - menuWidth, window.innerWidth - menuWidth - 16));
+    const top = Math.min(buttonRect.bottom + 8, window.innerHeight - 24);
+
+    setOpenCardHeaderMenu((current) => current?.key === columnKey ? null : { key: columnKey, left, top });
+  }
+
+  // --- Card CRUD ---
+
+  function openCardModal(mode, card = null) {
+    setCardModalMode(mode);
+    setCardSubmitError(null);
+
+    if (card) {
+      const nextForm = {
+        name: card.name || "",
+        user_id: card.user_id || "",
+        last_four: card.last_four || "",
+        cashback_rate: String(card.cashback_rate ?? "0"),
+        notes: card.notes || "",
+        is_active: Boolean(card.is_active)
+      };
+      setCardForm(nextForm);
+      setCardFormBaseline(nextForm);
+      setSelectedCardIds([card.id]);
+      setSelectionAnchorCardId(card.id);
+      return;
+    }
+
+    setCardForm(initialCardForm);
+    setCardFormBaseline(initialCardForm);
+  }
+
+  async function submitCardModal() {
+    const accessToken = await getAccessToken();
+    if (!accessToken) {
+      setCardSubmitError("Google sign-in is required before managing hosted cards.");
+      return;
+    }
+
+    if (!apiBaseUrl) {
+      setCardSubmitError("Set VITE_API_BASE_URL to enable hosted cards.");
+      return;
+    }
+
+    const payload = {
+      name: cardForm.name,
+      user_id: cardForm.user_id,
+      last_four: cardForm.last_four || null,
+      cashback_rate: parseFloat(cardForm.cashback_rate) || 0.0,
+      notes: cardForm.notes || null,
+      ...(cardModalMode === "edit" ? { is_active: cardForm.is_active } : {})
+    };
+    const url = cardModalMode === "edit" && selectedCard
+      ? `${apiBaseUrl}/v1/workspace/cards/${selectedCard.id}`
+      : `${apiBaseUrl}/v1/workspace/cards`;
+    const method = cardModalMode === "edit" ? "PATCH" : "POST";
+
+    try {
+      const response = await fetch(url, {
+        method,
+        headers: {
+          ...authHeaders(accessToken),
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify(payload)
+      });
+      const data = await response.json();
+
+      if (!response.ok) {
+        setCardSubmitError(data.detail || `Hosted cards save failed (${response.status}).`);
+        return;
+      }
+
+      setCards((current) => mergeCardsById(current, [data]));
+      setCardsTotalCount((current) => (method === "POST" && current !== null ? current + 1 : current));
+      setSelectedCardIds([data.id]);
+      setSelectionAnchorCardId(data.id);
+      setCardsStatus("Hosted cards ready.");
+      closeCardModalImmediately();
+    } catch (error) {
+      setCardSubmitError(describeFetchFailure(error, "Hosted cards save failed."));
+    }
+  }
+
+  async function handleCardsRefresh() {
+    try {
+      const accessToken = await getAccessToken();
+      clearCardSelection();
+      await Promise.all([loadCards(accessToken, { append: false }), loadUsers(accessToken)]);
+    } catch (error) {
+      setCardsStatus(describeFetchFailure(error, "Hosted cards failed to load."));
+    }
+  }
+
+  async function handleDeleteCard(cardsToDelete = selectedCards) {
+    const accessToken = await getAccessToken();
+    if (!cardsToDelete.length || !accessToken) {
+      setCardsStatus("Google sign-in is required before managing hosted cards.");
+      return;
+    }
+    if (!apiBaseUrl) {
+      setCardsStatus("Set VITE_API_BASE_URL to enable hosted cards.");
+      return;
+    }
+    const prompt = cardsToDelete.length === 1
+      ? `Delete card '${cardsToDelete[0].name}'? This cannot be undone.`
+      : `Delete ${cardsToDelete.length} cards? This cannot be undone.`;
+
+    openConfirmation({
+      title: cardsToDelete.length === 1 ? "Delete card?" : "Delete cards?",
+      message: prompt,
+      confirmLabel: cardsToDelete.length === 1 ? "Delete Card" : `Delete ${cardsToDelete.length} Cards`,
+      cancelLabel: "Cancel",
+      tone: "danger",
+      onConfirm: async () => {
+        setConfirmationState(null);
+
+        try {
+          setCardsStatus(`Deleting ${cardsToDelete.length} hosted ${cardsToDelete.length === 1 ? "card" : "cards"}...`);
+
+          const response = await fetch(`${apiBaseUrl}/v1/workspace/cards/batch-delete`, {
+            method: "POST",
+            headers: {
+              ...authHeaders(accessToken),
+              "Content-Type": "application/json"
+            },
+            body: JSON.stringify({
+              card_ids: cardsToDelete.map((card) => card.id)
+            })
+          });
+
+          if (!response.ok) {
+            const detail = response.headers.get("content-type")?.includes("application/json")
+              ? (await response.json()).detail
+              : `Hosted cards delete failed (${response.status}).`;
+            setCardsStatus(detail || `Hosted cards delete failed (${response.status}).`);
+            return;
+          }
+
+          const deletedIds = new Set(cardsToDelete.map((card) => card.id));
+          setCards((current) => current.filter((candidate) => !deletedIds.has(candidate.id)));
+          setCardsTotalCount((current) => (current === null ? null : Math.max(0, current - cardsToDelete.length)));
+          clearCardSelection();
+          closeCardModalImmediately();
+          setCardsStatus("Hosted cards ready.");
+        } catch (error) {
+          setCardsStatus(describeFetchFailure(error, "Hosted cards delete failed."));
+        }
+      }
+    });
+  }
+
+  // --- Render ---
+
+  return (
+    <section className="workspace-panel setup-panel users-page" aria-label="Setup Cards">
+      <div className="users-surface">
+        <div className="users-toolbar">
+          <div className="users-toolbar-top">
+            <nav className="users-breadcrumb" aria-label="Breadcrumb">
+              <span className="breadcrumb-segment">Setup</span>
+              <span className="breadcrumb-separator" aria-hidden="true">&rsaquo;</span>
+              <h2 className="breadcrumb-segment current" title="Manage workspace cards, inspect individual records, and export the current filtered view.">Cards</h2>
+            </nav>
+            <div className="toolbar-row wrap-toolbar users-toolbar-actions">
+              <button className="primary-button" type="button" onClick={() => openCardModal("create")} disabled={!hostedWorkspaceReady}>Add Card</button>
+              <button className="ghost-button" type="button" onClick={() => selectedCard && openCardModal("view", selectedCard)} disabled={!hostedWorkspaceReady || selectedCardIds.length !== 1}>View</button>
+              <button className="ghost-button" type="button" onClick={() => selectedCard && openCardModal("edit", selectedCard)} disabled={!hostedWorkspaceReady || selectedCardIds.length !== 1}>Edit</button>
+              <button className="ghost-button" type="button" onClick={() => handleDeleteCard()} disabled={!hostedWorkspaceReady || !selectedCardIds.length}>Delete</button>
+              <button className="ghost-button" type="button" onClick={() => setExportModalOpen(true)} disabled={!filteredCards.length}>Export CSV</button>
+              <button className="ghost-button" type="button" onClick={handleCardsRefresh} disabled={!hostedWorkspaceReady}>Refresh</button>
+            </div>
+          </div>
+          <div className="users-search-bar">
+            <label className="users-search-field" htmlFor="cards-search-input">
+              <span className="users-search-icon" aria-hidden="true"><Icon name="search" className="app-icon" /></span>
+              <input
+                id="cards-search-input"
+                className="text-input hero-search-input"
+                type="text"
+                placeholder="Search cards..."
+                value={cardsSearch}
+                disabled={!hostedWorkspaceReady}
+                onChange={(event) => setCardsSearch(event.target.value)}
+              />
+            </label>
+            <div className="toolbar-row users-search-actions">
+              <button className="ghost-button" type="button" onClick={() => { setCardsSearch(""); clearCardSelection(); }}>Clear Search</button>
+              <button className="ghost-button" type="button" onClick={clearAllCardFilters}>Clear All Filters</button>
+            </div>
+          </div>
+        </div>
+
+        <div className="users-table-scroll-area table-viewport" ref={cardsTableViewportRef} onScroll={(e) => setShowBackToTop(e.currentTarget.scrollTop > 120)}>
+          <div className="users-table-header" ref={headerRef} style={columnWidths ? { gridTemplateColumns: `36px ${columnWidths.map((w) => `${w}px`).join(" ")}`, minWidth: `${36 + columnWidths.reduce((a, b) => a + b, 0)}px` } : { gridTemplateColumns: "36px 20% 16% 10% 12% 10% 1fr" }}>
+            <div className="users-table-header-cell users-checkbox-cell">
+              <input
+                type="checkbox"
+                className="row-select-checkbox"
+                aria-label="Select all rows"
+                checked={filteredCards.length > 0 && selectedCardIds.length === filteredCards.length}
+                ref={(el) => { if (el) el.indeterminate = selectedCardIds.length > 0 && selectedCardIds.length < filteredCards.length; }}
+                onChange={() => {
+                  if (selectedCardIds.length === filteredCards.length) {
+                    setSelectedCardIds([]);
+                    setSelectionAnchorCardId(null);
+                    cardNavCursorRef.current = null;
+                  } else {
+                    setSelectedCardIds(filteredCards.map((c) => c.id));
+                    setSelectionAnchorCardId(filteredCards[0]?.id ?? null);
+                    cardNavCursorRef.current = filteredCards[filteredCards.length - 1]?.id ?? null;
+                  }
+                }}
+                disabled={!filteredCards.length}
+              />
+            </div>
+            {cardTableColumns.map((column, colIndex) => {
+              const sortDirection = cardsSort.column === column.key ? cardsSort.direction : null;
+              const filterValues = cardColumnFilters[column.key];
+              return (
+                <div key={column.key} className={`users-table-header-cell${selectedColumnKeys.has(column.key) ? " selected-column" : ""}`} onClick={(event) => {
+                  setSelectedCardIds([]);
+                  setSelectionAnchorCardId(null);
+
+                  const columnKeys = cardTableColumns.map((c) => c.key);
+                  let nextCols;
+                  if (event.shiftKey && selectedColumnKeys.size) {
+                    const lastKey = [...selectedColumnKeys].pop();
+                    const lastIdx = columnKeys.indexOf(lastKey);
+                    const curIdx = columnKeys.indexOf(column.key);
+                    const [start, end] = lastIdx < curIdx ? [lastIdx, curIdx] : [curIdx, lastIdx];
+                    nextCols = new Set(columnKeys.slice(start, end + 1));
+                  } else if (event.metaKey || event.ctrlKey) {
+                    nextCols = new Set(selectedColumnKeys);
+                    if (nextCols.has(column.key)) nextCols.delete(column.key); else nextCols.add(column.key);
+                  } else {
+                    nextCols = selectedColumnKeys.size === 1 && selectedColumnKeys.has(column.key) ? new Set() : new Set([column.key]);
+                  }
+                  setSelectedColumnKeys(nextCols);
+
+                  const next = new Set();
+                  for (const card of filteredCards) {
+                    for (const col of nextCols) {
+                      next.add(`${card.id}:${col}`);
+                    }
+                  }
+                  setSelectedCells(next);
+                  cellAnchorRef.current = null;
+                }} onContextMenu={(event) => { event.preventDefault(); openCardHeaderOptions(event, column.key); }}>
+                  <span className="users-table-header-label">{column.label}</span>
+                  <button
+                    className={sortDirection || filterValues.length ? "table-sort-button active" : "table-sort-button"}
+                    type="button"
+                    aria-label={`${column.label} options`}
+                    onClick={(event) => { event.stopPropagation(); openCardHeaderOptions(event, column.key); }}
+                  >
+                    <span className="table-sort-indicator" aria-hidden="true">
+                      {sortDirection === "asc"
+                        ? "\u2191"
+                        : sortDirection === "desc"
+                          ? "\u2193"
+                          : filterValues.length
+                            ? filterValues.length
+                            : <Icon name="filterMenu" className="app-icon table-filter-icon" />}
+                    </span>
+                  </button>
+
+                  {openCardHeaderMenu?.key === column.key ? (
+                    <UserHeaderFilterMenu
+                        column={column}
+                        options={cardFilterOptions[column.key]}
+                        selectedValues={filterValues}
+                        sortDirection={sortDirection}
+                        onClearFilter={() => {
+                          setCardColumnFilters((current) => ({ ...current, [column.key]: [] }));
+                          setOpenCardHeaderMenu(null);
+                        }}
+                        onSortAsc={() => {
+                          setCardsSort({ column: column.key, direction: "asc" });
+                          setOpenCardHeaderMenu(null);
+                        }}
+                        onSortDesc={() => {
+                          setCardsSort({ column: column.key, direction: "desc" });
+                          setOpenCardHeaderMenu(null);
+                        }}
+                        onClearSort={() => {
+                          setCardsSort({ column: null, direction: "asc" });
+                          setOpenCardHeaderMenu(null);
+                        }}
+                        onApplyFilter={(values) => {
+                          setCardColumnFilters((current) => ({ ...current, [column.key]: values }));
+                        }}
+                      onClose={() => setOpenCardHeaderMenu(null)}
+                      style={openCardHeaderMenu}
+                    />
+                  ) : null}
+                  <div
+                    className="column-resize-handle"
+                    onMouseDown={(event) => handleColumnResizeStart(event, colIndex)}
+                    onDoubleClick={(event) => { event.stopPropagation(); handleColumnAutoFit(colIndex); }}
+                    onClick={(event) => event.stopPropagation()}
+                  />
+                </div>
+              );
+            })}
+          </div>
+
+          <table className="data-table users-data-table" style={columnWidths ? { tableLayout: "fixed" } : undefined}>
+            <colgroup>
+              <col style={{ width: "36px" }} />
+              {columnWidths
+                ? columnWidths.map((w, i) => <col key={i} style={{ width: `${w}px` }} />)
+                : <>
+                    <col style={{ width: "20%" }} />
+                    <col style={{ width: "16%" }} />
+                    <col style={{ width: "10%" }} />
+                    <col style={{ width: "12%" }} />
+                    <col style={{ width: "10%" }} />
+                    <col />
+                  </>
+              }
+            </colgroup>
+            <tbody>
+              {filteredCards.length ? filteredCards.map((card) => (
+                <tr
+                  key={card.id}
+                  className={selectedCardIds.includes(card.id) ? "selected-row" : undefined}
+                  aria-selected={selectedCardIds.includes(card.id)}
+                  onMouseDown={(event) => {
+                    if (event.shiftKey || event.metaKey || event.ctrlKey) {
+                      event.preventDefault();
+                    }
+                  }}
+                  onClick={(event) => handleCardRowSelection(event, card.id)}
+                  onDoubleClick={() => openCardModal("view", card)}
+                  onContextMenu={(event) => handleTableContextMenu(event, card)}
+                >
+                  <td className="row-checkbox-cell" onClick={(event) => event.stopPropagation()}>
+                    <input
+                      type="checkbox"
+                      className="row-select-checkbox"
+                      aria-label={`Select ${card.name}`}
+                      checked={selectedCardIds.includes(card.id)}
+                      onChange={() => {
+                        setSelectedCardIds((current) =>
+                          current.includes(card.id)
+                            ? current.filter((id) => id !== card.id)
+                            : [...current, card.id]
+                        );
+                        setSelectionAnchorCardId(card.id);
+                      }}
+                    />
+                  </td>
+                  <td data-col="name" className={selectedCells.has(`${card.id}:name`) ? "selected-cell" : selectedColumnKeys.has("name") ? "selected-column-cell" : undefined} onClick={(event) => { if (handleCellClick(event, card.id, "name")) return; }}><HighlightMatch text={card.name} query={cardsSearch} /></td>
+                  <td data-col="user_name" className={selectedCells.has(`${card.id}:user_name`) ? "selected-cell" : selectedColumnKeys.has("user_name") ? "selected-column-cell" : undefined} onClick={(event) => { if (handleCellClick(event, card.id, "user_name")) return; }}>{card.user_name || "\u2014"}</td>
+                  <td data-col="last_four" className={selectedCells.has(`${card.id}:last_four`) ? "selected-cell" : selectedColumnKeys.has("last_four") ? "selected-column-cell" : undefined} onClick={(event) => { if (handleCellClick(event, card.id, "last_four")) return; }}>{card.last_four || "\u2014"}</td>
+                  <td data-col="cashback_rate" className={selectedCells.has(`${card.id}:cashback_rate`) ? "selected-cell" : selectedColumnKeys.has("cashback_rate") ? "selected-column-cell" : undefined} onClick={(event) => { if (handleCellClick(event, card.id, "cashback_rate")) return; }}>{getCellDisplayValue(card, "cashback_rate")}</td>
+                  <td data-col="status" className={selectedCells.has(`${card.id}:status`) ? "selected-cell" : selectedColumnKeys.has("status") ? "selected-column-cell" : undefined} onClick={(event) => { if (handleCellClick(event, card.id, "status")) return; }}>
+                    <span className={card.is_active ? "status-chip active" : "status-chip inactive"}>
+                      {card.is_active ? "Active" : "Inactive"}
+                    </span>
+                  </td>
+                  <td data-col="notes" className={`notes-cell${selectedCells.has(`${card.id}:notes`) ? " selected-cell" : selectedColumnKeys.has("notes") ? " selected-column-cell" : ""}`} onClick={(event) => { if (handleCellClick(event, card.id, "notes")) return; }} title={(card.notes || "").length > 100 ? card.notes : undefined}><HighlightMatch text={(card.notes || "").slice(0, 100) || "-"} query={cardsSearch} /></td>
+                </tr>
+              )) : (
+                <tr>
+                  <td colSpan={cardTableColumns.length + 1} className="empty-state-cell">
+                    <div className="empty-state-graphic">
+                      <svg width="64" height="64" viewBox="0 0 64 64" fill="none" aria-hidden="true">
+                        <rect x="8" y="16" width="48" height="36" rx="4" stroke="rgba(255,255,255,0.12)" strokeWidth="1.5" />
+                        <line x1="8" y1="28" x2="56" y2="28" stroke="rgba(255,255,255,0.08)" strokeWidth="1" />
+                        <line x1="8" y1="38" x2="56" y2="38" stroke="rgba(255,255,255,0.06)" strokeWidth="1" />
+                        <line x1="28" y1="16" x2="28" y2="52" stroke="rgba(255,255,255,0.06)" strokeWidth="1" />
+                        <circle cx="32" cy="40" r="8" stroke="rgba(126,195,172,0.25)" strokeWidth="1.5" />
+                        <line x1="38" y1="46" x2="44" y2="52" stroke="rgba(126,195,172,0.25)" strokeWidth="1.5" strokeLinecap="round" />
+                      </svg>
+                      <p>{hostedWorkspaceReady
+                        ? (cardsSearch
+                          ? <>No results for &ldquo;{cardsSearch}&rdquo;. <button className="inline-link-button" type="button" onClick={() => { setCardsSearch(""); clearCardSelection(); }}>Clear search</button></>
+                          : "No cards match the current view.")
+                        : "Connect the hosted workspace to load cards."
+                      }</p>
+                    </div>
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+
+        <div className="users-summary-rail users-summary-rail-bottom" aria-label="Card summary">
+          <div className="users-page-metrics">
+            <span className="users-metric-chip">{filteredCardCount} shown</span>
+            <span className="users-metric-chip subdued">{totalCardCount} total</span>
+            {selectedCardIds.length ? <span className="users-metric-chip accent">{selectedCardIds.length} selected</span> : null}
+            {cardsFiltersActive ? <span className="users-metric-chip subdued">Filtered view</span> : null}
+            {selectedCells.size ? (() => {
+              const cellValues = [];
+              for (const cellId of selectedCells) {
+                const [cardId, colKey] = cellId.split(":");
+                const card = filteredCards.find((c) => c.id === cardId);
+                if (card) cellValues.push(getCellDisplayValue(card, colKey));
+              }
+              const stats = computeCellStats(cellValues);
+              return (
+                <>
+                  <span className="users-metric-chip column-agg">Count: {stats.count}</span>
+                  {stats.numericCount > 0 ? (
+                    <>
+                      <span className="users-metric-chip column-agg">Sum: {stats.sum.toLocaleString(undefined, { minimumFractionDigits: 0, maximumFractionDigits: 2 })}</span>
+                      <span className="users-metric-chip column-agg">Avg: {stats.avg.toLocaleString(undefined, { minimumFractionDigits: 0, maximumFractionDigits: 2 })}</span>
+                      <span className="users-metric-chip column-agg">Min: {stats.min}</span>
+                      <span className="users-metric-chip column-agg">Max: {stats.max}</span>
+                    </>
+                  ) : null}
+                  {stats.numericCount === 0 ? <span className="users-metric-chip column-agg">{new Set(cellValues).size} unique</span> : null}
+                </>
+              );
+            })() : null}
+          </div>
+          <div className="users-summary-actions">
+            {cardsHasMore && !cardsFiltersActive ? (
+              <button className="ghost-button" type="button" onClick={loadNextCardsPage} disabled={cardsLoadingMore}>
+                {cardsLoadingMore ? "Loading..." : "Load More Cards"}
+              </button>
+            ) : null}
+          </div>
+        </div>
+
+        <button
+          className={`back-to-top-button${showBackToTop ? " visible" : ""}`}
+          type="button"
+          aria-label="Back to top"
+          onClick={() => {
+            const viewport = cardsTableViewportRef.current;
+            if (viewport) viewport.scrollTo({ top: 0, behavior: "smooth" });
+          }}
+        >
+          &uarr;
+        </button>
+      </div>
+
+      {contextMenu ? (
+        <TableContextMenu
+          position={{ x: contextMenu.x, y: contextMenu.y }}
+          items={contextMenu.items}
+          onClose={() => setContextMenu(null)}
+        />
+      ) : null}
+
+      {exportModalOpen ? (
+        <ExportModal
+          filteredUsers={filteredCards}
+          selectedUsers={selectedCards}
+          selectedCells={selectedCells}
+          allColumns={cardTableColumns}
+          onExport={(data, columns) => downloadCardsCsv(data, columns)}
+          onClose={() => setExportModalOpen(false)}
+        />
+      ) : null}
+
+      {confirmationState ? (
+        <ConfirmationModal
+          title={confirmationState.title}
+          message={confirmationState.message}
+          confirmLabel={confirmationState.confirmLabel}
+          cancelLabel={confirmationState.cancelLabel}
+          tone={confirmationState.tone}
+          onCancel={() => setConfirmationState(null)}
+          onConfirm={confirmationState.onConfirm}
+        />
+      ) : null}
+
+      {cardModalMode ? (
+        <CardModal
+          mode={cardModalMode}
+          card={selectedCard}
+          form={cardForm}
+          setForm={setCardForm}
+          submitError={cardSubmitError}
+          suggestions={cardSuggestions}
+          users={users}
+          onClose={requestCloseCardModal}
+          onRequestEdit={() => selectedCard && openCardModal("edit", selectedCard)}
+          onRequestDelete={() => selectedCard && handleDeleteCard([selectedCard])}
+          onSubmit={submitCardModal}
+        />
+      ) : null}
+    </section>
+  );
+}

--- a/web/src/components/CardsTab/cardsConstants.js
+++ b/web/src/components/CardsTab/cardsConstants.js
@@ -1,0 +1,29 @@
+export const initialCardForm = {
+  name: "",
+  user_id: "",
+  last_four: "",
+  cashback_rate: "",
+  notes: "",
+  is_active: true
+};
+
+export const initialCardColumnFilters = {
+  name: [],
+  user_name: [],
+  last_four: [],
+  cashback_rate: [],
+  status: [],
+  notes: []
+};
+
+export const cardTableColumns = [
+  { key: "name", label: "Name", sortable: true },
+  { key: "user_name", label: "User", sortable: true },
+  { key: "last_four", label: "Last Four", sortable: true },
+  { key: "cashback_rate", label: "Cashback %", sortable: true },
+  { key: "status", label: "Status", sortable: true },
+  { key: "notes", label: "Notes", sortable: true }
+];
+
+export const cardsPageSize = 100;
+export const cardsFallbackPageSize = 500;

--- a/web/src/components/CardsTab/cardsUtils.js
+++ b/web/src/components/CardsTab/cardsUtils.js
@@ -1,0 +1,195 @@
+import { cardTableColumns } from "./cardsConstants";
+
+export function normalizeCardForm(form) {
+  return {
+    name: form.name || "",
+    user_id: form.user_id || "",
+    last_four: form.last_four || "",
+    cashback_rate: String(form.cashback_rate ?? ""),
+    notes: form.notes || "",
+    is_active: Boolean(form.is_active)
+  };
+}
+
+export function isTextEntryElement(element) {
+  if (!(element instanceof HTMLElement)) {
+    return false;
+  }
+
+  if (element instanceof HTMLTextAreaElement) {
+    return !element.readOnly && !element.disabled;
+  }
+
+  if (element instanceof HTMLInputElement) {
+    const textLikeTypes = new Set(["text", "search", "email", "url", "tel", "password", "number"]);
+    return textLikeTypes.has(element.type) && !element.readOnly && !element.disabled;
+  }
+
+  return element.isContentEditable;
+}
+
+export function parseNumericValue(text) {
+  if (!text || typeof text !== "string") return null;
+  const trimmed = text.trim();
+  if (!trimmed || ["n/a", "na", "-", "\u2014", "\u2013"].includes(trimmed.toLowerCase())) return null;
+  let cleaned = trimmed.replace(/[$\u20ac\u00a3\u00a5,\s]/g, "");
+  if (cleaned.startsWith("(") && cleaned.endsWith(")")) cleaned = "-" + cleaned.slice(1, -1);
+  if (cleaned.endsWith("%")) cleaned = cleaned.slice(0, -1);
+  const num = Number(cleaned);
+  return Number.isFinite(num) ? num : null;
+}
+
+export function computeCellStats(values) {
+  const count = values.length;
+  const nums = values.map(parseNumericValue).filter((v) => v !== null);
+  if (!nums.length) return { count, numericCount: 0, sum: 0, avg: 0, min: null, max: null };
+  const sum = nums.reduce((a, b) => a + b, 0);
+  return {
+    count,
+    numericCount: nums.length,
+    sum,
+    avg: sum / nums.length,
+    min: Math.min(...nums),
+    max: Math.max(...nums)
+  };
+}
+
+export function getCellDisplayValue(card, columnKey) {
+  if (columnKey === "status") return card.is_active ? "Active" : "Inactive";
+  if (columnKey === "cashback_rate") {
+    const rate = Number(card.cashback_rate);
+    return Number.isFinite(rate) ? rate.toFixed(2) + "%" : "0.00%";
+  }
+  if (columnKey === "user_name") return card.user_name || "\u2014";
+  if (columnKey === "last_four") return card.last_four || "\u2014";
+  return String(card[columnKey] || "");
+}
+
+export function downloadCardsCsv(cards, columns) {
+  const activeColumns = columns || cardTableColumns;
+  const rows = [
+    activeColumns.map((c) => c.label),
+    ...cards.map((card) => activeColumns.map((c) => getCellDisplayValue(card, c.key)))
+  ];
+  const csv = rows
+    .map((row) => row.map((value) => `"${String(value).replaceAll('"', '""')}"`).join(","))
+    .join("\n");
+  const blob = new Blob([csv], { type: "text/csv;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = `cards_${new Date().toISOString().slice(0, 10)}.csv`;
+  link.click();
+  URL.revokeObjectURL(url);
+}
+
+export function getCardColumnValue(card, columnKey) {
+  if (columnKey === "status") return card.is_active ? "Active" : "Inactive";
+  if (columnKey === "cashback_rate") {
+    const rate = Number(card.cashback_rate);
+    return Number.isFinite(rate) ? rate.toFixed(2) + "%" : "0.00%";
+  }
+  if (columnKey === "user_name") return card.user_name || "\u2014";
+  if (columnKey === "last_four") return card.last_four || "\u2014";
+  return String(card[columnKey] || "");
+}
+
+export function buildCardFilterOptions(cards, columnKey) {
+  const values = [...new Set(cards.map((card) => getCardColumnValue(card, columnKey)))].sort((left, right) => left.localeCompare(right, undefined, { sensitivity: "base" }));
+
+  return values.map((value) => ({
+    value,
+    label: value || "(Blank)",
+    path: [value || "(Blank)"],
+    searchValue: value
+  }));
+}
+
+export function collectLeafValues(nodes) {
+  return nodes.flatMap((node) => (node.children?.length ? collectLeafValues(node.children) : [node.value]));
+}
+
+export function buildFilterTree(options) {
+  const tree = [];
+
+  options.forEach((option) => {
+    let currentLevel = tree;
+    option.path.forEach((segment, index) => {
+      const isLeaf = index === option.path.length - 1;
+      const nodeId = isLeaf
+        ? `leaf:${option.value}`
+        : `group:${option.path.slice(0, index + 1).join("/")}`;
+      let node = currentLevel.find((entry) => entry.id === nodeId);
+
+      if (!node) {
+        node = {
+          id: nodeId,
+          label: isLeaf ? option.label : segment,
+          value: isLeaf ? option.value : null,
+          children: []
+        };
+        currentLevel.push(node);
+      }
+
+      currentLevel = node.children;
+    });
+  });
+
+  return tree;
+}
+
+export function mergeCardsById(existingCards, incomingCards) {
+  const nextCards = [...existingCards];
+  const existingIds = new Set(existingCards.map((card) => card.id));
+
+  incomingCards.forEach((card) => {
+    if (existingIds.has(card.id)) {
+      const existingIndex = nextCards.findIndex((candidate) => candidate.id === card.id);
+      nextCards[existingIndex] = card;
+      return;
+    }
+    nextCards.push(card);
+  });
+
+  return nextCards.sort((left, right) => left.name.localeCompare(right.name, undefined, { sensitivity: "base" }));
+}
+
+export function filterTreeNodes(nodes, searchText) {
+  if (!searchText) {
+    return nodes;
+  }
+
+  const normalizedSearch = searchText.trim().toLowerCase();
+
+  return nodes.flatMap((node) => {
+    if (!node.children.length) {
+      return node.label.toLowerCase().includes(normalizedSearch) ? [node] : [];
+    }
+
+    const filteredChildren = filterTreeNodes(node.children, normalizedSearch);
+    if (node.label.toLowerCase().includes(normalizedSearch) || filteredChildren.length) {
+      return [{ ...node, children: filteredChildren }];
+    }
+
+    return [];
+  });
+}
+
+export function getNodeSelectionState(node, selectedValues) {
+  if (!node.children.length) {
+    return selectedValues.has(node.value) ? "checked" : "unchecked";
+  }
+
+  const descendantValues = collectLeafValues(node.children);
+  const selectedCount = descendantValues.filter((value) => selectedValues.has(value)).length;
+
+  if (!selectedCount) {
+    return "unchecked";
+  }
+
+  if (selectedCount === descendantValues.length) {
+    return "checked";
+  }
+
+  return "mixed";
+}

--- a/web/src/components/common/TypeaheadSelect.jsx
+++ b/web/src/components/common/TypeaheadSelect.jsx
@@ -1,0 +1,172 @@
+import { useEffect, useRef, useState } from "react";
+
+/**
+ * Themed typeahead select with keyboard navigation and autocomplete filtering.
+ * Replaces native <select> for cross-entity FK dropdowns.
+ */
+export default function TypeaheadSelect({
+  id,
+  options,
+  value,
+  onChange,
+  placeholder = "Search...",
+  disabled = false,
+  invalid = false
+}) {
+  const [inputText, setInputText] = useState("");
+  const [open, setOpen] = useState(false);
+  const [highlightIndex, setHighlightIndex] = useState(-1);
+  const containerRef = useRef(null);
+  const inputRef = useRef(null);
+  const listRef = useRef(null);
+
+  // Sync display text when value changes externally
+  useEffect(() => {
+    if (!open) {
+      const selected = options.find((opt) => opt.value === value);
+      setInputText(selected ? selected.label : "");
+    }
+  }, [value, options, open]);
+
+  const filtered = inputText.trim()
+    ? options.filter((opt) =>
+        opt.label.toLowerCase().includes(inputText.trim().toLowerCase())
+      )
+    : options;
+
+  function selectOption(opt) {
+    onChange(opt.value);
+    setInputText(opt.label);
+    setOpen(false);
+    setHighlightIndex(-1);
+    inputRef.current?.blur();
+  }
+
+  function handleInputChange(event) {
+    setInputText(event.target.value);
+    setHighlightIndex(-1);
+    if (!open) setOpen(true);
+  }
+
+  function handleInputFocus() {
+    if (!disabled) {
+      setOpen(true);
+      setHighlightIndex(-1);
+    }
+  }
+
+  function handleInputKeyDown(event) {
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      setHighlightIndex((current) => Math.min(current + 1, filtered.length - 1));
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault();
+      setHighlightIndex((current) => Math.max(current - 1, 0));
+    } else if (event.key === "Enter") {
+      event.preventDefault();
+      if (highlightIndex >= 0 && highlightIndex < filtered.length) {
+        selectOption(filtered[highlightIndex]);
+      }
+    } else if (event.key === "Escape") {
+      event.stopPropagation();
+      setOpen(false);
+      const selected = options.find((opt) => opt.value === value);
+      setInputText(selected ? selected.label : "");
+      inputRef.current?.blur();
+    } else if (event.key === "Tab") {
+      setOpen(false);
+      const selected = options.find((opt) => opt.value === value);
+      setInputText(selected ? selected.label : "");
+    }
+  }
+
+  function handleInputBlur(event) {
+    // Delay close so click on option can fire
+    requestAnimationFrame(() => {
+      if (containerRef.current && !containerRef.current.contains(document.activeElement)) {
+        setOpen(false);
+        const selected = options.find((opt) => opt.value === value);
+        setInputText(selected ? selected.label : "");
+      }
+    });
+  }
+
+  // Scroll highlighted item into view
+  useEffect(() => {
+    if (highlightIndex >= 0 && listRef.current) {
+      const item = listRef.current.children[highlightIndex];
+      if (item) item.scrollIntoView({ block: "nearest" });
+    }
+  }, [highlightIndex]);
+
+  // Close on outside click
+  useEffect(() => {
+    if (!open) return undefined;
+    function handlePointerDown(event) {
+      if (containerRef.current && !containerRef.current.contains(event.target)) {
+        setOpen(false);
+        const selected = options.find((opt) => opt.value === value);
+        setInputText(selected ? selected.label : "");
+      }
+    }
+    document.addEventListener("mousedown", handlePointerDown);
+    return () => document.removeEventListener("mousedown", handlePointerDown);
+  }, [open, options, value]);
+
+  return (
+    <div className="typeahead-select" ref={containerRef}>
+      <input
+        id={id}
+        ref={inputRef}
+        className={`text-input typeahead-input${invalid ? " invalid" : ""}`}
+        type="text"
+        autoComplete="off"
+        placeholder={placeholder}
+        value={inputText}
+        disabled={disabled}
+        onChange={handleInputChange}
+        onFocus={handleInputFocus}
+        onBlur={handleInputBlur}
+        onKeyDown={handleInputKeyDown}
+        role="combobox"
+        aria-expanded={open}
+        aria-autocomplete="list"
+        aria-controls={`${id}-listbox`}
+        aria-activedescendant={highlightIndex >= 0 ? `${id}-opt-${highlightIndex}` : undefined}
+      />
+      <span className="typeahead-chevron" aria-hidden="true">
+        {open ? "\u25B4" : "\u25BE"}
+      </span>
+      {open && filtered.length > 0 ? (
+        <ul
+          id={`${id}-listbox`}
+          ref={listRef}
+          className="typeahead-dropdown"
+          role="listbox"
+        >
+          {filtered.map((opt, idx) => (
+            <li
+              key={opt.value}
+              id={`${id}-opt-${idx}`}
+              className={`typeahead-option${idx === highlightIndex ? " highlighted" : ""}${opt.value === value ? " selected" : ""}`}
+              role="option"
+              aria-selected={opt.value === value}
+              onMouseDown={(event) => {
+                event.preventDefault();
+                selectOption(opt);
+              }}
+              onMouseEnter={() => setHighlightIndex(idx)}
+            >
+              {opt.label}
+            </li>
+          ))}
+        </ul>
+      ) : null}
+      {open && filtered.length === 0 ? (
+        <ul id={`${id}-listbox`} className="typeahead-dropdown" role="listbox">
+          <li className="typeahead-option typeahead-no-results">No matching users</li>
+        </ul>
+      ) : null}
+    </div>
+  );
+}

--- a/web/src/components/common/TypeaheadSelect.jsx
+++ b/web/src/components/common/TypeaheadSelect.jsx
@@ -1,8 +1,9 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 /**
- * Themed typeahead select with keyboard navigation and autocomplete filtering.
- * Replaces native <select> for cross-entity FK dropdowns.
+ * Themed typeahead select with inline ghost-text completion, Tab/Enter commit,
+ * and prefix-first matching. Mirrors the desktop app's QComboBox + QCompleter
+ * behavior (InlineCompletion + MatchStartsWith + CompleterEventFilter).
  */
 export default function TypeaheadSelect({
   id,
@@ -15,12 +16,13 @@ export default function TypeaheadSelect({
 }) {
   const [inputText, setInputText] = useState("");
   const [open, setOpen] = useState(false);
-  const [highlightIndex, setHighlightIndex] = useState(-1);
+  const [highlightIndex, setHighlightIndex] = useState(0);
   const containerRef = useRef(null);
   const inputRef = useRef(null);
   const listRef = useRef(null);
+  const committingRef = useRef(false);
 
-  // Sync display text when value changes externally
+  // Sync display text when value changes externally (and dropdown is closed)
   useEffect(() => {
     if (!open) {
       const selected = options.find((opt) => opt.value === value);
@@ -28,63 +30,120 @@ export default function TypeaheadSelect({
     }
   }, [value, options, open]);
 
-  const filtered = inputText.trim()
-    ? options.filter((opt) =>
-        opt.label.toLowerCase().includes(inputText.trim().toLowerCase())
-      )
-    : options;
+  // Filter & sort: prefix matches first, then contains matches
+  const filtered = useMemo(() => {
+    const query = inputText.trim().toLowerCase();
+    if (!query) return options;
 
-  function selectOption(opt) {
+    const prefixMatches = [];
+    const containsMatches = [];
+
+    for (const opt of options) {
+      const label = opt.label.toLowerCase();
+      if (label.startsWith(query)) {
+        prefixMatches.push(opt);
+      } else if (label.includes(query)) {
+        containsMatches.push(opt);
+      }
+    }
+
+    return [...prefixMatches, ...containsMatches];
+  }, [inputText, options]);
+
+  // Best prefix match for ghost text — the first option whose label starts with typed text
+  const ghostText = useMemo(() => {
+    const query = inputText.trim().toLowerCase();
+    if (!query) return "";
+    const match = options.find((opt) => opt.label.toLowerCase().startsWith(query));
+    return match ? match.label : "";
+  }, [inputText, options]);
+
+  // Commit the given option: set value, close dropdown
+  function commitOption(opt, { blur = true } = {}) {
+    committingRef.current = true;
     onChange(opt.value);
     setInputText(opt.label);
     setOpen(false);
-    setHighlightIndex(-1);
-    inputRef.current?.blur();
+    setHighlightIndex(0);
+    if (blur) {
+      inputRef.current?.blur();
+    }
+    requestAnimationFrame(() => { committingRef.current = false; });
+  }
+
+  // Commit the best available match (highlighted item, or first filtered item)
+  function commitBestMatch({ blur = true } = {}) {
+    const target = highlightIndex >= 0 && highlightIndex < filtered.length
+      ? filtered[highlightIndex]
+      : filtered[0];
+
+    if (target) {
+      commitOption(target, { blur });
+      return true;
+    }
+    return false;
   }
 
   function handleInputChange(event) {
-    setInputText(event.target.value);
-    setHighlightIndex(-1);
+    const text = event.target.value;
+    setInputText(text);
+    setHighlightIndex(0);
     if (!open) setOpen(true);
   }
 
   function handleInputFocus() {
     if (!disabled) {
       setOpen(true);
-      setHighlightIndex(-1);
+      setHighlightIndex(0);
     }
   }
 
   function handleInputKeyDown(event) {
     if (event.key === "ArrowDown") {
       event.preventDefault();
+      if (!open) {
+        setOpen(true);
+        return;
+      }
       setHighlightIndex((current) => Math.min(current + 1, filtered.length - 1));
+
     } else if (event.key === "ArrowUp") {
       event.preventDefault();
       setHighlightIndex((current) => Math.max(current - 1, 0));
+
     } else if (event.key === "Enter") {
+      // Commit the current match but do NOT let the event bubble up to the form
+      // (mirrors desktop: Enter commits the completion but doesn't trigger Save)
       event.preventDefault();
-      if (highlightIndex >= 0 && highlightIndex < filtered.length) {
-        selectOption(filtered[highlightIndex]);
+      event.stopPropagation();
+      commitBestMatch({ blur: false });
+
+    } else if (event.key === "Tab") {
+      // Tab commits the completion and allows default tab behavior (focus moves)
+      // Do NOT call preventDefault — let native Tab focus-advance happen
+      if (filtered.length > 0 && inputText.trim()) {
+        commitBestMatch({ blur: false });
+      } else {
+        setOpen(false);
+        const selected = options.find((opt) => opt.value === value);
+        setInputText(selected ? selected.label : "");
       }
+
     } else if (event.key === "Escape") {
       event.stopPropagation();
       setOpen(false);
       const selected = options.find((opt) => opt.value === value);
       setInputText(selected ? selected.label : "");
       inputRef.current?.blur();
-    } else if (event.key === "Tab") {
-      setOpen(false);
-      const selected = options.find((opt) => opt.value === value);
-      setInputText(selected ? selected.label : "");
     }
   }
 
-  function handleInputBlur(event) {
-    // Delay close so click on option can fire
+  function handleInputBlur() {
     requestAnimationFrame(() => {
+      if (committingRef.current) return;
       if (containerRef.current && !containerRef.current.contains(document.activeElement)) {
         setOpen(false);
+        // Revert to the currently committed value's label
         const selected = options.find((opt) => opt.value === value);
         setInputText(selected ? selected.label : "");
       }
@@ -113,27 +172,38 @@ export default function TypeaheadSelect({
     return () => document.removeEventListener("mousedown", handlePointerDown);
   }, [open, options, value]);
 
+  // Ghost text: the full suggestion shown faintly behind the input
+  const showGhost = open && ghostText && inputText.trim() && ghostText.toLowerCase() !== inputText.trim().toLowerCase();
+
   return (
     <div className="typeahead-select" ref={containerRef}>
-      <input
-        id={id}
-        ref={inputRef}
-        className={`text-input typeahead-input${invalid ? " invalid" : ""}`}
-        type="text"
-        autoComplete="off"
-        placeholder={placeholder}
-        value={inputText}
-        disabled={disabled}
-        onChange={handleInputChange}
-        onFocus={handleInputFocus}
-        onBlur={handleInputBlur}
-        onKeyDown={handleInputKeyDown}
-        role="combobox"
-        aria-expanded={open}
-        aria-autocomplete="list"
-        aria-controls={`${id}-listbox`}
-        aria-activedescendant={highlightIndex >= 0 ? `${id}-opt-${highlightIndex}` : undefined}
-      />
+      <div className="typeahead-input-wrap">
+        {showGhost ? (
+          <span className="typeahead-ghost" aria-hidden="true">
+            <span className="typeahead-ghost-typed">{inputText}</span>
+            <span className="typeahead-ghost-suffix">{ghostText.slice(inputText.length)}</span>
+          </span>
+        ) : null}
+        <input
+          id={id}
+          ref={inputRef}
+          className={`text-input typeahead-input${invalid ? " invalid" : ""}`}
+          type="text"
+          autoComplete="off"
+          placeholder={placeholder}
+          value={inputText}
+          disabled={disabled}
+          onChange={handleInputChange}
+          onFocus={handleInputFocus}
+          onBlur={handleInputBlur}
+          onKeyDown={handleInputKeyDown}
+          role="combobox"
+          aria-expanded={open}
+          aria-autocomplete="both"
+          aria-controls={`${id}-listbox`}
+          aria-activedescendant={highlightIndex >= 0 ? `${id}-opt-${highlightIndex}` : undefined}
+        />
+      </div>
       <span className="typeahead-chevron" aria-hidden="true">
         {open ? "\u25B4" : "\u25BE"}
       </span>
@@ -153,7 +223,7 @@ export default function TypeaheadSelect({
               aria-selected={opt.value === value}
               onMouseDown={(event) => {
                 event.preventDefault();
-                selectOption(opt);
+                commitOption(opt);
               }}
               onMouseEnter={() => setHighlightIndex(idx)}
             >

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1104,9 +1104,41 @@ h2.breadcrumb-segment {
   width: 100%;
 }
 
+.typeahead-input-wrap {
+  position: relative;
+  width: 100%;
+}
+
 .typeahead-input {
   padding-right: 32px !important;
   cursor: text;
+  background: transparent;
+  position: relative;
+  z-index: 1;
+}
+
+.typeahead-ghost {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  padding: 10px 12px;
+  pointer-events: none;
+  overflow: hidden;
+  white-space: nowrap;
+  font: inherit;
+  z-index: 0;
+}
+
+.typeahead-ghost-typed {
+  visibility: hidden;
+}
+
+.typeahead-ghost-suffix {
+  color: rgba(126, 195, 172, 0.40);
 }
 
 .typeahead-chevron {
@@ -1118,6 +1150,7 @@ h2.breadcrumb-segment {
   color: #7e8792;
   font-size: 0.72rem;
   line-height: 1;
+  z-index: 2;
 }
 
 .typeahead-dropdown {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1097,6 +1097,73 @@ h2.breadcrumb-segment {
   box-shadow: 0 0 0 1px rgba(239, 136, 99, 0.28);
 }
 
+/* --- Typeahead select --- */
+
+.typeahead-select {
+  position: relative;
+  width: 100%;
+}
+
+.typeahead-input {
+  padding-right: 32px !important;
+  cursor: text;
+}
+
+.typeahead-chevron {
+  position: absolute;
+  right: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  pointer-events: none;
+  color: #7e8792;
+  font-size: 0.72rem;
+  line-height: 1;
+}
+
+.typeahead-dropdown {
+  position: absolute;
+  z-index: 120;
+  top: calc(100% + 4px);
+  left: 0;
+  right: 0;
+  max-height: 200px;
+  overflow-y: auto;
+  margin: 0;
+  padding: 4px 0;
+  list-style: none;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: var(--surface, #1e2024);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.45);
+}
+
+.typeahead-option {
+  padding: 7px 12px;
+  font-size: 0.84rem;
+  color: var(--text);
+  cursor: pointer;
+  border-radius: 6px;
+  margin: 0 4px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.typeahead-option.highlighted {
+  background: rgba(126, 195, 172, 0.12);
+}
+
+.typeahead-option.selected {
+  color: var(--accent, #7ec3ac);
+  font-weight: 500;
+}
+
+.typeahead-no-results {
+  color: #7e8792;
+  cursor: default;
+  font-style: italic;
+}
+
 .users-search-field .hero-search-input {
   padding: 8px 14px 8px 52px;
   font-size: 0.84rem;


### PR DESCRIPTION
## Summary

Ports the full Setup > Cards CRUD workflow to the hosted web app, following the Sites pattern exactly.

Closes #246

## Changes

### Backend
- **HostedCard model** (`services/hosted/models.py`): Dataclass with validation — name required, user_id required, cashback_rate 0–100, last_four exactly 4 chars if provided
- **HostedCardRepository** (`repositories/hosted_card_repository.py`): Full CRUD with LEFT JOIN to `hosted_users` for `user_name` resolution
- **HostedWorkspaceCardService** (`services/hosted/workspace_card_service.py`): list, paginated list, create, update, delete, batch-delete
- **5 API endpoints** in `api/app.py`: GET/POST/PATCH/DELETE `/v1/workspace/cards` + POST batch-delete

### Frontend
- **CardsTab** (`web/src/components/CardsTab/`): Full table with search, column filters, sort, pagination, row/cell selection, keyboard nav, context menu, CSV export, back-to-top
- **CardModal**: Create/View/Edit modes with user dropdown (first cross-entity FK in web app), cashback rate 0–100, last_four 4-char input
- **AppShell**: Cards tab enabled in setup navigation

## Test Plan
- 28 existing card backend tests pass
- 19 frontend tests pass
- Frontend builds cleanly (`vite build`)

## Pitfalls / Follow-ups
- Shared utility functions (isTextEntryElement, computeCellStats, filter tree helpers) are duplicated across SitesTab/CardsTab utils — candidate for extraction into shared module (Issue TBD)
- Users dropdown in CardModal loads up to 500 users; may need search/pagination for large workspaces
- No hosted-specific backend tests yet for the new HostedCardRepository/Service layers
