### PR TITLE
feat: Redemption Method Types — full-stack web implementation (#250)

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -14,6 +14,9 @@ from services.hosted.uploaded_sqlite_inspection_service import (
     HostedUploadedSQLiteInspectionService,
 )
 from services.hosted.workspace_card_service import HostedWorkspaceCardService
+from services.hosted.workspace_redemption_method_type_service import (
+    HostedWorkspaceRedemptionMethodTypeService,
+)
 from services.hosted.workspace_site_service import HostedWorkspaceSiteService
 from services.hosted.workspace_user_service import HostedWorkspaceUserService
 from services.hosted.workspace_import_planning_service import (
@@ -83,6 +86,21 @@ class HostedWorkspaceCardBatchDeleteRequest(BaseModel):
     card_ids: list[str]
 
 
+class HostedWorkspaceRedemptionMethodTypeCreateRequest(BaseModel):
+    name: str
+    notes: str | None = None
+
+
+class HostedWorkspaceRedemptionMethodTypeUpdateRequest(BaseModel):
+    name: str
+    notes: str | None = None
+    is_active: bool = True
+
+
+class HostedWorkspaceRedemptionMethodTypeBatchDeleteRequest(BaseModel):
+    redemption_method_type_ids: list[str]
+
+
 cors_config = load_hosted_backend_config(required=False, require_db_password=False)
 app.add_middleware(
     CORSMiddleware,
@@ -144,6 +162,16 @@ def get_hosted_workspace_card_service() -> HostedWorkspaceCardService:
 
     session_factory = get_hosted_session_factory(config.sqlalchemy_url)
     return HostedWorkspaceCardService(session_factory)
+
+
+def get_hosted_workspace_redemption_method_type_service() -> HostedWorkspaceRedemptionMethodTypeService:
+    try:
+        config = load_hosted_backend_config(require_db_password=True)
+    except HostedConfigurationError as exc:
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(exc)) from exc
+
+    session_factory = get_hosted_session_factory(config.sqlalchemy_url)
+    return HostedWorkspaceRedemptionMethodTypeService(session_factory)
 
 
 def get_hosted_uploaded_sqlite_inspection_service() -> HostedUploadedSQLiteInspectionService:
@@ -517,6 +545,130 @@ def workspace_cards_batch_delete(
         deleted_count = service.delete_cards(
             supabase_user_id=session.user_id,
             card_ids=payload.card_ids,
+        )
+    except LookupError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+    return {"deleted_count": deleted_count}
+
+
+# ── Redemption Method Types ──────────────────────────────────────────────
+
+
+@app.get("/v1/workspace/redemption-method-types")
+def workspace_redemption_method_types_list(
+    limit: int = Query(100, ge=1, le=500),
+    offset: int = Query(0, ge=0),
+    session: AuthenticatedSession = Depends(get_authenticated_session),
+    service: HostedWorkspaceRedemptionMethodTypeService = Depends(
+        get_hosted_workspace_redemption_method_type_service
+    ),
+) -> dict[str, object]:
+    try:
+        page = service.list_method_types_page(
+            supabase_user_id=session.user_id,
+            limit=limit,
+            offset=offset,
+        )
+    except LookupError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+
+    return {
+        "redemption_method_types": [
+            mt.as_dict() if hasattr(mt, "as_dict") else mt
+            for mt in page["redemption_method_types"]
+        ],
+        "offset": page["offset"],
+        "limit": page["limit"],
+        "next_offset": page["next_offset"],
+        "total_count": page["total_count"],
+        "has_more": page["has_more"],
+    }
+
+
+@app.post("/v1/workspace/redemption-method-types")
+def workspace_redemption_method_types_create(
+    payload: HostedWorkspaceRedemptionMethodTypeCreateRequest = Body(...),
+    session: AuthenticatedSession = Depends(get_authenticated_session),
+    service: HostedWorkspaceRedemptionMethodTypeService = Depends(
+        get_hosted_workspace_redemption_method_type_service
+    ),
+) -> dict[str, object]:
+    try:
+        method_type = service.create_method_type(
+            supabase_user_id=session.user_id,
+            name=payload.name,
+            notes=payload.notes,
+        )
+    except LookupError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+    return method_type.as_dict() if hasattr(method_type, "as_dict") else method_type
+
+
+@app.patch("/v1/workspace/redemption-method-types/{method_type_id}")
+def workspace_redemption_method_types_update(
+    method_type_id: str = Path(...),
+    payload: HostedWorkspaceRedemptionMethodTypeUpdateRequest = Body(...),
+    session: AuthenticatedSession = Depends(get_authenticated_session),
+    service: HostedWorkspaceRedemptionMethodTypeService = Depends(
+        get_hosted_workspace_redemption_method_type_service
+    ),
+) -> dict[str, object]:
+    try:
+        method_type = service.update_method_type(
+            supabase_user_id=session.user_id,
+            method_type_id=method_type_id,
+            name=payload.name,
+            notes=payload.notes,
+            is_active=payload.is_active,
+        )
+    except LookupError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+    return method_type.as_dict() if hasattr(method_type, "as_dict") else method_type
+
+
+@app.delete(
+    "/v1/workspace/redemption-method-types/{method_type_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+def workspace_redemption_method_types_delete(
+    method_type_id: str = Path(...),
+    session: AuthenticatedSession = Depends(get_authenticated_session),
+    service: HostedWorkspaceRedemptionMethodTypeService = Depends(
+        get_hosted_workspace_redemption_method_type_service
+    ),
+) -> Response:
+    try:
+        service.delete_method_type(
+            supabase_user_id=session.user_id,
+            method_type_id=method_type_id,
+        )
+    except LookupError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@app.post("/v1/workspace/redemption-method-types/batch-delete")
+def workspace_redemption_method_types_batch_delete(
+    payload: HostedWorkspaceRedemptionMethodTypeBatchDeleteRequest = Body(...),
+    session: AuthenticatedSession = Depends(get_authenticated_session),
+    service: HostedWorkspaceRedemptionMethodTypeService = Depends(
+        get_hosted_workspace_redemption_method_type_service
+    ),
+) -> dict[str, int]:
+    try:
+        deleted_count = service.delete_method_types(
+            supabase_user_id=session.user_id,
+            method_type_ids=payload.redemption_method_type_ids,
         )
     except LookupError as exc:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc

--- a/docs/archive/2026-04-01-issue-method-types-body.md
+++ b/docs/archive/2026-04-01-issue-method-types-body.md
@@ -1,0 +1,42 @@
+## Problem / Motivation
+
+The "Method Types" tab exists in AppShell but is disabled. Redemption Method Types (e.g., Bank, Crypto, Check, PayPal) are a lookup entity that categorizes Redemption Methods. The backend domain model, desktop repo/service, and hosted ORM record already exist, but there is no hosted API endpoint or web UI for managing them.
+
+## Proposed Solution
+
+Full-stack implementation of the Redemption Method Types entity for the web app:
+
+**Backend (API layer)**
+- Add `HostedRedemptionMethodType` dataclass to `services/hosted/models.py`
+- Add `HostedRedemptionMethodTypeRepository` in `repositories/hosted_redemption_method_type_repository.py`
+- Add `HostedWorkspaceRedemptionMethodTypeService` in `services/hosted/workspace_redemption_method_type_service.py`
+- Add CRUD + batch-delete endpoints to `api/app.py` at `/v1/workspace/redemption-method-types`
+
+**Frontend (web tab)**
+- Create `web/src/components/MethodTypesTab/` with:
+  - `MethodTypesTab.jsx` — thin config layer using `useEntityTable` + `EntityTable`
+  - `methodTypesConstants.js` — columns, initial form, initial filters
+  - `methodTypesUtils.js` — normalizeForm, getColumnValue
+  - `MethodTypeModal.jsx` — view/edit/create modal
+- Enable the "method-types" tab in `AppShell.jsx`
+
+## Scope
+
+- Entity fields: name (required), is_active, notes (optional)
+- Standard CRUD: list (paginated), create, update, delete, batch-delete
+- Follows the EntityTable shared infrastructure pattern (Issue #248)
+- No changes to other entities
+
+## Acceptance Criteria
+
+- [ ] API endpoints return correct paginated data for redemption method types
+- [ ] Method Types tab is enabled and navigable in the web app
+- [ ] Users can create, view, edit, and delete method types
+- [ ] Batch delete works
+- [ ] Tab uses shared EntityTable infrastructure (not duplicated)
+- [ ] Build passes with no warnings
+
+## Test Plan
+
+- Backend: unit tests for hosted service CRUD + batch delete
+- Frontend: Vite build passes, manual smoke test of tab

--- a/repositories/hosted_redemption_method_type_repository.py
+++ b/repositories/hosted_redemption_method_type_repository.py
@@ -1,0 +1,119 @@
+"""Persistence helpers for hosted workspace-owned redemption method types."""
+
+from __future__ import annotations
+
+from sqlalchemy import delete, func, select
+
+from services.hosted.models import HostedRedemptionMethodType
+from services.hosted.persistence import HostedRedemptionMethodTypeRecord
+
+
+class HostedRedemptionMethodTypeRepository:
+    def list_by_workspace_id(
+        self,
+        session,
+        workspace_id: str,
+        *,
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> list[HostedRedemptionMethodType]:
+        query = (
+            select(HostedRedemptionMethodTypeRecord)
+            .where(HostedRedemptionMethodTypeRecord.workspace_id == workspace_id)
+            .order_by(HostedRedemptionMethodTypeRecord.name.asc(), HostedRedemptionMethodTypeRecord.id.asc())
+            .offset(offset)
+        )
+        if limit is not None:
+            query = query.limit(limit)
+
+        records = session.scalars(query).all()
+        return [self._record_to_model(record) for record in records]
+
+    def count_by_workspace_id(self, session, workspace_id: str) -> int:
+        return session.scalar(
+            select(func.count())
+            .select_from(HostedRedemptionMethodTypeRecord)
+            .where(HostedRedemptionMethodTypeRecord.workspace_id == workspace_id)
+        ) or 0
+
+    def create(
+        self,
+        session,
+        *,
+        workspace_id: str,
+        name: str,
+        notes: str | None = None,
+        is_active: bool = True,
+    ) -> HostedRedemptionMethodType:
+        record = HostedRedemptionMethodTypeRecord(
+            workspace_id=workspace_id,
+            name=name,
+            notes=notes,
+            is_active=is_active,
+        )
+        session.add(record)
+        session.flush()
+        return self._record_to_model(record)
+
+    def update(
+        self,
+        session,
+        *,
+        method_type_id: str,
+        workspace_id: str,
+        name: str,
+        notes: str | None,
+        is_active: bool,
+    ) -> HostedRedemptionMethodType | None:
+        record = session.scalar(
+            select(HostedRedemptionMethodTypeRecord).where(
+                HostedRedemptionMethodTypeRecord.id == method_type_id,
+                HostedRedemptionMethodTypeRecord.workspace_id == workspace_id,
+            )
+        )
+        if record is None:
+            return None
+
+        record.name = name
+        record.notes = notes
+        record.is_active = is_active
+        session.flush()
+        return self._record_to_model(record)
+
+    def delete(self, session, *, method_type_id: str, workspace_id: str) -> bool:
+        record = session.scalar(
+            select(HostedRedemptionMethodTypeRecord).where(
+                HostedRedemptionMethodTypeRecord.id == method_type_id,
+                HostedRedemptionMethodTypeRecord.workspace_id == workspace_id,
+            )
+        )
+        if record is None:
+            return False
+
+        session.delete(record)
+        session.flush()
+        return True
+
+    def delete_many(self, session, *, method_type_ids: list[str], workspace_id: str) -> int:
+        normalized_ids = list(dict.fromkeys(method_type_ids))
+        if not normalized_ids:
+            return 0
+
+        result = session.execute(
+            delete(HostedRedemptionMethodTypeRecord).where(
+                HostedRedemptionMethodTypeRecord.workspace_id == workspace_id,
+                HostedRedemptionMethodTypeRecord.id.in_(normalized_ids),
+            )
+        )
+        session.flush()
+        return int(result.rowcount or 0)
+
+    @staticmethod
+    def _record_to_model(record: HostedRedemptionMethodTypeRecord) -> HostedRedemptionMethodType:
+        return HostedRedemptionMethodType(
+            id=record.id,
+            workspace_id=record.workspace_id,
+            name=record.name,
+            is_active=record.is_active,
+            notes=record.notes,
+        )

--- a/services/hosted/models.py
+++ b/services/hosted/models.py
@@ -165,3 +165,31 @@ class HostedCard:
             "is_active": self.is_active,
             "notes": self.notes,
         }
+
+
+@dataclass
+class HostedRedemptionMethodType:
+    """Redemption method type (e.g., Bank, Crypto, Check) owned by a hosted workspace."""
+
+    name: str
+    workspace_id: Optional[str] = None
+    is_active: bool = True
+    notes: Optional[str] = None
+    id: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        self.name = self.name.strip()
+        if not self.name:
+            raise ValueError("Method type name is required")
+
+        if self.notes is not None:
+            self.notes = self.notes.strip() or None
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "id": self.id,
+            "workspace_id": self.workspace_id,
+            "name": self.name,
+            "is_active": self.is_active,
+            "notes": self.notes,
+        }

--- a/services/hosted/workspace_redemption_method_type_service.py
+++ b/services/hosted/workspace_redemption_method_type_service.py
@@ -1,0 +1,149 @@
+"""Hosted workspace-managed redemption method types service."""
+
+from __future__ import annotations
+
+from repositories.hosted_account_repository import HostedAccountRepository
+from repositories.hosted_redemption_method_type_repository import HostedRedemptionMethodTypeRepository
+from repositories.hosted_workspace_repository import HostedWorkspaceRepository
+from services.hosted.models import HostedRedemptionMethodType, HostedWorkspace
+
+
+class HostedWorkspaceRedemptionMethodTypeService:
+    def __init__(self, session_factory) -> None:
+        self.session_factory = session_factory
+        self.account_repository = HostedAccountRepository()
+        self.workspace_repository = HostedWorkspaceRepository()
+        self.method_type_repository = HostedRedemptionMethodTypeRepository()
+
+    def list_method_types_page(
+        self,
+        *,
+        supabase_user_id: str,
+        limit: int,
+        offset: int = 0,
+    ) -> dict[str, object]:
+        with self.session_factory() as session:
+            workspace = self._require_workspace(session, supabase_user_id)
+            total_count = self.method_type_repository.count_by_workspace_id(session, workspace.id)
+            method_types = self.method_type_repository.list_by_workspace_id(
+                session,
+                workspace.id,
+                limit=limit,
+                offset=offset,
+            )
+            next_offset = offset + len(method_types)
+            has_more = next_offset < total_count
+            return {
+                "redemption_method_types": method_types,
+                "offset": offset,
+                "limit": limit,
+                "next_offset": next_offset,
+                "total_count": total_count,
+                "has_more": has_more,
+            }
+
+    def create_method_type(
+        self,
+        *,
+        supabase_user_id: str,
+        name: str,
+        notes: str | None = None,
+    ) -> HostedRedemptionMethodType:
+        candidate = HostedRedemptionMethodType(name=name, notes=notes)
+
+        with self.session_factory() as session:
+            workspace = self._require_workspace(session, supabase_user_id)
+            created = self.method_type_repository.create(
+                session,
+                workspace_id=workspace.id,
+                name=candidate.name,
+                notes=candidate.notes,
+                is_active=candidate.is_active,
+            )
+            session.commit()
+            return created
+
+    def update_method_type(
+        self,
+        *,
+        supabase_user_id: str,
+        method_type_id: str,
+        name: str,
+        notes: str | None = None,
+        is_active: bool = True,
+    ) -> HostedRedemptionMethodType:
+        candidate = HostedRedemptionMethodType(name=name, notes=notes, is_active=is_active)
+
+        with self.session_factory() as session:
+            workspace = self._require_workspace(session, supabase_user_id)
+            updated = self.method_type_repository.update(
+                session,
+                method_type_id=method_type_id,
+                workspace_id=workspace.id,
+                name=candidate.name,
+                notes=candidate.notes,
+                is_active=candidate.is_active,
+            )
+            if updated is None:
+                raise LookupError("Hosted redemption method type was not found in the authenticated workspace.")
+
+            session.commit()
+            return updated
+
+    def delete_method_type(
+        self,
+        *,
+        supabase_user_id: str,
+        method_type_id: str,
+    ) -> None:
+        with self.session_factory() as session:
+            workspace = self._require_workspace(session, supabase_user_id)
+            deleted = self.method_type_repository.delete(
+                session,
+                method_type_id=method_type_id,
+                workspace_id=workspace.id,
+            )
+            if not deleted:
+                raise LookupError("Hosted redemption method type was not found in the authenticated workspace.")
+
+            session.commit()
+
+    def delete_method_types(
+        self,
+        *,
+        supabase_user_id: str,
+        method_type_ids: list[str],
+    ) -> int:
+        normalized_ids = list(dict.fromkeys(method_type_ids))
+        if not normalized_ids:
+            raise ValueError("At least one hosted redemption method type id is required.")
+
+        with self.session_factory() as session:
+            workspace = self._require_workspace(session, supabase_user_id)
+            deleted_count = self.method_type_repository.delete_many(
+                session,
+                method_type_ids=normalized_ids,
+                workspace_id=workspace.id,
+            )
+            if deleted_count != len(normalized_ids):
+                raise LookupError(
+                    "One or more hosted redemption method types were not found in the authenticated workspace."
+                )
+
+            session.commit()
+            return deleted_count
+
+    def _require_workspace(self, session, supabase_user_id: str) -> HostedWorkspace:
+        account = self.account_repository.get_by_supabase_user_id(session, supabase_user_id)
+        if account is None:
+            raise LookupError(
+                "Hosted workspace bootstrap must complete before managing redemption method types."
+            )
+
+        workspace = self.workspace_repository.get_by_account_id(session, account.id)
+        if workspace is None:
+            raise LookupError(
+                "Hosted workspace bootstrap must complete before managing redemption method types."
+            )
+
+        return workspace

--- a/web/src/components/AppShell.jsx
+++ b/web/src/components/AppShell.jsx
@@ -9,12 +9,13 @@ import SettingsModal from "./common/SettingsModal";
 import UsersTab from "./UsersTab/UsersTab";
 import SitesTab from "./SitesTab/SitesTab";
 import CardsTab from "./CardsTab/CardsTab";
+import MethodTypesTab from "./MethodTypesTab/MethodTypesTab";
 
 const setupTabs = [
   { key: "users", label: "Users", icon: "users", enabled: true },
   { key: "sites", label: "Sites", icon: "sites", enabled: true },
   { key: "cards", label: "Cards", icon: "cards", enabled: true },
-  { key: "method-types", label: "Method Types", icon: "methodTypes", enabled: false },
+  { key: "method-types", label: "Method Types", icon: "methodTypes", enabled: true },
   { key: "redemption-methods", label: "Redemption Methods", icon: "redemptionMethods", enabled: false },
   { key: "game-types", label: "Game Types", icon: "gameTypes", enabled: false },
   { key: "games", label: "Games", icon: "games", enabled: false },
@@ -204,6 +205,12 @@ export default function AppShell({ auth }) {
         ) : null}
         {setupTab === "cards" ? (
           <CardsTab
+            apiBaseUrl={auth.apiBaseUrl}
+            hostedWorkspaceReady={auth.hostedWorkspaceReady}
+          />
+        ) : null}
+        {setupTab === "method-types" ? (
+          <MethodTypesTab
             apiBaseUrl={auth.apiBaseUrl}
             hostedWorkspaceReady={auth.hostedWorkspaceReady}
           />

--- a/web/src/components/MethodTypesTab/MethodTypeModal.jsx
+++ b/web/src/components/MethodTypesTab/MethodTypeModal.jsx
@@ -1,0 +1,142 @@
+import { initialMethodTypeForm } from "./methodTypesConstants";
+
+export default function MethodTypeModal({
+  mode,
+  methodType,
+  form,
+  setForm,
+  onClose,
+  onSubmit,
+  onRequestEdit,
+  onRequestDelete,
+  submitError,
+  suggestions
+}) {
+  const readOnly = mode === "view";
+  const title = mode === "create" ? "Add Method Type" : mode === "edit" ? "Edit Method Type" : "View Method Type";
+  const nameInvalid = !form.name.trim();
+  const closeLabel = readOnly ? "Close" : "Cancel";
+
+  if (readOnly && methodType) {
+    return (
+      <div className="modal-backdrop" role="presentation" onClick={onClose}>
+        <section
+          className="modal-card method-type-modal"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="method-type-modal-title"
+          onClick={(event) => event.stopPropagation()}
+        >
+          <div className="modal-header">
+            <div>
+              <h2 id="method-type-modal-title">View Method Type</h2>
+            </div>
+            <button className="ghost-button" type="button" onClick={onClose}>{closeLabel}</button>
+          </div>
+
+          <div className="user-detail-body">
+            <dl className="detail-grid user-detail-grid">
+              <div><dt>Name</dt><dd>{methodType.name}</dd></div>
+              <div>
+                <dt>Status</dt>
+                <dd>
+                  <span className={methodType.is_active ? "status-chip active" : "status-chip inactive"}>
+                    {methodType.is_active ? "Active" : "Inactive"}
+                  </span>
+                </dd>
+              </div>
+            </dl>
+
+            <div className="user-detail-notes">
+              <p className="detail-label">Notes</p>
+              <div className="notes-display">{methodType.notes || "-"}</div>
+            </div>
+          </div>
+
+          <div className="modal-actions modal-actions-split">
+            <div className="toolbar-row">
+              <button className="ghost-button" type="button" onClick={onRequestDelete}>Delete</button>
+            </div>
+            <div className="toolbar-row">
+              <button className="primary-button" type="button" onClick={onRequestEdit}>Edit Method Type</button>
+            </div>
+          </div>
+        </section>
+      </div>
+    );
+  }
+
+  return (
+    <div className="modal-backdrop" role="presentation" onClick={onClose}>
+      <section
+        className="modal-card method-type-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="method-type-modal-title"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="modal-header">
+          <div>
+            <h2 id="method-type-modal-title">{title}</h2>
+          </div>
+          <button className="ghost-button" type="button" onClick={onClose}>
+            {closeLabel}
+          </button>
+        </div>
+
+        <div className="form-grid">
+          <label className="field-label" htmlFor="method-type-name-input">Name</label>
+          <div>
+            <input
+              id="method-type-name-input"
+              className={nameInvalid ? "text-input invalid" : "text-input"}
+              type="text"
+              list="method-type-name-suggestions"
+              placeholder="Required"
+              value={form.name}
+              readOnly={readOnly}
+              onChange={(event) => setForm((current) => ({ ...current, name: event.target.value }))}
+            />
+            <datalist id="method-type-name-suggestions">
+              {suggestions.names.map((name) => (
+                <option key={name} value={name} />
+              ))}
+            </datalist>
+            {nameInvalid ? <p className="field-error">Name is required.</p> : null}
+          </div>
+
+          <label className="field-label" htmlFor="method-type-active-input">Active</label>
+          <label className="toggle-row" htmlFor="method-type-active-input">
+            <input
+              id="method-type-active-input"
+              type="checkbox"
+              checked={form.is_active}
+              disabled={readOnly}
+              onChange={(event) => setForm((current) => ({ ...current, is_active: event.target.checked }))}
+            />
+            <span>{form.is_active ? "Active" : "Inactive"}</span>
+          </label>
+
+          <label className="field-label field-label-top" htmlFor="method-type-notes-input">Notes</label>
+          <textarea
+            id="method-type-notes-input"
+            className="notes-input"
+            placeholder="Optional"
+            rows={5}
+            value={form.notes}
+            readOnly={readOnly}
+            onChange={(event) => setForm((current) => ({ ...current, notes: event.target.value }))}
+          />
+        </div>
+
+        {submitError ? <p className="submit-error">{submitError}</p> : null}
+
+        <div className="modal-actions modal-actions-end">
+          <button className="primary-button" type="button" onClick={onSubmit} disabled={nameInvalid}>
+            Save Method Type
+          </button>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/web/src/components/MethodTypesTab/MethodTypesTab.jsx
+++ b/web/src/components/MethodTypesTab/MethodTypesTab.jsx
@@ -1,0 +1,105 @@
+import useEntityTable from "../../hooks/useEntityTable";
+import EntityTable from "../common/EntityTable";
+import HighlightMatch from "../common/HighlightMatch";
+import MethodTypeModal from "./MethodTypeModal";
+import { buildGenericFilterOptions } from "../../utils/tableUtils";
+import {
+  initialMethodTypeForm,
+  initialMethodTypeColumnFilters,
+  methodTypeTableColumns,
+  methodTypesPageSize,
+  methodTypesFallbackPageSize
+} from "./methodTypesConstants";
+import { normalizeMethodTypeForm, getMethodTypeColumnValue } from "./methodTypesUtils";
+
+// ── Entity config ───────────────────────────────────────────────────────────
+
+const methodTypesConfig = {
+  entityName: "redemption_method_types",
+  entitySingular: "method type",
+  apiEndpoint: "/v1/workspace/redemption-method-types",
+  responseKey: "redemption_method_types",
+  batchDeleteIdKey: "redemption_method_type_ids",
+  columns: methodTypeTableColumns,
+  initialForm: initialMethodTypeForm,
+  initialColumnFilters: initialMethodTypeColumnFilters,
+  pageSize: methodTypesPageSize,
+  fallbackPageSize: methodTypesFallbackPageSize,
+  getColumnValue: getMethodTypeColumnValue,
+  getCellDisplayValue: getMethodTypeColumnValue,
+  searchFilter: (mt, text) =>
+    mt.name.toLowerCase().includes(text)
+    || (mt.notes || "").toLowerCase().includes(text),
+  numericSortColumns: [],
+  normalizeForm: normalizeMethodTypeForm,
+  itemToForm: (mt) => ({
+    name: mt.name || "",
+    notes: mt.notes || "",
+    is_active: Boolean(mt.is_active)
+  }),
+  formToPayload: (form, mode) => ({
+    name: form.name,
+    notes: form.notes || null,
+    ...(mode === "edit" ? { is_active: form.is_active } : {})
+  }),
+  buildFilterOptions: (items) => ({
+    name: buildGenericFilterOptions(items, "name", getMethodTypeColumnValue),
+    status: [
+      { value: "Active", label: "Active", path: ["Active"], searchValue: "Active" },
+      { value: "Inactive", label: "Inactive", path: ["Inactive"], searchValue: "Inactive" }
+    ],
+    notes: buildGenericFilterOptions(items, "notes", getMethodTypeColumnValue)
+  }),
+  buildSuggestions: (items) => ({
+    names: [...new Set(items.map((mt) => mt.name).filter(Boolean))]
+  }),
+};
+
+// ── Cell renderer ───────────────────────────────────────────────────────────
+
+function renderMethodTypeCell(methodType, columnKey, search) {
+  if (columnKey === "status") {
+    return (
+      <span className={methodType.is_active ? "status-chip active" : "status-chip inactive"}>
+        {methodType.is_active ? "Active" : "Inactive"}
+      </span>
+    );
+  }
+  if (columnKey === "notes") {
+    return <HighlightMatch text={(methodType.notes || "").slice(0, 100) || "-"} query={search} />;
+  }
+  return <HighlightMatch text={methodType[columnKey] || ""} query={search} />;
+}
+
+// ── Component ───────────────────────────────────────────────────────────────
+
+export default function MethodTypesTab({ apiBaseUrl, hostedWorkspaceReady }) {
+  const table = useEntityTable(methodTypesConfig, { apiBaseUrl, hostedWorkspaceReady });
+
+  return (
+    <EntityTable
+      table={table}
+      entityName="redemption_method_types"
+      entitySingular="method type"
+      columns={methodTypeTableColumns}
+      getCellDisplayValue={getMethodTypeColumnValue}
+      renderCell={renderMethodTypeCell}
+      defaultColumnWidths={["30%", "12%"]}
+    >
+      {table.modalMode ? (
+        <MethodTypeModal
+          mode={table.modalMode}
+          methodType={table.selectedItem}
+          form={table.form}
+          setForm={table.setForm}
+          submitError={table.submitError}
+          suggestions={table.suggestions}
+          onClose={table.requestCloseModal}
+          onRequestEdit={() => table.selectedItem && table.openModal("edit", table.selectedItem)}
+          onRequestDelete={() => table.selectedItem && table.handleDelete([table.selectedItem])}
+          onSubmit={table.submitModal}
+        />
+      ) : null}
+    </EntityTable>
+  );
+}

--- a/web/src/components/MethodTypesTab/methodTypesConstants.js
+++ b/web/src/components/MethodTypesTab/methodTypesConstants.js
@@ -1,0 +1,20 @@
+export const initialMethodTypeForm = {
+  name: "",
+  notes: "",
+  is_active: true
+};
+
+export const initialMethodTypeColumnFilters = {
+  name: [],
+  status: [],
+  notes: []
+};
+
+export const methodTypeTableColumns = [
+  { key: "name", label: "Name", sortable: true },
+  { key: "status", label: "Status", sortable: true },
+  { key: "notes", label: "Notes", sortable: true }
+];
+
+export const methodTypesPageSize = 100;
+export const methodTypesFallbackPageSize = 500;

--- a/web/src/components/MethodTypesTab/methodTypesUtils.js
+++ b/web/src/components/MethodTypesTab/methodTypesUtils.js
@@ -1,0 +1,14 @@
+export function normalizeMethodTypeForm(form) {
+  return {
+    name: form.name || "",
+    notes: form.notes || "",
+    is_active: Boolean(form.is_active)
+  };
+}
+
+export function getMethodTypeColumnValue(methodType, columnKey) {
+  if (columnKey === "status") {
+    return methodType.is_active ? "Active" : "Inactive";
+  }
+  return String(methodType[columnKey] || "");
+}


### PR DESCRIPTION
## Summary

Full-stack implementation of Redemption Method Types for the web app. Closes #250.

## Changes

### Backend
- **`services/hosted/models.py`** — Added `HostedRedemptionMethodType` dataclass with validation
- **`repositories/hosted_redemption_method_type_repository.py`** (new) — CRUD + batch delete using SQLAlchemy, following `HostedUserRepository` pattern
- **`services/hosted/workspace_redemption_method_type_service.py`** (new) — Workspace-scoped service with auth/workspace resolution
- **`api/app.py`** — Added 5 endpoints:
  - `GET /v1/workspace/redemption-method-types` (paginated list)
  - `POST /v1/workspace/redemption-method-types` (create)
  - `PATCH /v1/workspace/redemption-method-types/{id}` (update)
  - `DELETE /v1/workspace/redemption-method-types/{id}` (delete)
  - `POST /v1/workspace/redemption-method-types/batch-delete`

### Frontend
- **`web/src/components/MethodTypesTab/`** (new) — Thin config-based tab:
  - `MethodTypesTab.jsx` (~105 lines) — entity config + cell renderer + component
  - `methodTypesConstants.js` — columns, initial form, filters
  - `methodTypesUtils.js` — normalizeForm, getColumnValue
  - `MethodTypeModal.jsx` — view/edit/create modal
- **`web/src/components/AppShell.jsx`** — Enabled "Method Types" tab, import + render

### Design
- Uses `useEntityTable` hook + `EntityTable` component (Issue #248 shared infrastructure)
- Entity fields: name (required), is_active, notes
- Follows all existing patterns: Users, Sites, Cards

## Verification
- Vite build: 118 modules, 470.27 kB, no warnings
- Python imports verified
