### PR TITLE
feat: Redemption Methods — full-stack web implementation (#252)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -15,15 +15,16 @@ You are assisting with **Sezzions**, a casino session tracker.
 1. Prefer minimal, surgical changes.
 2. Desktop UI (`desktop/ui/`) must not talk to the database directly. Web UI talks to `api/` endpoints.
 3. Preserve current app behavior unless explicitly instructed to change it.
-4. For accounting changes, add or update scenario-based tests to define expected outputs.
-5. **DRY / Reusability**: When implementing a pattern that already exists (or will exist for multiple entities), extract shared logic into a reusable source (utility, base class, generic component, shared hook) rather than copy-pasting per entity. Before writing new code, search the codebase for existing implementations of the same pattern. See `docs/PROJECT_SPEC.md` §2 "Design Principles" for the full doctrinal rules.
-6. **Stop-and-extract enforcement**: If a change requires the same edit in 2+ files, extract the shared logic first (or file an Issue for the extraction). Do not apply the same patch to N files. See `docs/PROJECT_SPEC.md` §2 principle 6.
-7. Keep docs tidy:
+4. **Desktop parity**: When implementing web equivalents of desktop features, consider the desktop **UI behavior** (validation rules, required fields, user-facing constraints) — not only the backend model/schema definitions. The desktop UI may enforce constraints not expressed in the data layer. Where the data layer and UI disagree, use best judgment or ask for clarification.
+5. For accounting changes, add or update scenario-based tests to define expected outputs.
+6. **DRY / Reusability**: When implementing a pattern that already exists (or will exist for multiple entities), extract shared logic into a reusable source (utility, base class, generic component, shared hook) rather than copy-pasting per entity. Before writing new code, search the codebase for existing implementations of the same pattern. See `docs/PROJECT_SPEC.md` §2 "Design Principles" for the full doctrinal rules.
+7. **Stop-and-extract enforcement**: If a change requires the same edit in 2+ files, extract the shared logic first (or file an Issue for the extraction). Do not apply the same patch to N files. See `docs/PROJECT_SPEC.md` §2 principle 6.
+8. Keep docs tidy:
    - Update canonical docs in `docs/`
    - Decisions go in `docs/adr/`
    - Status updates go in `docs/status/`
    - Archive old docs in `docs/archive/`
-7. Avoid documentation sprawl:
+9. Avoid documentation sprawl:
    - Prefer updating `docs/PROJECT_SPEC.md` over creating new docs
    - Add a changelog entry to `docs/status/CHANGELOG.md` for noteworthy changes
    - Prefer GitHub Issues for new work items

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@ This file defines how humans and AI agents should work in this repository.
 - Web UI (`web/src/`) talks to `api/` endpoints, which call `services/hosted/`.
 - Business rules live in services.
 - Keep behavior changes intentional: prefer tests that assert business outputs.
+- **Desktop parity**: When implementing web equivalents of desktop features, consider the desktop **UI behavior** (validation rules, required fields, user-facing constraints) — not only the backend model/schema definitions. The desktop UI may enforce constraints not expressed in the data layer. Where the data layer and UI disagree, use best judgment or ask for clarification.
 - **DRY / Reusability (Doctrinal)**: When two or more entities share the same structural pattern (CRUD repos, API routes, React table tabs, etc.), extract the shared logic into a reusable source — do not copy-paste and adapt per entity. Before writing new code, search the codebase for existing implementations. Shared components must have generic names (not entity-prefixed). See `docs/PROJECT_SPEC.md` §2 "Design Principles" for the full rules.
 - **Stop-and-extract enforcement**: If a change requires the same edit in 2+ files, that means the shared code hasn't been extracted yet. Extract it first (or file an Issue for the extraction). Do not apply the same patch to N files. See `docs/PROJECT_SPEC.md` §2 principle 6.
 

--- a/api/app.py
+++ b/api/app.py
@@ -14,6 +14,9 @@ from services.hosted.uploaded_sqlite_inspection_service import (
     HostedUploadedSQLiteInspectionService,
 )
 from services.hosted.workspace_card_service import HostedWorkspaceCardService
+from services.hosted.workspace_redemption_method_service import (
+    HostedWorkspaceRedemptionMethodService,
+)
 from services.hosted.workspace_redemption_method_type_service import (
     HostedWorkspaceRedemptionMethodTypeService,
 )
@@ -101,6 +104,25 @@ class HostedWorkspaceRedemptionMethodTypeBatchDeleteRequest(BaseModel):
     redemption_method_type_ids: list[str]
 
 
+class HostedWorkspaceRedemptionMethodCreateRequest(BaseModel):
+    name: str
+    method_type_id: str | None = None
+    user_id: str | None = None
+    notes: str | None = None
+
+
+class HostedWorkspaceRedemptionMethodUpdateRequest(BaseModel):
+    name: str
+    method_type_id: str | None = None
+    user_id: str | None = None
+    notes: str | None = None
+    is_active: bool = True
+
+
+class HostedWorkspaceRedemptionMethodBatchDeleteRequest(BaseModel):
+    redemption_method_ids: list[str]
+
+
 cors_config = load_hosted_backend_config(required=False, require_db_password=False)
 app.add_middleware(
     CORSMiddleware,
@@ -172,6 +194,16 @@ def get_hosted_workspace_redemption_method_type_service() -> HostedWorkspaceRede
 
     session_factory = get_hosted_session_factory(config.sqlalchemy_url)
     return HostedWorkspaceRedemptionMethodTypeService(session_factory)
+
+
+def get_hosted_workspace_redemption_method_service() -> HostedWorkspaceRedemptionMethodService:
+    try:
+        config = load_hosted_backend_config(require_db_password=True)
+    except HostedConfigurationError as exc:
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(exc)) from exc
+
+    session_factory = get_hosted_session_factory(config.sqlalchemy_url)
+    return HostedWorkspaceRedemptionMethodService(session_factory)
 
 
 def get_hosted_uploaded_sqlite_inspection_service() -> HostedUploadedSQLiteInspectionService:
@@ -669,6 +701,134 @@ def workspace_redemption_method_types_batch_delete(
         deleted_count = service.delete_method_types(
             supabase_user_id=session.user_id,
             method_type_ids=payload.redemption_method_type_ids,
+        )
+    except LookupError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+    return {"deleted_count": deleted_count}
+
+
+# ── Redemption Methods ───────────────────────────────────────────────────
+
+
+@app.get("/v1/workspace/redemption-methods")
+def workspace_redemption_methods_list(
+    limit: int = Query(100, ge=1, le=500),
+    offset: int = Query(0, ge=0),
+    session: AuthenticatedSession = Depends(get_authenticated_session),
+    service: HostedWorkspaceRedemptionMethodService = Depends(
+        get_hosted_workspace_redemption_method_service
+    ),
+) -> dict[str, object]:
+    try:
+        page = service.list_methods_page(
+            supabase_user_id=session.user_id,
+            limit=limit,
+            offset=offset,
+        )
+    except LookupError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+
+    return {
+        "redemption_methods": [
+            m.as_dict() if hasattr(m, "as_dict") else m
+            for m in page["redemption_methods"]
+        ],
+        "offset": page["offset"],
+        "limit": page["limit"],
+        "next_offset": page["next_offset"],
+        "total_count": page["total_count"],
+        "has_more": page["has_more"],
+    }
+
+
+@app.post("/v1/workspace/redemption-methods")
+def workspace_redemption_methods_create(
+    payload: HostedWorkspaceRedemptionMethodCreateRequest = Body(...),
+    session: AuthenticatedSession = Depends(get_authenticated_session),
+    service: HostedWorkspaceRedemptionMethodService = Depends(
+        get_hosted_workspace_redemption_method_service
+    ),
+) -> dict[str, object]:
+    try:
+        method = service.create_method(
+            supabase_user_id=session.user_id,
+            name=payload.name,
+            method_type_id=payload.method_type_id,
+            user_id=payload.user_id,
+            notes=payload.notes,
+        )
+    except LookupError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+    return method.as_dict() if hasattr(method, "as_dict") else method
+
+
+@app.patch("/v1/workspace/redemption-methods/{method_id}")
+def workspace_redemption_methods_update(
+    method_id: str = Path(...),
+    payload: HostedWorkspaceRedemptionMethodUpdateRequest = Body(...),
+    session: AuthenticatedSession = Depends(get_authenticated_session),
+    service: HostedWorkspaceRedemptionMethodService = Depends(
+        get_hosted_workspace_redemption_method_service
+    ),
+) -> dict[str, object]:
+    try:
+        method = service.update_method(
+            supabase_user_id=session.user_id,
+            method_id=method_id,
+            name=payload.name,
+            method_type_id=payload.method_type_id,
+            user_id=payload.user_id,
+            notes=payload.notes,
+            is_active=payload.is_active,
+        )
+    except LookupError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+    return method.as_dict() if hasattr(method, "as_dict") else method
+
+
+@app.delete(
+    "/v1/workspace/redemption-methods/{method_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+def workspace_redemption_methods_delete(
+    method_id: str = Path(...),
+    session: AuthenticatedSession = Depends(get_authenticated_session),
+    service: HostedWorkspaceRedemptionMethodService = Depends(
+        get_hosted_workspace_redemption_method_service
+    ),
+) -> Response:
+    try:
+        service.delete_method(
+            supabase_user_id=session.user_id,
+            method_id=method_id,
+        )
+    except LookupError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@app.post("/v1/workspace/redemption-methods/batch-delete")
+def workspace_redemption_methods_batch_delete(
+    payload: HostedWorkspaceRedemptionMethodBatchDeleteRequest = Body(...),
+    session: AuthenticatedSession = Depends(get_authenticated_session),
+    service: HostedWorkspaceRedemptionMethodService = Depends(
+        get_hosted_workspace_redemption_method_service
+    ),
+) -> dict[str, int]:
+    try:
+        deleted_count = service.delete_methods(
+            supabase_user_id=session.user_id,
+            method_ids=payload.redemption_method_ids,
         )
     except LookupError as exc:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc

--- a/api/app.py
+++ b/api/app.py
@@ -106,15 +106,15 @@ class HostedWorkspaceRedemptionMethodTypeBatchDeleteRequest(BaseModel):
 
 class HostedWorkspaceRedemptionMethodCreateRequest(BaseModel):
     name: str
-    method_type_id: str | None = None
-    user_id: str | None = None
+    method_type_id: str
+    user_id: str
     notes: str | None = None
 
 
 class HostedWorkspaceRedemptionMethodUpdateRequest(BaseModel):
     name: str
-    method_type_id: str | None = None
-    user_id: str | None = None
+    method_type_id: str
+    user_id: str
     notes: str | None = None
     is_active: bool = True
 

--- a/docs/archive/2026-03-31-issue-cards-implementation-body.md
+++ b/docs/archive/2026-03-31-issue-cards-implementation-body.md
@@ -1,0 +1,342 @@
+## Problem / Motivation
+
+The hosted web app currently has Setup > Users and Setup > Sites. The next entity to port is **Cards** — a user-owned entity with a cashback rate that drives automatic cashback calculations on purchases. Cards is the first hosted entity with a **foreign key to another business entity** (users), which introduces new patterns: user-selector dropdown in the modal, user-name display in the table row, and cross-entity data fetching.
+
+The desktop Cards tab has nuanced features (cashback %, last-four masking, user-FK autocomplete, display name formatting, multi-select delete with FK protection, and integration into the purchase cashback pipeline) that must reach parity in the hosted web app.
+
+## Proposal
+
+Implement full **Setup > Cards** CRUD in the hosted web app following the established Users/Sites pattern, with all desktop-parity features.
+
+### Scope
+
+**In scope:**
+- Hosted backend: HostedCard model, repository, service, 5 API endpoints
+- Frontend: CardsTab, CardModal, cardsConstants, cardsUtils
+- User dropdown in Card create/edit modal (foreign-key selector)
+- Cashback rate field with percent formatting and 0-100 validation
+- Last-four field with 4-character mask
+- Table row display: Name, User, Last Four, Cashback %, Status, Notes
+- View/Edit/Delete from view dialog
+- Multi-row delete with batch endpoint
+- Desktop parity for: search, sort, filter, export CSV
+- Tests (backend unit + frontend integration)
+
+**Out of scope (follow-up issues):**
+- Purchase cashback auto-calculation (depends on Purchases tab, Issue TBD)
+- Cashback recalculation service (depends on Purchases + FIFO)
+- CSV import of cards (depends on import infrastructure)
+- Card deletion FK protection (no purchases table yet — trivially deletable for now)
+
+## Detailed Implementation Plan
+
+---
+
+### Phase 1 — Backend (Hosted Card Model + Repository + Service + API)
+
+#### 1A. HostedCard Model (`services/hosted/models.py`)
+
+Add `HostedCard` dataclass following the HostedSite pattern:
+
+```python
+@dataclass
+class HostedCard:
+    name: str                              # Required, stripped, non-empty
+    user_id: str                           # Required, FK to hosted_users.id
+    workspace_id: Optional[str] = None
+    last_four: Optional[str] = None        # Exactly 4 numeric chars if provided
+    cashback_rate: float = 0.0             # 0-100 range, 2 decimal display
+    is_active: bool = True
+    notes: Optional[str] = None
+    id: Optional[str] = None
+    user_name: Optional[str] = None        # Denormalized from FK join (read-only)
+```
+
+**Validation rules (parity with desktop `models/card.py`):**
+- `name`: required, strip whitespace, non-empty after strip
+- `user_id`: required, non-empty string
+- `cashback_rate`: must be 0 ≤ rate ≤ 100
+- `last_four`: if provided, must be exactly 4 characters (numeric-only check optional — desktop enforces in UI, not model)
+- `notes`: strip whitespace, coerce empty to None
+
+**Method:** `as_dict()` — returns dict for API serialization; includes `user_name`.
+
+**Note:** Unlike desktop Card (which has `display_name()` returning `"Name -- x1234"`), the hosted model keeps this as a frontend concern — the API returns raw fields and the frontend formats.
+
+---
+
+#### 1B. HostedCard Repository (`repositories/hosted_card_repository.py`)
+
+Follow the `HostedSiteRepository` pattern. Methods:
+
+| Method | Signature | Notes |
+|--------|-----------|-------|
+| `list_by_workspace_id()` | `(session, workspace_id, *, limit, offset)` → `list[HostedCard]` | LEFT JOIN `hosted_users` for `user_name`. Order by `name ASC, id ASC`. |
+| `count_by_workspace_id()` | `(session, workspace_id)` → `int` | Count for pagination. |
+| `get_by_id_and_workspace_id()` | `(session, *, card_id, workspace_id)` → `HostedCard \| None` | Single fetch with user_name join. |
+| `create()` | `(session, *, workspace_id, user_id, name, last_four, cashback_rate, is_active, notes)` → `HostedCard` | Insert, flush, return model. |
+| `update()` | `(session, *, card_id, workspace_id, user_id, name, last_four, cashback_rate, is_active, notes)` → `HostedCard \| None` | Full update. |
+| `delete()` | `(session, *, card_id, workspace_id)` → `bool` | Single delete. |
+| `delete_many()` | `(session, *, card_ids, workspace_id)` → `int` | Batch delete. |
+
+**Key difference from Sites:** Cards requires a LEFT JOIN to `hosted_users` for `user_name` in list/get queries (same pattern as desktop `card_repository.py`). The `_record_to_model()` helper must map `user_name` from the joined user record.
+
+**FK validation:** `create()` and `update()` should validate that `user_id` exists in `hosted_users` for the same workspace (prevent cross-workspace user references). This can be done via a query or by relying on the FK constraint + catching IntegrityError.
+
+---
+
+#### 1C. Hosted Workspace Card Service (`services/hosted/workspace_card_service.py`)
+
+Follow `HostedWorkspaceSiteService` pattern:
+
+| Method | Parameters | Returns | Notes |
+|--------|------------|---------|-------|
+| `list_cards()` | `supabase_user_id, *, limit, offset` | `(list[HostedCard], int)` | Returns (cards, total_count) |
+| `create_card()` | `supabase_user_id, *, name, user_id, last_four, cashback_rate, notes` | `HostedCard` | Validates via HostedCard model, then persists |
+| `update_card()` | `supabase_user_id, card_id, *, name, user_id, last_four, cashback_rate, is_active, notes` | `HostedCard` | Returns None → 404 |
+| `delete_card()` | `supabase_user_id, card_id` | `bool` | Single delete |
+| `delete_cards()` | `supabase_user_id, card_ids` | `int` | Batch delete, returns count |
+
+All methods resolve workspace from `supabase_user_id` via `_require_workspace()`.
+
+---
+
+#### 1D. API Endpoints (`api/app.py`)
+
+5 endpoints following the Sites pattern:
+
+| Method | Path | Request | Response |
+|--------|------|---------|----------|
+| `GET` | `/v1/workspace/cards?limit=100&offset=0` | Query params | `{ cards: [...], total: N }` |
+| `POST` | `/v1/workspace/cards` | `{ name, user_id, last_four?, cashback_rate?, notes? }` | `201` + card object |
+| `PATCH` | `/v1/workspace/cards/{card_id}` | `{ name, user_id, last_four?, cashback_rate?, is_active, notes? }` | `200` + card object |
+| `DELETE` | `/v1/workspace/cards/{card_id}` | — | `204` |
+| `POST` | `/v1/workspace/cards/batch-delete` | `{ ids: [...] }` | `200` + `{ deleted: N }` |
+
+**Card response shape:**
+```json
+{
+  "id": "uuid",
+  "workspace_id": "uuid",
+  "user_id": "uuid",
+  "user_name": "Elliot",
+  "name": "Chase Sapphire",
+  "last_four": "1234",
+  "cashback_rate": 2.0,
+  "is_active": true,
+  "notes": null
+}
+```
+
+**Note:** `user_name` is denormalized in the response so the frontend doesn't need a separate users fetch for display (same pattern as desktop `card_repository.get_by_id()` joining `users.name`).
+
+---
+
+### Phase 2 — Frontend (CardsTab + CardModal)
+
+#### 2A. File Structure
+
+```
+web/src/components/CardsTab/
+├── CardsTab.jsx         # Main tab component (follows SitesTab pattern)
+├── CardModal.jsx        # View / Create / Edit modal
+├── cardsConstants.js    # Form defaults, column defs, page sizes
+└── cardsUtils.js        # Card-specific display/filter helpers
+```
+
+#### 2B. `cardsConstants.js`
+
+```javascript
+export const initialCardForm = {
+  name: "",
+  user_id: "",        // FK — populated from user dropdown
+  last_four: "",
+  cashback_rate: "",   // String for input; parsed on submit
+  notes: "",
+  is_active: true,
+};
+
+export const initialCardColumnFilters = {
+  name: [],
+  user_name: [],
+  last_four: [],
+  cashback_rate: [],
+  status: [],
+  notes: [],
+};
+
+export const cardTableColumns = [
+  { key: "name", label: "Name", sortable: true },
+  { key: "user_name", label: "User", sortable: true },
+  { key: "last_four", label: "Last Four", sortable: true },
+  { key: "cashback_rate", label: "Cashback %", sortable: true, numeric: true, align: "right" },
+  { key: "status", label: "Status", sortable: true },
+  { key: "notes", label: "Notes", sortable: true },
+];
+
+export const cardsPageSize = 100;
+export const cardsFallbackPageSize = 500;
+```
+
+#### 2C. `CardModal.jsx`
+
+**View mode:** Read-only display of all fields including user name, cashback formatted as `X.XX%`, last four as `x1234`, status as Active/Inactive. Action buttons: Edit, Delete, Close.
+
+**Create/Edit mode:** Form with:
+1. **User** (required) — `<select>` or searchable dropdown populated from `GET /v1/workspace/users?limit=500` (active users). Shows user name, stores user_id. This is the **first cross-entity dropdown** in the hosted web app.
+2. **Card Name** (required) — text input
+3. **Cashback %** (optional) — numeric input, placeholder "0.00", validated 0-100
+4. **Last Four** (optional) — text input, maxLength=4, placeholder "Optional"
+5. **Active** toggle (edit mode only)
+6. **Notes** — collapsible textarea (matches desktop pattern)
+
+**Validation (inline + submit):**
+- User required (non-empty user_id)
+- Name required (non-empty after trim)
+- Cashback: if provided, numeric and 0-100
+- Last four: if provided, exactly 4 characters
+
+**Dirty tracking:** Same `formBaseline` comparison pattern as Users/Sites for unsaved-changes confirmation on close.
+
+#### 2D. `CardsTab.jsx`
+
+Follows SitesTab exactly for:
+- Paginated fetch with `GET /v1/workspace/cards?limit=100&offset=0`
+- Search across: name, user_name, last_four, cashback_rate (formatted), notes
+- Column sorting with numeric sort for cashback_rate
+- Column filters via HeaderFilterMenu
+- Selection state, multi-select, batch delete
+- Export CSV with columns: Name, User, Last Four, Cashback %, Status, Notes
+- Toolbar: Add, View, Edit, Delete, Export, Refresh
+- Double-click row → View modal
+- Keyboard: Cmd+F for search focus
+
+**Card-specific display:**
+- Cashback: `{rate.toFixed(2)}%` (right-aligned)
+- Last Four: show as-is or "—" if null
+- User: show `user_name` or "—" if null/orphaned
+- Status: "Active" / "Inactive" with gray styling for inactive
+
+#### 2E. AppShell Registration
+
+- Enable the cards tab: `{ key: "cards", label: "Cards", icon: "cards", enabled: true }`
+- Import `CardsTab` and render when `setupTab === "cards"`
+
+---
+
+### Phase 3 — Cascading Dependencies & Future Integration Points
+
+These are **not in scope for this issue** but must be documented because Cards implementation choices affect them:
+
+#### 3A. Purchases → Cards FK (Future: Purchases Tab)
+
+When Purchases are implemented:
+- Purchase create/edit modal needs a **card dropdown** filtered by the selected user (same user-scoped FK pattern as desktop)
+- Card dropdown only populated after user is selected
+- `card_id` is optional on purchases (`ON DELETE SET NULL`)
+- Cashback auto-calculation: `amount × (cashback_rate / 100)` when card has a rate
+- `cashback_is_manual` flag: if user overrides cashback, skip auto-recalculation on future edits
+
+**Design implication for this issue:** The card API response already includes `cashback_rate` so the frontend can compute display cashback without extra API calls. No cashback calculation logic is needed in the Cards tab itself.
+
+#### 3B. Card-User Cascade
+
+- Deleting a hosted user cascades to delete their cards (`ON DELETE CASCADE` on `hosted_cards.user_id`)
+- The Cards tab must handle the case where a listed card's user was deleted between fetch and display (show "Unknown User" or re-fetch)
+- The Users tab delete confirmation should ideally warn about cascading card deletions (future enhancement)
+
+#### 3C. Cashback Recalculation Pipeline (Future)
+
+Desktop has `RecalculationService._recalculate_cashback_for_pair()` that:
+1. Joins purchases → cards
+2. Skips manually-set cashback
+3. Recalculates `amount × (rate / 100)` for auto-calculated purchases
+4. Called during full rebuild and pair rebuild
+
+The hosted equivalent will need:
+- A hosted recalculation service
+- Same `cashback_is_manual` guard
+- Triggered by: card cashback_rate update, purchase amount update, card reassignment
+
+#### 3D. CSV Import/Export (Future)
+
+Desktop supports CSV import/export for cards with user-scoped FK resolution:
+- Export: Name, User, Last Four, Cashback %, Status, Notes
+- Import: resolves user by name, scoped to avoid cross-user ambiguity
+
+#### 3E. Data Migration (Future)
+
+The migration upload plan already inventories cards from the desktop SQLite. When import-execute is built, cards will need:
+- Desktop `cards.user_id` (integer) → hosted `hosted_cards.user_id` (UUID) mapping via user name/email match
+- Cashback rates preserved as-is
+- Active/inactive status preserved
+
+---
+
+## Acceptance Criteria
+
+- [ ] `GET /v1/workspace/cards` returns paginated cards with `user_name` from FK join
+- [ ] `POST /v1/workspace/cards` creates a card with user_id FK validation
+- [ ] `PATCH /v1/workspace/cards/{id}` updates all card fields including user reassignment
+- [ ] `DELETE /v1/workspace/cards/{id}` and `POST /v1/workspace/cards/batch-delete` work
+- [ ] Cards tab renders in Setup navigation and displays the 6-column table
+- [ ] Card create/edit modal has user dropdown populated from hosted users endpoint
+- [ ] Cashback % field validates 0-100 range and displays with 2 decimal places
+- [ ] Last Four field validates maxLength=4
+- [ ] View modal shows all fields read-only with Edit/Delete actions
+- [ ] Multi-row delete works with confirmation dialog
+- [ ] Search filters across name, user_name, last_four, cashback_rate, notes
+- [ ] Column sorting works (numeric sort for cashback_rate)
+- [ ] Export CSV exports visible rows with headers
+- [ ] Deleting a user cascades to delete their cards (verified via DB constraint)
+
+## Test Plan
+
+**Backend unit tests:**
+- HostedCard model validation (name, user_id, cashback_rate range, last_four length)
+- Repository CRUD + user_name join
+- Service layer with workspace isolation
+- API endpoint responses + error cases
+
+**Frontend integration tests (in App.test.jsx):**
+- Cards tab renders after bootstrap with empty state
+- Create card via modal with user dropdown
+- Edit card (modify name, cashback, user)
+- Delete card with confirmation
+- Cashback % display formatting
+- User name display from FK
+
+## Cascading Implementation Summary
+
+```
+                    ┌──────────────┐
+                    │  hosted_users │  ← Already implemented
+                    └──────┬───────┘
+                           │ ON DELETE CASCADE
+                           ▼
+                    ┌──────────────┐
+     THIS ISSUE ──▶ │ hosted_cards │  ← Cards CRUD + user FK dropdown
+                    └──────┬───────┘
+                           │ ON DELETE SET NULL (future)
+                           ▼
+                    ┌────────────────┐
+     FUTURE ──────▶ │hosted_purchases│  ← card_id FK, cashback auto-calc
+                    └────────┬───────┘
+                             │
+                             ▼
+                    ┌────────────────────────┐
+     FUTURE ──────▶ │cashback recalculation  │  ← rate changes, amount changes
+                    └────────────────────────┘
+```
+
+**Blocking order:**
+1. **Cards** (this issue) — no blockers, depends only on Users (done)
+2. **Purchases** — depends on Cards + Sites (both done after this issue)
+3. **Cashback pipeline** — depends on Purchases + Cards
+4. **FIFO / Recalculation** — depends on Purchases + Cards + full accounting chain
+
+---
+
+## Labels
+
+enhancement

--- a/docs/archive/2026-03-31-pr-243-body.md
+++ b/docs/archive/2026-03-31-pr-243-body.md
@@ -1,0 +1,65 @@
+## Summary
+
+Ports Setup > Sites CRUD to the hosted web app, matching the existing Users pattern end-to-end.
+
+Also fixes a critical FK cascade bug in the desktop schema migration that was silently nulling `redemption_method_id` on all redemptions.
+
+Closes #242
+
+## Changes
+
+### Backend
+- **Model**: Added `HostedSite` dataclass to `services/hosted/models.py` with validation (name required, sc_rate >= 0, playthrough_requirement >= 0)
+- **Repository**: New `repositories/hosted_site_repository.py` -- full CRUD (list, count, create, update, delete, delete_many)
+- **Service**: New `services/hosted/workspace_site_service.py` -- business logic with workspace isolation
+- **API**: 5 new endpoints in `api/app.py`:
+  - `GET /v1/workspace/sites` (paginated list)
+  - `POST /v1/workspace/sites` (create)
+  - `PATCH /v1/workspace/sites/{site_id}` (update)
+  - `DELETE /v1/workspace/sites/{site_id}` (delete, 204)
+  - `POST /v1/workspace/sites/batch-delete` (bulk delete)
+
+### Frontend
+- **SitesTab**: New component set (`SitesTab.jsx`, `SiteModal.jsx`, `sitesConstants.js`, `sitesUtils.js`)
+- **AppShell**: Sites tab enabled, renders SitesTab when selected
+- Reuses generic components from UsersTab (ExportModal, TableContextMenu, UserHeaderFilterMenu, FilterTreeNode)
+- 6-column table: Name, URL, SC Rate, Playthrough, Status, Notes
+- Full feature parity with Users: search, sort, column filters, cell/row/column selection, keyboard navigation, resize, context menus, export CSV, infinite scroll pagination
+
+### Bugfix: FK cascade migration
+- `_migrate_user_fk_cascade()` and `_migrate_redemption_methods_table()` in `repositories/database.py` ran `DROP TABLE` with `PRAGMA foreign_keys=ON`, triggering `ON DELETE SET NULL` on `redemptions.redemption_method_id` and silently nulling 288 method assignments
+- Fixed by wrapping all table-rebuild migrations with `PRAGMA foreign_keys=OFF/ON`
+- Affected data restored from the 3/30 auto-backup
+
+### Documentation
+- Added DRY/reusability design principles to `docs/PROJECT_SPEC.md`, `.github/copilot-instructions.md`, and `AGENTS.md`
+- Changelog entries for Sites CRUD and FK migration fix
+
+### Tests
+- 12 API tests (`tests/api/test_workspace_sites.py`): all CRUD + auth + error cases
+- 13 service integration tests (`tests/services/hosted/test_workspace_site_service.py`): happy path, edge cases, cross-workspace isolation, atomic batch delete
+- 19 existing web tests pass with no regressions
+- 1195 backend tests pass (1 pre-existing unrelated UI autocomplete failure)
+
+## Test Matrix
+
+| Category | Test | Status |
+|----------|------|--------|
+| Happy path | Create site with full fields | PASS |
+| Happy path | List sites (paginated) | PASS |
+| Happy path | Update all fields | PASS |
+| Happy path | Delete single + batch | PASS |
+| Edge case | Reject blank name | PASS |
+| Edge case | Reject negative sc_rate | PASS |
+| Edge case | Reject negative playthrough | PASS |
+| Edge case | Cross-workspace isolation | PASS |
+| Failure injection | Batch delete with invalid ID (atomic rollback) | PASS |
+| Invariant | Only workspace-scoped sites affected | PASS |
+
+## Pitfalls / Follow-ups
+
+- ExportModal imports `userTableColumns` but only uses `allColumns` prop -- works fine but the dead import could be cleaned up in a shared-components refactor
+- UserHeaderFilterMenu / FilterTreeNode names are user-specific but the components are generic -- consider renaming to shared names in a future refactor (tracked in design principles)
+- SiteModal does not yet have a "seed demo sites" dev tool (Users has one) -- could add if useful
+- Sites with URLs could eventually support click-to-open behavior in the table
+- URL-based routing for tab navigation tracked as Issue #244

--- a/docs/archive/2026-03-31-pr-244-body.md
+++ b/docs/archive/2026-03-31-pr-244-body.md
@@ -1,0 +1,48 @@
+Closes #244
+
+## Summary
+
+Replace hash-based routing (`/#/migration`, `hashchange` listeners) with React Router v6 pathname-based routing.
+
+## Changes
+
+### Routing infrastructure
+- Installed `react-router-dom` v6
+- Wrapped `<App>` in `<BrowserRouter>` in `main.jsx`
+- Replaced manual hash routing in `App.jsx` with `<Routes>` / `<Route>` components
+- Routes: `/setup/:tabKey` (Setup tabs), `/migration` (migration page), `/` (redirect), `*` (catch-all)
+
+### Component updates
+- `AppShell.jsx`: `useParams()` for `tabKey`, `useNavigate()` for tab clicks, `<Link>` for migration
+- `MarketingShell.jsx`: `<Link to="/migration">` replaces `<a href="/#/migration">`
+- `MigrationShell.jsx`: `<Link to="/">` replaces `<a href="/#/">`
+
+### Auth integration
+- `useAuth.js`: Uses React Router's `useLocation()` for OAuth return route persistence instead of `window.location.pathname`
+- Removed `readCurrentRoute()` dependency from useAuth
+
+### Dev/build
+- `vite.config.js`: Added `server: { historyApiFallback: true }` for SPA fallback
+- `routing.js`: Simplified to pathname-based (`readCurrentRoute` reads `pathname`, `applyRoute` uses `replaceState`)
+
+### Tests
+- All 19 tests updated with `MemoryRouter` wrapper via `renderApp()` helper
+- Migration-specific tests use `renderApp("/migration")` for route context
+- Renamed "hash-routed return target" test to "return target" (no longer hash-specific)
+
+## Test matrix
+
+- **Happy paths**: Landing page renders, Google sign-in works, Setup tabs navigate, migration page loads
+- **Edge cases**: Invalid tab key falls back to "users", catch-all route redirects to `/`
+- **Failure injection**: Bootstrap fetch fails but shell stays visible
+- **Invariants**: OAuth return route preserved in sessionStorage, auth state unchanged across route changes
+
+## Verification
+
+- `npx vitest run`: 19/19 pass
+- `npx vite build`: clean production build (106 modules, 473KB JS)
+
+## Pitfalls / Follow-ups
+
+- **Production SPA fallback**: Render (or other hosting) needs `_redirects` or equivalent fallback rule so `/setup/users` doesn't 404 on direct load. This is a deploy config concern, not a code issue.
+- **`readCurrentRoute()` in routing.js**: Still exported but no longer imported anywhere. Could be removed in a cleanup pass.

--- a/docs/archive/2026-03-31-pr-246-body.md
+++ b/docs/archive/2026-03-31-pr-246-body.md
@@ -1,0 +1,28 @@
+## Summary
+
+Ports the full Setup > Cards CRUD workflow to the hosted web app, following the Sites pattern exactly.
+
+Closes #246
+
+## Changes
+
+### Backend
+- **HostedCard model** (`services/hosted/models.py`): Dataclass with validation — name required, user_id required, cashback_rate 0–100, last_four exactly 4 chars if provided
+- **HostedCardRepository** (`repositories/hosted_card_repository.py`): Full CRUD with LEFT JOIN to `hosted_users` for `user_name` resolution
+- **HostedWorkspaceCardService** (`services/hosted/workspace_card_service.py`): list, paginated list, create, update, delete, batch-delete
+- **5 API endpoints** in `api/app.py`: GET/POST/PATCH/DELETE `/v1/workspace/cards` + POST batch-delete
+
+### Frontend
+- **CardsTab** (`web/src/components/CardsTab/`): Full table with search, column filters, sort, pagination, row/cell selection, keyboard nav, context menu, CSV export, back-to-top
+- **CardModal**: Create/View/Edit modes with user dropdown (first cross-entity FK in web app), cashback rate 0–100, last_four 4-char input
+- **AppShell**: Cards tab enabled in setup navigation
+
+## Test Plan
+- 28 existing card backend tests pass
+- 19 frontend tests pass
+- Frontend builds cleanly (`vite build`)
+
+## Pitfalls / Follow-ups
+- Shared utility functions (isTextEntryElement, computeCellStats, filter tree helpers) are duplicated across SitesTab/CardsTab utils — candidate for extraction into shared module (Issue TBD)
+- Users dropdown in CardModal loads up to 500 users; may need search/pagination for large workspaces
+- No hosted-specific backend tests yet for the new HostedCardRepository/Service layers

--- a/docs/archive/2026-04-01-issue-redemption-methods-body.md
+++ b/docs/archive/2026-04-01-issue-redemption-methods-body.md
@@ -1,0 +1,45 @@
+## Problem / Motivation
+
+The Redemption Methods entity tab is stubbed in the web app (disabled in AppShell) but has no backend API or frontend implementation yet. The desktop app has full Redemption Methods CRUD, and the web app needs functional parity.
+
+Redemption Methods have two FK relationships (user_id -> Users, method_type_id -> Redemption Method Types), making this the first entity with two foreign-key joins.
+
+## Proposed Solution
+
+Full-stack implementation following the established EntityTable thin-config pattern:
+
+### Backend
+- Add `HostedRedemptionMethod` dataclass to `services/hosted/models.py` (fields: name, method_type_id, user_id, is_active, notes; display fields: user_name, method_type_name)
+- Create `repositories/hosted_redemption_method_repository.py` with two outerjoin queries (users + method types) for display names
+- Create `services/hosted/workspace_redemption_method_service.py` (list, create, update, delete, batch-delete)
+- Add 5 API endpoints at `/v1/workspace/redemption-methods` in `api/app.py`
+
+### Frontend
+- Create `web/src/components/RedemptionMethodsTab/` with thin config (~120 lines)
+- Constants: columns (Name, Method Type, User, Status, Notes), initial form, page size
+- Utils: normalizeForm, getColumnValue
+- Modal: two TypeaheadSelect dropdowns (users + method types) following CardModal pattern
+- Tab: extraLoaders for both users and method types
+- Enable tab in AppShell
+
+## Scope / Boundaries
+
+- In scope: Full CRUD for Redemption Methods, two-FK JOIN pattern, frontend tab with TypeaheadSelect dropdowns
+- Out of scope: Redemptions entity, CSV export, advanced filters beyond what EntityTable provides
+
+## Acceptance Criteria
+
+- [ ] `GET /v1/workspace/redemption-methods` returns paginated list with user_name and method_type_name resolved
+- [ ] `POST /v1/workspace/redemption-methods` creates with FK validation
+- [ ] `PATCH /v1/workspace/redemption-methods/{id}` updates all fields
+- [ ] `DELETE /v1/workspace/redemption-methods/{id}` deletes single record
+- [ ] `POST /v1/workspace/redemption-methods/batch-delete` deletes multiple
+- [ ] Frontend tab shows Name, Method Type, User, Status, Notes columns
+- [ ] Modal has TypeaheadSelect for both User and Method Type
+- [ ] Tab is enabled in AppShell navigation
+
+## Test Plan
+
+- Unit tests for HostedRedemptionMethod model validation
+- Integration tests for repository CRUD with two-FK joins
+- Service-level tests for workspace scoping

--- a/docs/archive/2026-04-01-pr-250-body.md
+++ b/docs/archive/2026-04-01-pr-250-body.md
@@ -1,0 +1,33 @@
+## Summary
+
+Full-stack implementation of Redemption Method Types for the web app. Closes #250.
+
+## Changes
+
+### Backend
+- **`services/hosted/models.py`** — Added `HostedRedemptionMethodType` dataclass with validation
+- **`repositories/hosted_redemption_method_type_repository.py`** (new) — CRUD + batch delete using SQLAlchemy, following `HostedUserRepository` pattern
+- **`services/hosted/workspace_redemption_method_type_service.py`** (new) — Workspace-scoped service with auth/workspace resolution
+- **`api/app.py`** — Added 5 endpoints:
+  - `GET /v1/workspace/redemption-method-types` (paginated list)
+  - `POST /v1/workspace/redemption-method-types` (create)
+  - `PATCH /v1/workspace/redemption-method-types/{id}` (update)
+  - `DELETE /v1/workspace/redemption-method-types/{id}` (delete)
+  - `POST /v1/workspace/redemption-method-types/batch-delete`
+
+### Frontend
+- **`web/src/components/MethodTypesTab/`** (new) — Thin config-based tab:
+  - `MethodTypesTab.jsx` (~105 lines) — entity config + cell renderer + component
+  - `methodTypesConstants.js` — columns, initial form, filters
+  - `methodTypesUtils.js` — normalizeForm, getColumnValue
+  - `MethodTypeModal.jsx` — view/edit/create modal
+- **`web/src/components/AppShell.jsx`** — Enabled "Method Types" tab, import + render
+
+### Design
+- Uses `useEntityTable` hook + `EntityTable` component (Issue #248 shared infrastructure)
+- Entity fields: name (required), is_active, notes
+- Follows all existing patterns: Users, Sites, Cards
+
+## Verification
+- Vite build: 118 modules, 470.27 kB, no warnings
+- Python imports verified

--- a/docs/archive/2026-04-01-pr-252-body.md
+++ b/docs/archive/2026-04-01-pr-252-body.md
@@ -1,0 +1,31 @@
+## Summary
+
+Full-stack implementation of Redemption Methods entity for the web app, closing #252.
+
+This is the first entity with **two FK relationships** (user_id -> Users, method_type_id -> Redemption Method Types), extending the single-FK pattern established by Cards.
+
+## Backend
+
+- **Model**: `HostedRedemptionMethod` dataclass with `user_name` and `method_type_name` display fields
+- **Repository**: `HostedRedemptionMethodRepository` with two outerjoin queries (aliased UserRecord + MethodTypeRecord) for resolving FK display names
+- **Service**: `HostedWorkspaceRedemptionMethodService` — workspace-scoped CRUD (list, create, update, delete, batch-delete)
+- **API**: 5 endpoints at `/v1/workspace/redemption-methods` (GET list, POST create, PATCH update, DELETE single, POST batch-delete)
+
+## Frontend
+
+- **RedemptionMethodsTab**: thin EntityTable config (~120 lines) with two `extraLoaders` (users + method types)
+- **RedemptionMethodModal**: view/create/edit modes with two `TypeaheadSelect` dropdowns for User and Method Type (both optional)
+- **Constants**: 5 columns (Name, Method Type, User, Status, Notes), form fields, page sizes
+- **Utils**: `normalizeRedemptionMethodForm`, `getRedemptionMethodColumnValue`
+- **AppShell**: tab enabled, import added, render block wired
+
+## Verification
+
+- All 1196 existing tests pass (0 failures)
+- Frontend builds clean (122 modules, 478 kB)
+- Follows established EntityTable thin-config pattern
+
+## Pitfalls / Follow-ups
+
+- TypeaheadSelect does not currently support clearing a selection to null (no `allowClear`). Users can work around by not selecting a value. A follow-up could add optional clear button to TypeaheadSelect.
+- Both user_id and method_type_id are nullable FKs — the modal does not mark them as required, matching desktop behavior.

--- a/docs/status/CHANGELOG.md
+++ b/docs/status/CHANGELOG.md
@@ -12,6 +12,35 @@ Rules:
 ## 2026-04-01
 
 ```yaml
+id: 2026-04-01-02
+type: feature
+areas: [web, api]
+issue: "#252"
+summary: "Redemption Methods — full-stack web implementation"
+details: >
+  Full-stack Redemption Methods entity with two FK relationships (user_id, method_type_id).
+  Backend: HostedRedemptionMethod model, repository with two-FK outerjoin pattern (users +
+  method types), workspace service, 5 API endpoints at /v1/workspace/redemption-methods.
+  Frontend: thin EntityTable config with extraLoaders for both users and method types,
+  RedemptionMethodModal with two TypeaheadSelect dropdowns. Tab enabled in AppShell.
+
+files_changed:
+  - services/hosted/models.py (add HostedRedemptionMethod)
+  - repositories/hosted_redemption_method_repository.py (new)
+  - services/hosted/workspace_redemption_method_service.py (new)
+  - api/app.py (add endpoints + request models + dependency)
+  - web/src/components/RedemptionMethodsTab/RedemptionMethodsTab.jsx (new)
+  - web/src/components/RedemptionMethodsTab/RedemptionMethodModal.jsx (new)
+  - web/src/components/RedemptionMethodsTab/redemptionMethodsConstants.js (new)
+  - web/src/components/RedemptionMethodsTab/redemptionMethodsUtils.js (new)
+  - web/src/components/AppShell.jsx (enable tab + import)
+```
+
+---
+
+## 2026-04-01
+
+```yaml
 id: 2026-04-01-01
 type: refactor
 areas: [web]

--- a/repositories/hosted_redemption_method_repository.py
+++ b/repositories/hosted_redemption_method_repository.py
@@ -1,0 +1,177 @@
+"""Persistence helpers for hosted workspace-owned redemption methods."""
+
+from __future__ import annotations
+
+from sqlalchemy import delete, func, select
+from sqlalchemy.orm import aliased
+
+from services.hosted.models import HostedRedemptionMethod
+from services.hosted.persistence import (
+    HostedRedemptionMethodRecord,
+    HostedRedemptionMethodTypeRecord,
+    HostedUserRecord,
+)
+
+
+class HostedRedemptionMethodRepository:
+    def list_by_workspace_id(
+        self,
+        session,
+        workspace_id: str,
+        *,
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> list[HostedRedemptionMethod]:
+        user_alias = aliased(HostedUserRecord)
+        type_alias = aliased(HostedRedemptionMethodTypeRecord)
+        query = (
+            select(
+                HostedRedemptionMethodRecord,
+                user_alias.name.label("user_name"),
+                type_alias.name.label("method_type_name"),
+            )
+            .outerjoin(user_alias, HostedRedemptionMethodRecord.user_id == user_alias.id)
+            .outerjoin(type_alias, HostedRedemptionMethodRecord.method_type_id == type_alias.id)
+            .where(HostedRedemptionMethodRecord.workspace_id == workspace_id)
+            .order_by(HostedRedemptionMethodRecord.name.asc(), HostedRedemptionMethodRecord.id.asc())
+            .offset(offset)
+        )
+        if limit is not None:
+            query = query.limit(limit)
+
+        rows = session.execute(query).all()
+        return [self._row_to_model(row) for row in rows]
+
+    def count_by_workspace_id(self, session, workspace_id: str) -> int:
+        return session.scalar(
+            select(func.count())
+            .select_from(HostedRedemptionMethodRecord)
+            .where(HostedRedemptionMethodRecord.workspace_id == workspace_id)
+        ) or 0
+
+    def get_by_id_and_workspace_id(
+        self,
+        session,
+        *,
+        method_id: str,
+        workspace_id: str,
+    ) -> HostedRedemptionMethod | None:
+        user_alias = aliased(HostedUserRecord)
+        type_alias = aliased(HostedRedemptionMethodTypeRecord)
+        row = session.execute(
+            select(
+                HostedRedemptionMethodRecord,
+                user_alias.name.label("user_name"),
+                type_alias.name.label("method_type_name"),
+            )
+            .outerjoin(user_alias, HostedRedemptionMethodRecord.user_id == user_alias.id)
+            .outerjoin(type_alias, HostedRedemptionMethodRecord.method_type_id == type_alias.id)
+            .where(
+                HostedRedemptionMethodRecord.id == method_id,
+                HostedRedemptionMethodRecord.workspace_id == workspace_id,
+            )
+        ).first()
+        if row is None:
+            return None
+        return self._row_to_model(row)
+
+    def create(
+        self,
+        session,
+        *,
+        workspace_id: str,
+        name: str,
+        method_type_id: str | None = None,
+        user_id: str | None = None,
+        is_active: bool = True,
+        notes: str | None = None,
+    ) -> HostedRedemptionMethod:
+        record = HostedRedemptionMethodRecord(
+            workspace_id=workspace_id,
+            name=name,
+            method_type_id=method_type_id,
+            user_id=user_id,
+            is_active=is_active,
+            notes=notes,
+        )
+        session.add(record)
+        session.flush()
+        return self.get_by_id_and_workspace_id(
+            session, method_id=record.id, workspace_id=workspace_id
+        )
+
+    def update(
+        self,
+        session,
+        *,
+        method_id: str,
+        workspace_id: str,
+        name: str,
+        method_type_id: str | None,
+        user_id: str | None,
+        is_active: bool,
+        notes: str | None,
+    ) -> HostedRedemptionMethod | None:
+        record = session.scalar(
+            select(HostedRedemptionMethodRecord).where(
+                HostedRedemptionMethodRecord.id == method_id,
+                HostedRedemptionMethodRecord.workspace_id == workspace_id,
+            )
+        )
+        if record is None:
+            return None
+
+        record.name = name
+        record.method_type_id = method_type_id
+        record.user_id = user_id
+        record.is_active = is_active
+        record.notes = notes
+        session.flush()
+        return self.get_by_id_and_workspace_id(
+            session, method_id=record.id, workspace_id=workspace_id
+        )
+
+    def delete(self, session, *, method_id: str, workspace_id: str) -> bool:
+        record = session.scalar(
+            select(HostedRedemptionMethodRecord).where(
+                HostedRedemptionMethodRecord.id == method_id,
+                HostedRedemptionMethodRecord.workspace_id == workspace_id,
+            )
+        )
+        if record is None:
+            return False
+
+        session.delete(record)
+        session.flush()
+        return True
+
+    def delete_many(self, session, *, method_ids: list[str], workspace_id: str) -> int:
+        normalized_ids = list(dict.fromkeys(method_ids))
+        if not normalized_ids:
+            return 0
+
+        result = session.execute(
+            delete(HostedRedemptionMethodRecord).where(
+                HostedRedemptionMethodRecord.workspace_id == workspace_id,
+                HostedRedemptionMethodRecord.id.in_(normalized_ids),
+            )
+        )
+        session.flush()
+        return int(result.rowcount or 0)
+
+    @staticmethod
+    def _row_to_model(row) -> HostedRedemptionMethod:
+        record = row[0] if hasattr(row, "__getitem__") else row
+        user_name = row.user_name if hasattr(row, "user_name") else None
+        method_type_name = row.method_type_name if hasattr(row, "method_type_name") else None
+        return HostedRedemptionMethod(
+            id=record.id,
+            workspace_id=record.workspace_id,
+            name=record.name,
+            method_type_id=record.method_type_id,
+            user_id=record.user_id,
+            is_active=record.is_active,
+            notes=record.notes,
+            user_name=user_name,
+            method_type_name=method_type_name,
+        )

--- a/repositories/hosted_redemption_method_repository.py
+++ b/repositories/hosted_redemption_method_repository.py
@@ -30,8 +30,8 @@ class HostedRedemptionMethodRepository:
                 user_alias.name.label("user_name"),
                 type_alias.name.label("method_type_name"),
             )
-            .outerjoin(user_alias, HostedRedemptionMethodRecord.user_id == user_alias.id)
-            .outerjoin(type_alias, HostedRedemptionMethodRecord.method_type_id == type_alias.id)
+            .join(user_alias, HostedRedemptionMethodRecord.user_id == user_alias.id)
+            .join(type_alias, HostedRedemptionMethodRecord.method_type_id == type_alias.id)
             .where(HostedRedemptionMethodRecord.workspace_id == workspace_id)
             .order_by(HostedRedemptionMethodRecord.name.asc(), HostedRedemptionMethodRecord.id.asc())
             .offset(offset)
@@ -64,8 +64,8 @@ class HostedRedemptionMethodRepository:
                 user_alias.name.label("user_name"),
                 type_alias.name.label("method_type_name"),
             )
-            .outerjoin(user_alias, HostedRedemptionMethodRecord.user_id == user_alias.id)
-            .outerjoin(type_alias, HostedRedemptionMethodRecord.method_type_id == type_alias.id)
+            .join(user_alias, HostedRedemptionMethodRecord.user_id == user_alias.id)
+            .join(type_alias, HostedRedemptionMethodRecord.method_type_id == type_alias.id)
             .where(
                 HostedRedemptionMethodRecord.id == method_id,
                 HostedRedemptionMethodRecord.workspace_id == workspace_id,
@@ -81,8 +81,8 @@ class HostedRedemptionMethodRepository:
         *,
         workspace_id: str,
         name: str,
-        method_type_id: str | None = None,
-        user_id: str | None = None,
+        method_type_id: str,
+        user_id: str,
         is_active: bool = True,
         notes: str | None = None,
     ) -> HostedRedemptionMethod:
@@ -107,8 +107,8 @@ class HostedRedemptionMethodRepository:
         method_id: str,
         workspace_id: str,
         name: str,
-        method_type_id: str | None,
-        user_id: str | None,
+        method_type_id: str,
+        user_id: str,
         is_active: bool,
         notes: str | None,
     ) -> HostedRedemptionMethod | None:

--- a/services/hosted/models.py
+++ b/services/hosted/models.py
@@ -172,8 +172,8 @@ class HostedRedemptionMethod:
     """Redemption method (e.g., 'Chase checking', 'Coinbase BTC') owned by a hosted workspace."""
 
     name: str
-    method_type_id: Optional[str] = None
-    user_id: Optional[str] = None
+    method_type_id: str
+    user_id: str
     workspace_id: Optional[str] = None
     is_active: bool = True
     notes: Optional[str] = None

--- a/services/hosted/models.py
+++ b/services/hosted/models.py
@@ -168,6 +168,42 @@ class HostedCard:
 
 
 @dataclass
+class HostedRedemptionMethod:
+    """Redemption method (e.g., 'Chase checking', 'Coinbase BTC') owned by a hosted workspace."""
+
+    name: str
+    method_type_id: Optional[str] = None
+    user_id: Optional[str] = None
+    workspace_id: Optional[str] = None
+    is_active: bool = True
+    notes: Optional[str] = None
+    id: Optional[str] = None
+    user_name: Optional[str] = None
+    method_type_name: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        self.name = self.name.strip()
+        if not self.name:
+            raise ValueError("Redemption method name is required")
+
+        if self.notes is not None:
+            self.notes = self.notes.strip() or None
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "id": self.id,
+            "workspace_id": self.workspace_id,
+            "name": self.name,
+            "method_type_id": self.method_type_id,
+            "method_type_name": self.method_type_name,
+            "user_id": self.user_id,
+            "user_name": self.user_name,
+            "is_active": self.is_active,
+            "notes": self.notes,
+        }
+
+
+@dataclass
 class HostedRedemptionMethodType:
     """Redemption method type (e.g., Bank, Crypto, Check) owned by a hosted workspace."""
 

--- a/services/hosted/workspace_redemption_method_service.py
+++ b/services/hosted/workspace_redemption_method_service.py
@@ -47,8 +47,8 @@ class HostedWorkspaceRedemptionMethodService:
         *,
         supabase_user_id: str,
         name: str,
-        method_type_id: str | None = None,
-        user_id: str | None = None,
+        method_type_id: str,
+        user_id: str,
         notes: str | None = None,
     ) -> HostedRedemptionMethod:
         candidate = HostedRedemptionMethod(
@@ -78,8 +78,8 @@ class HostedWorkspaceRedemptionMethodService:
         supabase_user_id: str,
         method_id: str,
         name: str,
-        method_type_id: str | None = None,
-        user_id: str | None = None,
+        method_type_id: str,
+        user_id: str,
         notes: str | None = None,
         is_active: bool = True,
     ) -> HostedRedemptionMethod:

--- a/services/hosted/workspace_redemption_method_service.py
+++ b/services/hosted/workspace_redemption_method_service.py
@@ -1,0 +1,168 @@
+"""Hosted workspace-managed redemption methods service."""
+
+from __future__ import annotations
+
+from repositories.hosted_account_repository import HostedAccountRepository
+from repositories.hosted_redemption_method_repository import HostedRedemptionMethodRepository
+from repositories.hosted_workspace_repository import HostedWorkspaceRepository
+from services.hosted.models import HostedRedemptionMethod, HostedWorkspace
+
+
+class HostedWorkspaceRedemptionMethodService:
+    def __init__(self, session_factory) -> None:
+        self.session_factory = session_factory
+        self.account_repository = HostedAccountRepository()
+        self.workspace_repository = HostedWorkspaceRepository()
+        self.method_repository = HostedRedemptionMethodRepository()
+
+    def list_methods_page(
+        self,
+        *,
+        supabase_user_id: str,
+        limit: int,
+        offset: int = 0,
+    ) -> dict[str, object]:
+        with self.session_factory() as session:
+            workspace = self._require_workspace(session, supabase_user_id)
+            total_count = self.method_repository.count_by_workspace_id(session, workspace.id)
+            methods = self.method_repository.list_by_workspace_id(
+                session,
+                workspace.id,
+                limit=limit,
+                offset=offset,
+            )
+            next_offset = offset + len(methods)
+            has_more = next_offset < total_count
+            return {
+                "redemption_methods": methods,
+                "offset": offset,
+                "limit": limit,
+                "next_offset": next_offset,
+                "total_count": total_count,
+                "has_more": has_more,
+            }
+
+    def create_method(
+        self,
+        *,
+        supabase_user_id: str,
+        name: str,
+        method_type_id: str | None = None,
+        user_id: str | None = None,
+        notes: str | None = None,
+    ) -> HostedRedemptionMethod:
+        candidate = HostedRedemptionMethod(
+            name=name,
+            method_type_id=method_type_id,
+            user_id=user_id,
+            notes=notes,
+        )
+
+        with self.session_factory() as session:
+            workspace = self._require_workspace(session, supabase_user_id)
+            created = self.method_repository.create(
+                session,
+                workspace_id=workspace.id,
+                name=candidate.name,
+                method_type_id=candidate.method_type_id,
+                user_id=candidate.user_id,
+                notes=candidate.notes,
+                is_active=candidate.is_active,
+            )
+            session.commit()
+            return created
+
+    def update_method(
+        self,
+        *,
+        supabase_user_id: str,
+        method_id: str,
+        name: str,
+        method_type_id: str | None = None,
+        user_id: str | None = None,
+        notes: str | None = None,
+        is_active: bool = True,
+    ) -> HostedRedemptionMethod:
+        candidate = HostedRedemptionMethod(
+            name=name,
+            method_type_id=method_type_id,
+            user_id=user_id,
+            notes=notes,
+            is_active=is_active,
+        )
+
+        with self.session_factory() as session:
+            workspace = self._require_workspace(session, supabase_user_id)
+            updated = self.method_repository.update(
+                session,
+                method_id=method_id,
+                workspace_id=workspace.id,
+                name=candidate.name,
+                method_type_id=candidate.method_type_id,
+                user_id=candidate.user_id,
+                notes=candidate.notes,
+                is_active=candidate.is_active,
+            )
+            if updated is None:
+                raise LookupError("Hosted redemption method was not found in the authenticated workspace.")
+
+            session.commit()
+            return updated
+
+    def delete_method(
+        self,
+        *,
+        supabase_user_id: str,
+        method_id: str,
+    ) -> None:
+        with self.session_factory() as session:
+            workspace = self._require_workspace(session, supabase_user_id)
+            deleted = self.method_repository.delete(
+                session,
+                method_id=method_id,
+                workspace_id=workspace.id,
+            )
+            if not deleted:
+                raise LookupError("Hosted redemption method was not found in the authenticated workspace.")
+
+            session.commit()
+
+    def delete_methods(
+        self,
+        *,
+        supabase_user_id: str,
+        method_ids: list[str],
+    ) -> int:
+        normalized_ids = list(dict.fromkeys(method_ids))
+        if not normalized_ids:
+            raise ValueError("At least one hosted redemption method id is required.")
+
+        with self.session_factory() as session:
+            workspace = self._require_workspace(session, supabase_user_id)
+            deleted_count = self.method_repository.delete_many(
+                session,
+                method_ids=normalized_ids,
+                workspace_id=workspace.id,
+            )
+            if deleted_count != len(normalized_ids):
+                raise LookupError(
+                    "One or more hosted redemption methods were not found in the authenticated workspace."
+                )
+
+            session.commit()
+            return deleted_count
+
+    def _require_workspace(self, session, supabase_user_id: str) -> HostedWorkspace:
+        account = self.account_repository.get_by_supabase_user_id(session, supabase_user_id)
+        if account is None:
+            raise LookupError(
+                "Hosted workspace bootstrap must complete before managing redemption methods."
+            )
+
+        workspace = self.workspace_repository.get_by_account_id(session, account.id)
+        if workspace is None:
+            raise LookupError(
+                "Hosted workspace bootstrap must complete before managing redemption methods."
+            )
+
+        return workspace

--- a/web/src/components/AppShell.jsx
+++ b/web/src/components/AppShell.jsx
@@ -10,13 +10,14 @@ import UsersTab from "./UsersTab/UsersTab";
 import SitesTab from "./SitesTab/SitesTab";
 import CardsTab from "./CardsTab/CardsTab";
 import MethodTypesTab from "./MethodTypesTab/MethodTypesTab";
+import RedemptionMethodsTab from "./RedemptionMethodsTab/RedemptionMethodsTab";
 
 const setupTabs = [
   { key: "users", label: "Users", icon: "users", enabled: true },
   { key: "sites", label: "Sites", icon: "sites", enabled: true },
   { key: "cards", label: "Cards", icon: "cards", enabled: true },
   { key: "method-types", label: "Method Types", icon: "methodTypes", enabled: true },
-  { key: "redemption-methods", label: "Redemption Methods", icon: "redemptionMethods", enabled: false },
+  { key: "redemption-methods", label: "Redemption Methods", icon: "redemptionMethods", enabled: true },
   { key: "game-types", label: "Game Types", icon: "gameTypes", enabled: false },
   { key: "games", label: "Games", icon: "games", enabled: false },
   { key: "tools", label: "Tools", icon: "tools", enabled: false }
@@ -211,6 +212,12 @@ export default function AppShell({ auth }) {
         ) : null}
         {setupTab === "method-types" ? (
           <MethodTypesTab
+            apiBaseUrl={auth.apiBaseUrl}
+            hostedWorkspaceReady={auth.hostedWorkspaceReady}
+          />
+        ) : null}
+        {setupTab === "redemption-methods" ? (
+          <RedemptionMethodsTab
             apiBaseUrl={auth.apiBaseUrl}
             hostedWorkspaceReady={auth.hostedWorkspaceReady}
           />

--- a/web/src/components/RedemptionMethodsTab/RedemptionMethodModal.jsx
+++ b/web/src/components/RedemptionMethodsTab/RedemptionMethodModal.jsx
@@ -1,0 +1,182 @@
+import { initialRedemptionMethodForm } from "./redemptionMethodsConstants";
+import TypeaheadSelect from "../common/TypeaheadSelect";
+
+export default function RedemptionMethodModal({
+  mode,
+  method,
+  form,
+  setForm,
+  onClose,
+  onSubmit,
+  onRequestEdit,
+  onRequestDelete,
+  submitError,
+  suggestions,
+  users,
+  methodTypes
+}) {
+  const readOnly = mode === "view";
+  const title = mode === "create" ? "Add Redemption Method" : mode === "edit" ? "Edit Redemption Method" : "View Redemption Method";
+  const nameInvalid = !form.name.trim();
+  const closeLabel = readOnly ? "Close" : "Cancel";
+
+  if (readOnly && method) {
+    return (
+      <div className="modal-backdrop" role="presentation" onClick={onClose}>
+        <section
+          className="modal-card site-modal"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="redemption-method-modal-title"
+          onClick={(event) => event.stopPropagation()}
+        >
+          <div className="modal-header">
+            <div>
+              <h2 id="redemption-method-modal-title">View Redemption Method</h2>
+            </div>
+            <button className="ghost-button" type="button" onClick={onClose}>{closeLabel}</button>
+          </div>
+
+          <div className="user-detail-body">
+            <dl className="detail-grid user-detail-grid">
+              <div><dt>Name</dt><dd>{method.name}</dd></div>
+              <div><dt>Method Type</dt><dd>{method.method_type_name || "\u2014"}</dd></div>
+              <div><dt>User</dt><dd>{method.user_name || "\u2014"}</dd></div>
+              <div>
+                <dt>Status</dt>
+                <dd>
+                  <span className={method.is_active ? "status-chip active" : "status-chip inactive"}>
+                    {method.is_active ? "Active" : "Inactive"}
+                  </span>
+                </dd>
+              </div>
+            </dl>
+
+            <div className="user-detail-notes">
+              <p className="detail-label">Notes</p>
+              <div className="notes-display">{method.notes || "-"}</div>
+            </div>
+          </div>
+
+          <div className="modal-actions modal-actions-split">
+            <div className="toolbar-row">
+              <button className="ghost-button" type="button" onClick={onRequestDelete}>Delete</button>
+            </div>
+            <div className="toolbar-row">
+              <button className="primary-button" type="button" onClick={onRequestEdit}>Edit Method</button>
+            </div>
+          </div>
+        </section>
+      </div>
+    );
+  }
+
+  return (
+    <div className="modal-backdrop" role="presentation" onClick={onClose}>
+      <section
+        className="modal-card site-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="redemption-method-modal-title"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="modal-header">
+          <div>
+            <h2 id="redemption-method-modal-title">{title}</h2>
+          </div>
+          <button className="ghost-button" type="button" onClick={onClose}>
+            {closeLabel}
+          </button>
+        </div>
+
+        <div className="form-grid">
+          <label className="field-label" htmlFor="rm-name-input">Name</label>
+          <div>
+            <input
+              id="rm-name-input"
+              className={nameInvalid ? "text-input invalid" : "text-input"}
+              type="text"
+              list="rm-name-suggestions"
+              placeholder="Required"
+              value={form.name}
+              readOnly={readOnly}
+              onChange={(event) => setForm((current) => ({ ...current, name: event.target.value }))}
+            />
+            <datalist id="rm-name-suggestions">
+              {suggestions.names.map((name) => (
+                <option key={name} value={name} />
+              ))}
+            </datalist>
+            {nameInvalid ? <p className="field-error">Name is required.</p> : null}
+          </div>
+
+          <label className="field-label" htmlFor="rm-method-type-input">Method Type</label>
+          <div>
+            <TypeaheadSelect
+              id="rm-method-type-input"
+              options={methodTypes.map((mt) => ({
+                value: mt.id,
+                label: mt.name
+              }))}
+              value={form.method_type_id}
+              onChange={(mtId) => setForm((current) => ({ ...current, method_type_id: mtId }))}
+              placeholder="Search method types..."
+              disabled={readOnly}
+            />
+          </div>
+
+          <label className="field-label" htmlFor="rm-user-input">User</label>
+          <div>
+            <TypeaheadSelect
+              id="rm-user-input"
+              options={users.map((user) => ({
+                value: user.id,
+                label: user.name || user.email || user.id
+              }))}
+              value={form.user_id}
+              onChange={(userId) => setForm((current) => ({ ...current, user_id: userId }))}
+              placeholder="Search users..."
+              disabled={readOnly}
+            />
+          </div>
+
+          <label className="field-label" htmlFor="rm-active-input">Active</label>
+          <label className="toggle-row" htmlFor="rm-active-input">
+            <input
+              id="rm-active-input"
+              type="checkbox"
+              checked={form.is_active}
+              disabled={readOnly}
+              onChange={(event) => setForm((current) => ({ ...current, is_active: event.target.checked }))}
+            />
+            <span>{form.is_active ? "Active" : "Inactive"}</span>
+          </label>
+
+          <label className="field-label field-label-top" htmlFor="rm-notes-input">Notes</label>
+          <textarea
+            id="rm-notes-input"
+            className="notes-input"
+            placeholder="Optional"
+            rows={5}
+            value={form.notes}
+            readOnly={readOnly}
+            onChange={(event) => setForm((current) => ({ ...current, notes: event.target.value }))}
+          />
+        </div>
+
+        {submitError ? <p className="submit-error">{submitError}</p> : null}
+
+        <div className="modal-actions modal-actions-end">
+          <button
+            className="primary-button"
+            type="button"
+            onClick={onSubmit}
+            disabled={nameInvalid}
+          >
+            Save Method
+          </button>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/web/src/components/RedemptionMethodsTab/RedemptionMethodModal.jsx
+++ b/web/src/components/RedemptionMethodsTab/RedemptionMethodModal.jsx
@@ -18,6 +18,9 @@ export default function RedemptionMethodModal({
   const readOnly = mode === "view";
   const title = mode === "create" ? "Add Redemption Method" : mode === "edit" ? "Edit Redemption Method" : "View Redemption Method";
   const nameInvalid = !form.name.trim();
+  const methodTypeInvalid = !form.method_type_id;
+  const userInvalid = !form.user_id;
+  const formInvalid = nameInvalid || methodTypeInvalid || userInvalid;
   const closeLabel = readOnly ? "Close" : "Cancel";
 
   if (readOnly && method) {
@@ -40,8 +43,8 @@ export default function RedemptionMethodModal({
           <div className="user-detail-body">
             <dl className="detail-grid user-detail-grid">
               <div><dt>Name</dt><dd>{method.name}</dd></div>
-              <div><dt>Method Type</dt><dd>{method.method_type_name || "\u2014"}</dd></div>
-              <div><dt>User</dt><dd>{method.user_name || "\u2014"}</dd></div>
+              <div><dt>Method Type</dt><dd>{method.method_type_name}</dd></div>
+              <div><dt>User</dt><dd>{method.user_name}</dd></div>
               <div>
                 <dt>Status</dt>
                 <dd>
@@ -120,10 +123,10 @@ export default function RedemptionMethodModal({
               }))}
               value={form.method_type_id}
               onChange={(mtId) => setForm((current) => ({ ...current, method_type_id: mtId }))}
-              placeholder="Search method types..."
+              placeholder="Required"
               disabled={readOnly}
-              allowClear
             />
+            {methodTypeInvalid ? <p className="field-error">Method type is required.</p> : null}
           </div>
 
           <label className="field-label" htmlFor="rm-user-input">User</label>
@@ -136,10 +139,10 @@ export default function RedemptionMethodModal({
               }))}
               value={form.user_id}
               onChange={(userId) => setForm((current) => ({ ...current, user_id: userId }))}
-              placeholder="Search users..."
+              placeholder="Required"
               disabled={readOnly}
-              allowClear
             />
+            {userInvalid ? <p className="field-error">User is required.</p> : null}
           </div>
 
           <label className="field-label" htmlFor="rm-active-input">Active</label>
@@ -173,7 +176,7 @@ export default function RedemptionMethodModal({
             className="primary-button"
             type="button"
             onClick={onSubmit}
-            disabled={nameInvalid}
+            disabled={formInvalid}
           >
             Save Method
           </button>

--- a/web/src/components/RedemptionMethodsTab/RedemptionMethodModal.jsx
+++ b/web/src/components/RedemptionMethodsTab/RedemptionMethodModal.jsx
@@ -122,6 +122,7 @@ export default function RedemptionMethodModal({
               onChange={(mtId) => setForm((current) => ({ ...current, method_type_id: mtId }))}
               placeholder="Search method types..."
               disabled={readOnly}
+              allowClear
             />
           </div>
 
@@ -137,6 +138,7 @@ export default function RedemptionMethodModal({
               onChange={(userId) => setForm((current) => ({ ...current, user_id: userId }))}
               placeholder="Search users..."
               disabled={readOnly}
+              allowClear
             />
           </div>
 

--- a/web/src/components/RedemptionMethodsTab/RedemptionMethodsTab.jsx
+++ b/web/src/components/RedemptionMethodsTab/RedemptionMethodsTab.jsx
@@ -1,0 +1,130 @@
+import useEntityTable from "../../hooks/useEntityTable";
+import EntityTable from "../common/EntityTable";
+import HighlightMatch from "../common/HighlightMatch";
+import RedemptionMethodModal from "./RedemptionMethodModal";
+import { buildGenericFilterOptions } from "../../utils/tableUtils";
+import {
+  initialRedemptionMethodForm,
+  initialRedemptionMethodColumnFilters,
+  redemptionMethodTableColumns,
+  redemptionMethodsPageSize,
+  redemptionMethodsFallbackPageSize
+} from "./redemptionMethodsConstants";
+import { normalizeRedemptionMethodForm, getRedemptionMethodColumnValue } from "./redemptionMethodsUtils";
+
+// ── Entity config ───────────────────────────────────────────────────────────
+
+const redemptionMethodsConfig = {
+  entityName: "redemption_methods",
+  entitySingular: "redemption method",
+  apiEndpoint: "/v1/workspace/redemption-methods",
+  responseKey: "redemption_methods",
+  batchDeleteIdKey: "redemption_method_ids",
+  columns: redemptionMethodTableColumns,
+  initialForm: initialRedemptionMethodForm,
+  initialColumnFilters: initialRedemptionMethodColumnFilters,
+  pageSize: redemptionMethodsPageSize,
+  fallbackPageSize: redemptionMethodsFallbackPageSize,
+  getColumnValue: getRedemptionMethodColumnValue,
+  getCellDisplayValue: getRedemptionMethodColumnValue,
+  searchFilter: (method, text) =>
+    method.name.toLowerCase().includes(text)
+    || (method.method_type_name || "").toLowerCase().includes(text)
+    || (method.user_name || "").toLowerCase().includes(text)
+    || (method.notes || "").toLowerCase().includes(text),
+  numericSortColumns: [],
+  normalizeForm: normalizeRedemptionMethodForm,
+  itemToForm: (method) => ({
+    name: method.name || "",
+    method_type_id: method.method_type_id || "",
+    user_id: method.user_id || "",
+    notes: method.notes || "",
+    is_active: Boolean(method.is_active)
+  }),
+  formToPayload: (form, mode) => ({
+    name: form.name,
+    method_type_id: form.method_type_id || null,
+    user_id: form.user_id || null,
+    notes: form.notes || null,
+    ...(mode === "edit" ? { is_active: form.is_active } : {})
+  }),
+  buildFilterOptions: (items) => {
+    const options = {};
+    for (const col of redemptionMethodTableColumns) {
+      if (col.key === "status") {
+        options[col.key] = [
+          { value: "Active", label: "Active", path: ["Active"], searchValue: "Active" },
+          { value: "Inactive", label: "Inactive", path: ["Inactive"], searchValue: "Inactive" }
+        ];
+      } else {
+        options[col.key] = buildGenericFilterOptions(items, col.key, getRedemptionMethodColumnValue);
+      }
+    }
+    return options;
+  },
+  buildSuggestions: (items) => ({
+    names: [...new Set(items.map((m) => m.name).filter(Boolean))]
+  }),
+  extraLoaders: [
+    { key: "users", endpoint: "/v1/workspace/users?limit=500&offset=0", responseKey: "users" },
+    { key: "methodTypes", endpoint: "/v1/workspace/redemption-method-types?limit=500&offset=0", responseKey: "redemption_method_types" }
+  ],
+};
+
+// ── Cell renderer ───────────────────────────────────────────────────────────
+
+function renderRedemptionMethodCell(method, columnKey, search) {
+  if (columnKey === "status") {
+    return (
+      <span className={method.is_active ? "status-chip active" : "status-chip inactive"}>
+        <HighlightMatch text={method.is_active ? "Active" : "Inactive"} query={search} />
+      </span>
+    );
+  }
+  if (columnKey === "method_type_name") {
+    return <HighlightMatch text={method.method_type_name || "\u2014"} query={search} />;
+  }
+  if (columnKey === "user_name") {
+    return <HighlightMatch text={method.user_name || "\u2014"} query={search} />;
+  }
+  if (columnKey === "notes") {
+    return <HighlightMatch text={(method.notes || "").slice(0, 100) || "-"} query={search} />;
+  }
+  return <HighlightMatch text={method[columnKey] || ""} query={search} />;
+}
+
+// ── Component ───────────────────────────────────────────────────────────────
+
+export default function RedemptionMethodsTab({ apiBaseUrl, hostedWorkspaceReady }) {
+  const table = useEntityTable(redemptionMethodsConfig, { apiBaseUrl, hostedWorkspaceReady });
+
+  return (
+    <EntityTable
+      table={table}
+      entityName="redemption_methods"
+      entitySingular="redemption method"
+      columns={redemptionMethodTableColumns}
+      getCellDisplayValue={getRedemptionMethodColumnValue}
+      renderCell={renderRedemptionMethodCell}
+      defaultColumnWidths={["22%", "16%", "16%", "10%"]}
+      defaultHeaderGridTemplate="36px 22% 16% 16% 10% 1fr"
+    >
+      {table.modalMode ? (
+        <RedemptionMethodModal
+          mode={table.modalMode}
+          method={table.selectedItem}
+          form={table.form}
+          setForm={table.setForm}
+          submitError={table.submitError}
+          suggestions={table.suggestions}
+          users={table.extraData.users || []}
+          methodTypes={table.extraData.methodTypes || []}
+          onClose={table.requestCloseModal}
+          onRequestEdit={() => table.selectedItem && table.openModal("edit", table.selectedItem)}
+          onRequestDelete={() => table.selectedItem && table.handleDelete([table.selectedItem])}
+          onSubmit={table.submitModal}
+        />
+      ) : null}
+    </EntityTable>
+  );
+}

--- a/web/src/components/RedemptionMethodsTab/redemptionMethodsConstants.js
+++ b/web/src/components/RedemptionMethodsTab/redemptionMethodsConstants.js
@@ -1,0 +1,26 @@
+export const initialRedemptionMethodForm = {
+  name: "",
+  method_type_id: "",
+  user_id: "",
+  notes: "",
+  is_active: true
+};
+
+export const initialRedemptionMethodColumnFilters = {
+  name: [],
+  method_type_name: [],
+  user_name: [],
+  status: [],
+  notes: []
+};
+
+export const redemptionMethodTableColumns = [
+  { key: "name", label: "Name", sortable: true },
+  { key: "method_type_name", label: "Method Type", sortable: true },
+  { key: "user_name", label: "User", sortable: true },
+  { key: "status", label: "Status", sortable: true },
+  { key: "notes", label: "Notes", sortable: true }
+];
+
+export const redemptionMethodsPageSize = 100;
+export const redemptionMethodsFallbackPageSize = 500;

--- a/web/src/components/RedemptionMethodsTab/redemptionMethodsUtils.js
+++ b/web/src/components/RedemptionMethodsTab/redemptionMethodsUtils.js
@@ -1,0 +1,16 @@
+export function normalizeRedemptionMethodForm(form) {
+  return {
+    name: form.name || "",
+    method_type_id: form.method_type_id || "",
+    user_id: form.user_id || "",
+    notes: form.notes || "",
+    is_active: Boolean(form.is_active)
+  };
+}
+
+export function getRedemptionMethodColumnValue(method, columnKey) {
+  if (columnKey === "status") return method.is_active ? "Active" : "Inactive";
+  if (columnKey === "method_type_name") return method.method_type_name || "\u2014";
+  if (columnKey === "user_name") return method.user_name || "\u2014";
+  return String(method[columnKey] || "");
+}

--- a/web/src/components/common/TypeaheadSelect.jsx
+++ b/web/src/components/common/TypeaheadSelect.jsx
@@ -144,9 +144,13 @@ export default function TypeaheadSelect({
       if (committingRef.current) return;
       if (containerRef.current && !containerRef.current.contains(document.activeElement)) {
         setOpen(false);
-        // Revert to the currently committed value's label
-        const selected = options.find((opt) => opt.value === value);
-        setInputText(selected ? selected.label : "");
+        if (allowClear && !inputText.trim()) {
+          onChange("");
+          setInputText("");
+        } else {
+          const selected = options.find((opt) => opt.value === value);
+          setInputText(selected ? selected.label : "");
+        }
       }
     });
   }
@@ -165,13 +169,18 @@ export default function TypeaheadSelect({
     function handlePointerDown(event) {
       if (containerRef.current && !containerRef.current.contains(event.target)) {
         setOpen(false);
-        const selected = options.find((opt) => opt.value === value);
-        setInputText(selected ? selected.label : "");
+        if (allowClear && !inputRef.current?.value.trim()) {
+          onChange("");
+          setInputText("");
+        } else {
+          const selected = options.find((opt) => opt.value === value);
+          setInputText(selected ? selected.label : "");
+        }
       }
     }
     document.addEventListener("mousedown", handlePointerDown);
     return () => document.removeEventListener("mousedown", handlePointerDown);
-  }, [open, options, value]);
+  }, [open, options, value, allowClear, onChange]);
 
   // Ghost text: the full suggestion shown faintly behind the input
   const showGhost = open && ghostText && inputText.trim() && ghostText.toLowerCase() !== inputText.trim().toLowerCase();

--- a/web/src/components/common/TypeaheadSelect.jsx
+++ b/web/src/components/common/TypeaheadSelect.jsx
@@ -12,7 +12,8 @@ export default function TypeaheadSelect({
   onChange,
   placeholder = "Search...",
   disabled = false,
-  invalid = false
+  invalid = false,
+  allowClear = false
 }) {
   const [inputText, setInputText] = useState("");
   const [open, setOpen] = useState(false);
@@ -174,6 +175,19 @@ export default function TypeaheadSelect({
 
   // Ghost text: the full suggestion shown faintly behind the input
   const showGhost = open && ghostText && inputText.trim() && ghostText.toLowerCase() !== inputText.trim().toLowerCase();
+  const showClear = allowClear && !disabled && value;
+
+  function handleClear(event) {
+    event.preventDefault();
+    event.stopPropagation();
+    committingRef.current = true;
+    onChange("");
+    setInputText("");
+    setOpen(false);
+    setHighlightIndex(0);
+    inputRef.current?.focus();
+    requestAnimationFrame(() => { committingRef.current = false; });
+  }
 
   return (
     <div className="typeahead-select" ref={containerRef}>
@@ -187,7 +201,7 @@ export default function TypeaheadSelect({
         <input
           id={id}
           ref={inputRef}
-          className={`text-input typeahead-input${invalid ? " invalid" : ""}`}
+          className={`text-input typeahead-input${invalid ? " invalid" : ""}${showClear ? " typeahead-has-clear" : ""}`}
           type="text"
           autoComplete="off"
           placeholder={placeholder}
@@ -204,6 +218,17 @@ export default function TypeaheadSelect({
           aria-activedescendant={highlightIndex >= 0 ? `${id}-opt-${highlightIndex}` : undefined}
         />
       </div>
+      {showClear ? (
+        <button
+          className="typeahead-clear"
+          type="button"
+          aria-label="Clear selection"
+          tabIndex={-1}
+          onMouseDown={handleClear}
+        >
+          &#x2715;
+        </button>
+      ) : null}
       <span className="typeahead-chevron" aria-hidden="true">
         {open ? "\u25B4" : "\u25BE"}
       </span>

--- a/web/src/components/common/TypeaheadSelect.jsx
+++ b/web/src/components/common/TypeaheadSelect.jsx
@@ -124,6 +124,10 @@ export default function TypeaheadSelect({
       // Do NOT call preventDefault — let native Tab focus-advance happen
       if (filtered.length > 0 && inputText.trim()) {
         commitBestMatch({ blur: false });
+      } else if (allowClear && !inputText.trim()) {
+        setOpen(false);
+        onChange("");
+        setInputText("");
       } else {
         setOpen(false);
         const selected = options.find((opt) => opt.value === value);

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1117,6 +1117,33 @@ h2.breadcrumb-segment {
   z-index: 1;
 }
 
+.typeahead-input.typeahead-has-clear {
+  padding-right: 52px !important;
+}
+
+.typeahead-clear {
+  position: absolute;
+  right: 26px;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 2;
+  border: none;
+  background: none;
+  color: #7e8792;
+  font-size: 0.72rem;
+  line-height: 1;
+  padding: 2px 4px;
+  cursor: pointer;
+  border-radius: 4px;
+  opacity: 0.7;
+  transition: opacity 0.15s, color 0.15s;
+}
+
+.typeahead-clear:hover {
+  opacity: 1;
+  color: var(--text);
+}
+
 .typeahead-ghost {
   position: absolute;
   top: 0;


### PR DESCRIPTION
## Summary

Full-stack implementation of Redemption Methods entity for the web app, closing #252.

This is the first entity with **two FK relationships** (user_id -> Users, method_type_id -> Redemption Method Types), extending the single-FK pattern established by Cards.

## Backend

- **Model**: `HostedRedemptionMethod` dataclass with `user_name` and `method_type_name` display fields
- **Repository**: `HostedRedemptionMethodRepository` with two outerjoin queries (aliased UserRecord + MethodTypeRecord) for resolving FK display names
- **Service**: `HostedWorkspaceRedemptionMethodService` — workspace-scoped CRUD (list, create, update, delete, batch-delete)
- **API**: 5 endpoints at `/v1/workspace/redemption-methods` (GET list, POST create, PATCH update, DELETE single, POST batch-delete)

## Frontend

- **RedemptionMethodsTab**: thin EntityTable config (~120 lines) with two `extraLoaders` (users + method types)
- **RedemptionMethodModal**: view/create/edit modes with two `TypeaheadSelect` dropdowns for User and Method Type (both optional)
- **Constants**: 5 columns (Name, Method Type, User, Status, Notes), form fields, page sizes
- **Utils**: `normalizeRedemptionMethodForm`, `getRedemptionMethodColumnValue`
- **AppShell**: tab enabled, import added, render block wired

## Verification

- All 1196 existing tests pass (0 failures)
- Frontend builds clean (122 modules, 478 kB)
- Follows established EntityTable thin-config pattern

## Pitfalls / Follow-ups

- TypeaheadSelect does not currently support clearing a selection to null (no `allowClear`). Users can work around by not selecting a value. A follow-up could add optional clear button to TypeaheadSelect.
- Both user_id and method_type_id are nullable FKs — the modal does not mark them as required, matching desktop behavior.
