### PR TITLE
feat(web): Game Types full-stack implementation

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -22,6 +22,9 @@ from services.hosted.workspace_redemption_method_type_service import (
 )
 from services.hosted.workspace_site_service import HostedWorkspaceSiteService
 from services.hosted.workspace_user_service import HostedWorkspaceUserService
+from services.hosted.workspace_game_type_service import (
+    HostedWorkspaceGameTypeService,
+)
 from services.hosted.workspace_import_planning_service import (
     HostedWorkspaceImportPlanningService,
 )
@@ -123,6 +126,21 @@ class HostedWorkspaceRedemptionMethodBatchDeleteRequest(BaseModel):
     redemption_method_ids: list[str]
 
 
+class HostedWorkspaceGameTypeCreateRequest(BaseModel):
+    name: str
+    notes: str | None = None
+
+
+class HostedWorkspaceGameTypeUpdateRequest(BaseModel):
+    name: str
+    notes: str | None = None
+    is_active: bool = True
+
+
+class HostedWorkspaceGameTypeBatchDeleteRequest(BaseModel):
+    game_type_ids: list[str]
+
+
 cors_config = load_hosted_backend_config(required=False, require_db_password=False)
 app.add_middleware(
     CORSMiddleware,
@@ -204,6 +222,16 @@ def get_hosted_workspace_redemption_method_service() -> HostedWorkspaceRedemptio
 
     session_factory = get_hosted_session_factory(config.sqlalchemy_url)
     return HostedWorkspaceRedemptionMethodService(session_factory)
+
+
+def get_hosted_workspace_game_type_service() -> HostedWorkspaceGameTypeService:
+    try:
+        config = load_hosted_backend_config(require_db_password=True)
+    except HostedConfigurationError as exc:
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(exc)) from exc
+
+    session_factory = get_hosted_session_factory(config.sqlalchemy_url)
+    return HostedWorkspaceGameTypeService(session_factory)
 
 
 def get_hosted_uploaded_sqlite_inspection_service() -> HostedUploadedSQLiteInspectionService:
@@ -829,6 +857,130 @@ def workspace_redemption_methods_batch_delete(
         deleted_count = service.delete_methods(
             supabase_user_id=session.user_id,
             method_ids=payload.redemption_method_ids,
+        )
+    except LookupError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+    return {"deleted_count": deleted_count}
+
+
+# ── Game Types ───────────────────────────────────────────────────────────
+
+
+@app.get("/v1/workspace/game-types")
+def workspace_game_types_list(
+    limit: int = Query(100, ge=1, le=500),
+    offset: int = Query(0, ge=0),
+    session: AuthenticatedSession = Depends(get_authenticated_session),
+    service: HostedWorkspaceGameTypeService = Depends(
+        get_hosted_workspace_game_type_service
+    ),
+) -> dict[str, object]:
+    try:
+        page = service.list_game_types_page(
+            supabase_user_id=session.user_id,
+            limit=limit,
+            offset=offset,
+        )
+    except LookupError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+
+    return {
+        "game_types": [
+            gt.as_dict() if hasattr(gt, "as_dict") else gt
+            for gt in page["game_types"]
+        ],
+        "offset": page["offset"],
+        "limit": page["limit"],
+        "next_offset": page["next_offset"],
+        "total_count": page["total_count"],
+        "has_more": page["has_more"],
+    }
+
+
+@app.post("/v1/workspace/game-types")
+def workspace_game_types_create(
+    payload: HostedWorkspaceGameTypeCreateRequest = Body(...),
+    session: AuthenticatedSession = Depends(get_authenticated_session),
+    service: HostedWorkspaceGameTypeService = Depends(
+        get_hosted_workspace_game_type_service
+    ),
+) -> dict[str, object]:
+    try:
+        game_type = service.create_game_type(
+            supabase_user_id=session.user_id,
+            name=payload.name,
+            notes=payload.notes,
+        )
+    except LookupError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+    return game_type.as_dict() if hasattr(game_type, "as_dict") else game_type
+
+
+@app.patch("/v1/workspace/game-types/{game_type_id}")
+def workspace_game_types_update(
+    game_type_id: str = Path(...),
+    payload: HostedWorkspaceGameTypeUpdateRequest = Body(...),
+    session: AuthenticatedSession = Depends(get_authenticated_session),
+    service: HostedWorkspaceGameTypeService = Depends(
+        get_hosted_workspace_game_type_service
+    ),
+) -> dict[str, object]:
+    try:
+        game_type = service.update_game_type(
+            supabase_user_id=session.user_id,
+            game_type_id=game_type_id,
+            name=payload.name,
+            notes=payload.notes,
+            is_active=payload.is_active,
+        )
+    except LookupError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+    return game_type.as_dict() if hasattr(game_type, "as_dict") else game_type
+
+
+@app.delete(
+    "/v1/workspace/game-types/{game_type_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+def workspace_game_types_delete(
+    game_type_id: str = Path(...),
+    session: AuthenticatedSession = Depends(get_authenticated_session),
+    service: HostedWorkspaceGameTypeService = Depends(
+        get_hosted_workspace_game_type_service
+    ),
+) -> Response:
+    try:
+        service.delete_game_type(
+            supabase_user_id=session.user_id,
+            game_type_id=game_type_id,
+        )
+    except LookupError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@app.post("/v1/workspace/game-types/batch-delete")
+def workspace_game_types_batch_delete(
+    payload: HostedWorkspaceGameTypeBatchDeleteRequest = Body(...),
+    session: AuthenticatedSession = Depends(get_authenticated_session),
+    service: HostedWorkspaceGameTypeService = Depends(
+        get_hosted_workspace_game_type_service
+    ),
+) -> dict[str, int]:
+    try:
+        deleted_count = service.delete_game_types(
+            supabase_user_id=session.user_id,
+            game_type_ids=payload.game_type_ids,
         )
     except LookupError as exc:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc

--- a/docs/WEB_PORT_PLAN.md
+++ b/docs/WEB_PORT_PLAN.md
@@ -1,0 +1,814 @@
+# Sezzions Web Port — Comprehensive Implementation Plan
+
+**Created**: 2026-04-01
+**Purpose**: Master roadmap for porting the desktop app to the web. Covers all entities, tools, settings, and infrastructure in dependency order with implementation notes derived from thorough review of the desktop codebase, PROJECT_SPEC, and CHANGELOG.
+
+---
+
+## Table of Contents
+
+1. [Current State](#1-current-state)
+2. [Porting Phases Overview](#2-porting-phases-overview)
+3. [Phase 1 — Remaining Setup Entities](#3-phase-1--remaining-setup-entities)
+4. [Phase 2 — Accounting Engine Core](#4-phase-2--accounting-engine-core)
+5. [Phase 3 — Transaction Tabs](#5-phase-3--transaction-tabs)
+6. [Phase 4 — Derived Views & Reports](#6-phase-4--derived-views--reports)
+7. [Phase 5 — Tools & Data Operations](#7-phase-5--tools--data-operations)
+8. [Phase 6 — Settings & Configuration](#8-phase-6--settings--configuration)
+9. [Phase 7 — Operational Modes & Safety](#9-phase-7--operational-modes--safety)
+10. [Phase 8 — Polish & Feature Parity](#10-phase-8--polish--feature-parity)
+11. [Cross-Cutting Concerns](#11-cross-cutting-concerns)
+12. [Supabase-Specific Considerations](#12-supabase-specific-considerations)
+13. [Entity Dependency Graph](#13-entity-dependency-graph)
+14. [Open Questions & Decision Points](#14-open-questions--decision-points)
+
+---
+
+## 1. Current State
+
+### Already Ported (Web)
+| Layer | Entity | Status |
+|-------|--------|--------|
+| Full stack | Users | ✅ Complete |
+| Full stack | Sites | ✅ Complete |
+| Full stack | Cards | ✅ Complete (FK → User) |
+| Full stack | Redemption Method Types | ✅ Complete |
+| Full stack | Redemption Methods | ✅ Complete (FK → User, Method Type) |
+| Persistence record only | Game Types | `HostedGameTypeRecord` exists, no model/repo/service/API/frontend |
+| Persistence record only | Games | `HostedGameRecord` exists, no model/repo/service/API/frontend |
+| Persistence record only | Purchases | `HostedPurchaseRecord` exists |
+| Persistence record only | Redemptions | `HostedRedemptionRecord` exists |
+| Persistence record only | Game Sessions | `HostedGameSessionRecord` exists |
+
+### Shared Web Infrastructure
+- `useEntityTable` hook + `EntityTable` component (shared CRUD table pattern)
+- `TypeaheadSelect` component (with `allowClear` for optional FKs)
+- `ExportModal`, `FilterTreeNode`, `TableContextMenu`, `TableHeaderFilterMenu`
+- `tableUtils.js` for sorting, filtering, column values
+- API pattern: FastAPI endpoints → workspace-scoped services → repositories
+- Auth: Supabase JWT → `AuthenticatedSession` → workspace resolution
+
+### Not Yet Ported
+- All transaction/accounting entities (Purchases, Redemptions, Game Sessions)
+- FIFO accounting engine
+- Recalculation infrastructure
+- Event linking
+- Adjustments & corrections
+- Undo/redo
+- Audit log
+- Reports & summaries
+- Daily sessions
+- Realized transactions / unrealized positions
+- Expenses
+- All Tools (backup/restore/reset/CSV/recalc)
+- All Settings (timezone, tax, themes, notifications)
+- Repair Mode, Maintenance Mode
+
+---
+
+## 2. Porting Phases Overview
+
+The phases are ordered by **data dependency** and **risk**:
+
+```
+Phase 1: Remaining Setup Entities (Game Types, Games)
+   ↓ no accounting logic, pure catalog CRUD
+Phase 2: Accounting Engine Core (FIFO, timestamps, event links)
+   ↓ the foundation all transactions depend on
+Phase 3: Transaction Tabs (Purchases → Redemptions → Game Sessions)
+   ↓ order matters: purchases create FIFO lots, redemptions consume them, sessions wrap them
+Phase 4: Derived Views & Reports (Daily Sessions, Realized, Unrealized, Reports)
+   ↓ read from transaction data
+Phase 5: Tools (Recalculation, CSV import/export, adjustments)
+   ↓ operate on transaction data
+Phase 6: Settings (Timezone, Tax, Themes, Notifications)
+   ↓ configure behavior
+Phase 7: Operational Modes (Repair Mode, Maintenance Mode, Data Integrity)
+   ↓ safety nets
+Phase 8: Polish (Undo/Redo, Audit Log viewer, UX refinements)
+```
+
+**Rationale for this order:**
+- Setup entities are trivial, high-confidence, and unblock FK references for transactions.
+- The accounting engine MUST exist before any transaction can be created (FIFO, timestamps, recalculation).
+- Purchases before Redemptions because redemptions consume purchase lots.
+- Game Sessions last among transactions because they reference games, game_types, AND interact with purchases/redemptions during their lifecycle.
+- Derived views are read-only projections — easy to add once data exists.
+- Tools operate on data, so data must exist first.
+- Settings/modes are operational concerns, not data-critical.
+- Undo/redo is deferred because it's complex and the web app can function without it initially.
+
+---
+
+## 3. Phase 1 — Remaining Setup Entities
+
+### 3a. Game Types (Issue #254)
+
+**What it is**: Simple catalog entity (name, is_active, notes). No FK dependencies.
+
+**Desktop parity notes:**
+- Model: `name` (required, unique per workspace), `is_active`, `notes`
+- Desktop UI: name required, notes optional (collapsible section), is_active checkbox
+- DB constraint: `UNIQUE(workspace_id, name)` — already in `HostedGameTypeRecord`
+- Create: is_active defaults to True (not exposed in create dialog, only edit)
+
+**Implementation**: Standard EntityTable pattern. ~2 hours. Identical structure to Redemption Method Types.
+
+**Backend**: HostedGameType model, hosted_game_type_repository, workspace_game_type_service, 5 API endpoints.
+**Frontend**: GameTypesTab/ with EntityTable config, modal, constants, utils.
+
+### 3b. Games (Issue #255)
+
+**What it is**: Catalog entity with FK → Game Types. Includes optional RTP (Return to Player) percentage.
+
+**Desktop parity notes:**
+- Model: `name` (required), `game_type_id` (required, FK), `rtp` (optional, 0-100), `actual_rtp` (computed, read-only), `is_active`, `notes`
+- Desktop UI: name and game_type required; game_type is editable autocomplete combo; RTP is optional float with range validation
+- `actual_rtp` is computed from game session data — displayed read-only, not editable
+- Desktop has "Recalculate RTP" button in edit dialog — **defer to follow-up** (requires game sessions)
+
+**Implementation**: Uses the Redemption Methods pattern (single FK JOIN). RTP adds a numeric input field.
+
+**Backend**: HostedGame model, hosted_game_repository (JOIN on game_types), workspace_game_service, 5 API endpoints.
+**Frontend**: GamesTab/ with EntityTable + TypeaheadSelect for game_type. Numeric input for RTP with 0-100 validation.
+
+---
+
+## 4. Phase 2 — Accounting Engine Core
+
+This is the **highest-risk, highest-complexity** phase. Every transaction depends on this infrastructure. Must be built and thoroughly tested before any transaction tab.
+
+### 4a. Timestamp Service (Hosted)
+
+**What it does**: Ensures no two events (purchase, redemption, session start/end) for the same (user, site) pair share an exact timestamp. Auto-increments by 1 second on conflict.
+
+**Why it matters**: FIFO allocation order depends on chronological ordering. Duplicate timestamps create ambiguous FIFO.
+
+**Desktop code**: `services/timestamp_service.py` — `ensure_unique_timestamp(user_id, site_id, date, time, exclude_id, entity_type)`
+
+**Web implementation notes:**
+- Port directly as a hosted service
+- Must query across purchases, redemptions, and sessions for the same (user, site) pair
+- Postgres vs SQLite: same logic, different timestamp handling (ISO strings vs native timestamps)
+
+### 4b. FIFO Service (Hosted)
+
+**What it does**: The core cost basis engine. Calculates cost_basis, taxable_profit, and per-purchase allocations for each redemption.
+
+**Desktop code**: `services/fifo_service.py`
+
+**Key semantics:**
+- **PARTIAL redemption** (`more_remaining=True`): Consume purchases in FIFO order up to exactly the redemption amount
+- **FULL redemption** (`more_remaining=False`): Consume ALL remaining basis (regardless of amount), representing a complete close-out
+- `calculate_cost_basis()` → returns `(cost_basis, taxable_profit, allocations[])`
+- `apply_allocation()` → decrements `purchase.remaining_amount`
+- `reverse_allocation()` → restores `purchase.remaining_amount` (for undo/cancel)
+- Allocation source: `purchase_repo.get_available_for_fifo_as_of(user_id, site_id, date, time)` — chronological, non-dormant, remaining > 0
+
+**Web implementation notes:**
+- This must be a backend-only service (never expose FIFO internals to the frontend)
+- Needs `hosted_redemption_allocation_repository` for the junction table
+- Must handle Postgres decimal precision correctly (Decimal, not float)
+- Critical: extensive test coverage with golden scenarios before integration
+
+### 4c. Recalculation Service (Hosted)
+
+**What it does**: Orchestrates "suffix rebuilds" — given a (user_id, site_id, boundary_date, boundary_time), reprocesses all FIFO allocations and session P/L from that point forward.
+
+**Desktop code**: `services/recalculation_service.py` — `rebuild_fifo_for_pair_from()`, `rebuild_all()`
+
+**Why it matters**: Every accounting mutation (create/update/delete purchase, redemption, or session) triggers a partial rebuild from the affected timestamp forward. This ensures all derived data is consistent.
+
+**Web implementation notes:**
+- Must run synchronously within the same DB transaction as the mutation
+- The `_containing_boundary()` logic (finding the enclosing session start) must be ported
+- `rebuild_all()` for full recalculation will be expensive — may need async job queue for web (Celery, background task, etc.)
+- Consider timeout implications for large datasets
+
+### 4d. Event Link Service (Hosted)
+
+**What it does**: Links purchases and redemptions to game sessions with a relation type: `BEFORE`, `DURING`, or `AFTER`.
+
+**Desktop code**: `services/game_session_event_link_service.py`
+
+**Why it matters**: The "Adjusted" badge in session/purchase/redemption tables, and the session view dialog's cross-references, all depend on event links.
+
+**Web implementation notes:**
+- Needs `hosted_game_session_event_link` table/record
+- Rebuild links runs as part of the recalculation chain
+- Lower priority than FIFO/recalc — can be added incrementally
+
+### 4e. Hosted Persistence Records for Derived Tables
+
+The following ORM records need to be created (or confirmed existing) in `services/hosted/persistence.py`:
+- `HostedRedemptionAllocationRecord` — FIFO junction (redemption_id → purchase_id, amount)
+- `HostedRealizedTransactionRecord` — cashflow P/L per redemption
+- `HostedGameSessionEventLinkRecord` — event linking
+- `HostedDailySessionRecord` — aggregated daily view
+- `HostedAdjustmentRecord` — basis adjustments & balance checkpoints
+
+**Check**: Some of these may already exist in persistence.py. Must audit before creating.
+
+---
+
+## 5. Phase 3 — Transaction Tabs
+
+These are built on top of Phase 2's accounting engine. Order is critical.
+
+### 5a. Purchases Tab
+
+**What it is**: Logs every sweep coin purchase (cost basis lot). This is the simplest transaction entity because it doesn't trigger FIFO on create — it just creates a new lot.
+
+**Desktop form fields (required in UI):**
+- Date (required), Time (optional), User (required), Site (required)
+- Amount $ (required, > 0), SC Received (defaults to amount), Post-Purchase SC (required)
+- Payment Card (optional, filtered by user)
+- Cashback $ (auto-calculated from card rate, manually overridable)
+- Notes (optional)
+
+**FK dependencies**: users, sites, cards
+
+**Key business logic to port:**
+- `remaining_amount` initialized to `amount` (FIFO lot)
+- `starting_redeemable_balance` auto-computed from expected balance
+- Active session warning when purchase overlaps an active game session
+- Balance check: expected vs actual post-purchase SC
+- Cashback auto-calculation from card rate
+- Dormant/active status lifecycle
+- FIFO protection: cannot change amount/date if consumed
+
+**Desktop-specific behaviors to reinterpret for web:**
+- Inline date picker (MM/DD/YY + calendar) → web date input component
+- "Today" / "Now" buttons → similar convenience controls
+- Timestamp adjustment info banner → informational display
+- Post-save prompt "Start session now?" → optional follow-up action
+- Travel mode timezone handling → probably defer initially
+- Collapsible notes → match web UX pattern
+
+**New web infrastructure needed:**
+- Date/time input component (reusable across all transaction tabs)
+- Currency input component (decimal formatting, validation)
+- Balance check display component
+- Active session check API endpoint
+
+**Estimated complexity**: HIGH — first transaction entity, sets the pattern for redemptions and sessions.
+
+### 5b. Redemptions Tab
+
+**What it is**: Logs every cash-out. Triggers FIFO allocation against purchases.
+
+**Desktop form fields (required in UI):**
+- Date (required), Time (optional), User (required), Site (required)
+- Method Type (optional, filters Method), Method (optional)
+- Amount $ (required, ≥ 0), Fees $ (optional)
+- Redemption Type: Partial/Full radio (required) — with help tooltip
+- Receipt Date (optional), Processed checkbox
+- Notes (optional)
+
+**FK dependencies**: users, sites, redemption_methods (which → redemption_method_types)
+
+**Key business logic to port:**
+- FIFO allocation on create: PARTIAL vs FULL semantics (see Phase 2)
+- Redemption lifecycle: PENDING → received (receipt_date set) → processed (flag)
+- Cancel/uncancel: `PENDING_CANCEL` when active session exists (deferred cancel)
+- `realized_transaction` creation with FIFO results
+- `redemption_allocations` junction table tracking
+- Active session block: cannot create redemption while session is active for (user, site)
+- Bulk actions: Mark Received (date picker dialog), Mark Processed
+- Row color coding by status (pending/canceled/loss/etc.)
+- Metadata-only vs accounting-field edit paths
+- FIFO reprocessing on accounting-field edits
+
+**Estimated complexity**: VERY HIGH — FIFO integration, status lifecycle, cancel/uncancel, bulk actions.
+
+### 5c. Game Sessions Tab
+
+**What it is**: The primary transaction entity — two-phase lifecycle (Start → End). Calculates per-session taxable P/L.
+
+**Desktop form fields:**
+*Start Session (required in UI):*
+- Date (required), Time (optional), User (required), Site (required)
+- Game Type (optional), Game Name (optional, filtered by game type)
+- Starting Total SC (required, auto-filled from expected), Starting Redeemable SC (required, auto-filled)
+- Notes (optional)
+
+*End Session (required in UI):*
+- End Date (required), End Time (required)
+- Ending Total SC (required), Ending Redeemable SC (required)
+- Wager Amount (optional)
+- Notes (optional)
+
+**FK dependencies**: users, sites, games, game_types
+
+**Key business logic to port:**
+- `compute_expected_balances()` — chronological timeline projection
+- Balance auto-fill and balance check display
+- Active session guard: one per (user, site)
+- P/L calculation formula (see Phase 2 notes): `net_taxable_pl = ((discoverable_sc + delta_redeem) * sc_rate) - basis_consumed`
+- Session close triggers: FIFO recalc, event link rebuild, tax withholding recalc, game RTP sync, daily session sync, PENDING_CANCEL processing, low-balance close prompt
+- "End & Start New" workflow
+- Dormant purchase reactivation on new session start
+- Multi-day session support
+- Travel mode timezone handling
+
+**Estimated complexity**: EXTREME — the most complex entity in the entire app. Every other accounting concept converges here.
+
+**Implementation strategy:**
+1. Start with basic Start Session (create Active) without auto-fill or balance checks
+2. Add End Session (update status to Closed) with manual balances
+3. Wire up expected balance computation
+4. Wire up P/L calculation
+5. Add auto-fill and balance check
+6. Add "End & Start New"
+7. Add low-balance close prompt
+8. Add event linking
+9. Add tax withholding
+10. Add travel mode (if needed)
+
+---
+
+## 6. Phase 4 — Derived Views & Reports
+
+These are read-only projections over transaction data.
+
+### 6a. Daily Sessions View
+
+**What it is**: Aggregated view grouping game sessions by date. Shows daily totals for P/L, purchases, redemptions.
+
+**Desktop code**: `services/daily_sessions_service.py`, `repositories/daily_session_repository.py`
+
+**Web notes**: Could be a virtual computed view or a materialized table. Desktop uses a `daily_sessions` table that's synced on session close.
+
+### 6b. Realized Transactions View
+
+**What it is**: Per-redemption cashflow P/L records (cost_basis, payout, net_pl).
+
+**Desktop code**: Auto-created when redemptions are processed through FIFO.
+
+**Web notes**: Read-only table view. Realized transactions are created by the FIFO engine, not directly by users.
+
+### 6c. Unrealized Positions View
+
+**What it is**: Open FIFO lots — purchases with remaining_amount > 0 grouped by (user, site).
+
+**Desktop code**: `get_unrealized_positions()` in AppFacade
+
+**Web notes**: This is a computed query, not a separate table. Reads from purchases.
+
+### 6d. Reports
+
+**Available reports (all read-only computations):**
+1. **User Summary**: Total purchases, redemptions, sessions, P/L, available balance per user (optional site filter)
+2. **Site Summary**: Same metrics per site (optional user filter)
+3. **Tax Report**: Realized gains/losses via FIFO (user + optional site/date range) — maps to IRS Schedule D concepts
+4. **Session P/L Report**: Win/loss rate, avg P/L, best/worst sessions
+
+**Web implementation options:**
+- API endpoints that run aggregate queries on demand
+- Frontend dashboard components (charts, summary cards)
+- CSV/PDF export for tax reporting
+
+### 6e. Expenses
+
+**What it is**: Simple CRUD entity for tracking business expenses (not casino-related). Desktop has it as a separate tab.
+
+**Model**: amount, date, category, description, receipt_url, notes
+**Web notes**: Straightforward EntityTable. No FIFO involvement. Can be deferred or prioritized based on user need.
+
+---
+
+## 7. Phase 5 — Tools & Data Operations
+
+### 7a. Recalculation Tools (Web)
+
+**What it is**: Manual triggers for FIFO/P&L rebuilds. Desktop has scoped (user/site pair) and full recalculation.
+
+**Web implementation:**
+- API endpoint: `POST /v1/workspace/tools/recalculate` with optional `user_id`, `site_id` scope
+- Full recalculation may be long-running → async job with status polling
+- Stats display endpoint: `GET /v1/workspace/tools/recalculation-stats`
+
+### 7b. CSV Import / Export
+
+**What it is**: Schema-driven bulk data operations. Import supports preview/validate/confirm workflow.
+
+**Desktop code**: `services/tools/csv_import_service.py`, `csv_export_service.py`, `schemas.py`
+
+**Web implementation:**
+- **Export**: API endpoint generates CSV for any entity → browser download
+- **Import**: Multi-step flow: upload → server-side validate/preview → confirm → apply
+- Supports 10 entity types (users, sites, cards, games, game_types, redemption_methods, redemption_method_types, purchases, redemptions, game_sessions)
+- FK resolution: name→ID mapping (e.g., user name in CSV → user_id)
+- Conflict handling: skip or overwrite
+- Post-import recalculation prompt for accounting entities
+
+**Web infrastructure needed:**
+- File upload endpoint
+- Server-side CSV parsing + validation
+- Preview/conflict resolution UI
+- Batch insert/update with FK resolution
+
+### 7c. Adjustments & Corrections
+
+**What it is**: Manual FIFO corrections — two types:
+1. **Basis Adjustment**: Inserts synthetic cost basis at a timestamp (positive or negative delta)
+2. **Balance Checkpoint**: Overrides expected SC balance at a timestamp
+
+**Desktop code**: `services/adjustment_service.py`
+
+**Web implementation:** API endpoints + simple form dialogs. Triggers recalculation from the adjustment timestamp.
+
+### 7d. Database Backup & Restore (Web Adaptation)
+
+**Desktop**: SQLite file copy (online backup API). Backup location, manual backup, auto-backup timer, restore with 3 modes (REPLACE, MERGE_ALL, MERGE_SELECTED).
+
+**Supabase adaptation** (see Section 12 for details):
+- **Backup**: Supabase provides automated daily backups on Pro plan. Manual backups could be implemented as:
+  - CSV export of all workspace data (download as ZIP)
+  - Workspace snapshot to a separate schema or timestamped tables
+  - Supabase Management API for point-in-time recovery (Pro plan)
+- **Restore**: Import from a previous export (CSV ZIP or snapshot)
+- **The desktop's file-level backup doesn't translate** — need to think in terms of workspace-level data snapshots
+
+### 7e. Database Reset
+
+**Desktop**: Clears all data (optionally keeping setup entities and/or audit log).
+
+**Web implementation**: API endpoint to delete all workspace data, with option to keep setup entities (users, sites, cards, games, game_types, methods, method_types). Must require explicit confirmation.
+
+---
+
+## 8. Phase 6 — Settings & Configuration
+
+### 8a. Timezone Settings
+
+**Desktop**: Three TZ concepts:
+- `accounting_time_zone` — the "legal" TZ for tax calculations and date bucketing
+- `current_time_zone` — the user's current wall-clock TZ (may differ if traveling)
+- `travel_mode_enabled` — when True, timestamps are stored with both entry TZ and accounting TZ
+
+**Web implementation options:**
+- Store timezone preference per workspace (accounting TZ)
+- Browser provides `Intl.DateTimeFormat().resolvedOptions().timeZone` for local TZ
+- Travel mode: store entry TZ on each transaction when it differs from accounting TZ
+- **Change Accounting TZ** dialog: migration from one TZ to another with effective date (complex — desktop has a dedicated `timezone_migration_service.py`)
+- **Recommendation**: Start with a single accounting TZ per workspace. Defer travel mode and TZ migration to a later phase.
+
+### 8b. Tax Settings
+
+**Desktop**: Enable/disable withholding estimates, default rate (0-100%), "Recalculate Withholding" bulk action.
+
+**Web implementation:**
+- Workspace-level settings: `tax_withholding_enabled`, `default_withholding_rate_pct`
+- `tax_withholding_service` port for per-date withholding calculation
+- Endpoint to recalculate all withholding
+- **Recommendation**: Port after game sessions (Phase 3c), since tax withholding triggers on session close.
+
+### 8c. Themes
+
+**Desktop**: 3 themes (Light, Dark, Blue) applied via QSS with 12 color tokens.
+
+**Web implementation:**
+- CSS custom properties (already in use — the web app has a theme system via `styles.css`)
+- Theme selector in settings
+- Store preference per user/workspace
+- Easy to implement — just toggle CSS classes or custom property sets
+- **Recommendation**: Implement early for user satisfaction, but low priority vs functionality.
+
+### 8d. Notification Settings
+
+**Desktop**: Configurable thresholds for backup overdue, redemption pending, app updates.
+
+**Web implementation:**
+- Notification rules service port (evaluate periodically or on login)
+- In-app notification center (bell icon + dropdown — desktop has this pattern)
+- Email notifications (optional Supabase integration)
+- Browser push notifications (optional)
+- **Recommendation**: In-app notifications first. Email/push as follow-up.
+
+---
+
+## 9. Phase 7 — Operational Modes & Safety
+
+### 9a. Repair Mode
+
+**Desktop**: Disables automatic cascade recalculation. Edits mark (user, site) pairs as "stale" instead of rebuilding. User manually triggers rebuild when ready.
+
+**Web options:**
+1. **Port directly**: Same concept — workspace-level flag that defers recalculation. Useful for bulk edits or imports where recalculating after every change is expensive.
+2. **Replace with "batch mode"**: Instead of a persistent mode toggle, offer batch operations that defer recalculation (e.g., bulk import with post-import recalc).
+3. **Hybrid**: Auto-detect when many changes are queued and suggest deferring recalculation.
+
+**Recommendation**: Option 2 (batch mode) for web. Persistent repair mode is a desktop UX pattern that doesn't translate well to multi-user web. Batch operations with explicit "recalculate now" are cleaner.
+
+### 9b. Maintenance Mode
+
+**Desktop**: Triggered by data integrity violations at startup. Restricts UI to setup-only. Also entered during restore/reset.
+
+**Web options:**
+1. **Read-only mode**: Lock the workspace from writes during maintenance operations
+2. **Operation-level locking**: Lock individual operations (restore/reset) rather than the whole UI
+3. **Background maintenance**: Data integrity checks run asynchronously; violations flagged but don't block the UI
+
+**Recommendation**: Option 2. Web users shouldn't be locked out of their entire workspace. Use operation-level locks with progress indicators.
+
+### 9c. Data Integrity Checks
+
+**Desktop**: `data_integrity_service.py` — checks for orphan records, broken FK references, inconsistent FIFO state.
+
+**Web implementation:**
+- Periodic background checks (cron job or on-demand API endpoint)
+- Results displayed as warnings in a health dashboard
+- Auto-repair option for fixable issues
+- Postgres constraints provide stronger guarantees than SQLite, so fewer integrity violations expected
+
+---
+
+## 10. Phase 8 — Polish & Feature Parity
+
+### 10a. Undo/Redo
+
+**Desktop**: Excel-like undo/redo stack. JSON snapshots in `settings` table. Max depth configurable (default 100). Undoable entities: purchases, redemptions, game sessions.
+
+**Web implementation options:**
+1. **Port directly**: Server-side undo/redo stack per workspace. Same JSON snapshot approach.
+   - Pro: Exact parity
+   - Con: Complex, storage-heavy
+2. **Simplified version**: Only undo last N operations. No redo.
+   - Pro: Simpler implementation
+   - Con: Less powerful
+3. **Audit-log-based undo**: Use audit log entries to reconstruct previous state.
+   - Pro: No separate stack needed
+   - Con: Slower for complex operations
+
+**Recommendation**: Option 1 for direct parity. The desktop undo/redo is well-tested and users rely on it. Port the service layer as-is, expose via API endpoints.
+
+**API design:**
+- `POST /v1/workspace/undo` — undo last operation
+- `POST /v1/workspace/redo` — redo
+- `GET /v1/workspace/undo-stack` — peek at stack (for UI display of "Undo: Create Purchase")
+
+### 10b. Audit Log
+
+**Desktop**: Structured logging of all CRUD operations with JSON snapshots (old_data, new_data), group_id for multi-step operations, summary_data for compact retention.
+
+**Web implementation:**
+- Port `audit_service.py` to hosted backend
+- `hosted_audit_log` table
+- API endpoint for querying with filters (date range, table, action)
+- Audit log viewer in web UI (table + detail panel)
+- CSV export of audit entries
+- Retention policy (configurable max rows)
+
+### 10c. Spreadsheet UX Features
+
+**Desktop has extensive spreadsheet features that should be web-parity:**
+- Copy selection (Cmd+C)
+- Copy with headers
+- Column header filter dropdowns → **already implemented** in EntityTable
+- Text search → **already implemented**
+- Spreadsheet stats bar (sum, count, average of selected column values)
+- CSV export → **partially implemented** (ExportModal exists)
+- Context menu → **already implemented** (TableContextMenu)
+
+**Remaining**: Stats bar, copy-with-headers keyboard shortcut, date range filter.
+
+### 10d. Date Range Filter
+
+**Desktop**: All transaction tabs have a `DateFilterWidget` (default: Jan 1 of current year → today).
+
+**Web implementation**: Reusable date range picker component. Apply to Purchases, Redemptions, Game Sessions tabs.
+
+### 10e. Quick Filters
+
+**Desktop quick filters by tab:**
+- Game Sessions: "Active Only" checkbox
+- Purchases: "Basis Remaining" checkbox (remaining_amount > 0)
+- Redemptions: "Pending" checkbox, "Unprocessed" checkbox
+
+**Web implementation**: Toggle buttons or checkboxes in table toolbar. Server-side filtering via API query params for performance.
+
+---
+
+## 11. Cross-Cutting Concerns
+
+### 11a. Currency & Decimal Handling
+
+**Desktop**: Python `Decimal` throughout. All money fields stored as REAL in SQLite. Renders with 2-decimal formatting and "$" prefix.
+
+**Web**: JavaScript doesn't have native Decimal. Options:
+- Store as strings in API transport, convert to numbers for display only
+- Use a library like `decimal.js` for client-side calculations
+- **All accounting math MUST happen server-side** — client renders only
+- API should return currency values as strings to prevent floating-point drift
+
+### 11b. Date/Time Handling
+
+**Desktop**: Stores dates as ISO strings in SQLite. Display in `MM/DD/YY` format. Times as `HH:MM:SS`. UTC conversion via `accounting_time_zone_service.py`.
+
+**Web**: ISO 8601 in Postgres. Display format configurable per user preference (but default to American `MM/DD/YY` for parity). All API transport in ISO 8601.
+
+### 11c. Pagination
+
+**Desktop**: No pagination — loads all rows into memory (QTableWidget). Practical since desktop = single user, local DB.
+
+**Web**: Already paginated for setup entities (limit/offset). Transaction tabs will have MORE data — pagination is essential. Consider:
+- Server-side cursors for large datasets
+- Infinite scroll or page-based navigation
+- Default page size of 100 with fallback to 500
+
+### 11d. Real-Time Refresh
+
+**Desktop**: Direct function calls — UI refreshes after every mutation. No stale data concern.
+
+**Web**: After a mutation, the frontend re-fetches the affected data. Already handled by `useEntityTable`'s `loadPage()` after create/update/delete.
+
+### 11e. Error Handling
+
+**Desktop**: Exception → dialog box with message.
+
+**Web**: HTTP error codes → toast notifications or inline error displays. 409 for conflicts, 400 for validation, 404 for missing, 500 for server errors.
+
+### 11f. Concurrency
+
+**Desktop**: Single-user, single-thread (with QThreadPool for background tasks). No concurrency concerns.
+
+**Web**: Multi-tab, potentially multi-device. Need:
+- Optimistic locking on updates (check `updated_at` timestamp)
+- Transaction isolation for FIFO operations
+- Row-level locks during recalculation
+
+---
+
+## 12. Supabase-Specific Considerations
+
+### 12a. Backup Strategy
+
+Desktop SQLite backup doesn't translate. Supabase options:
+
+1. **Supabase Automated Backups** (Pro plan): Daily backups with point-in-time recovery. No custom code needed, but workspace-level granularity may not be available (it's project-level).
+
+2. **Workspace Data Export**: API endpoint that exports all workspace data as JSON or CSV ZIP. User-triggered "Download My Data" button.
+   - Pro: User-controlled, works regardless of Supabase plan
+   - Con: Import requires separate restore flow
+
+3. **Snapshot Tables**: Copy workspace data to timestamped tables or a `workspace_snapshots` schema.
+   - Pro: Fast restore (just copy back)
+   - Con: Storage cost, complexity
+
+4. **Supabase Database Functions**: pg_dump equivalent via custom RPC function.
+
+**Recommendation**: Start with Option 2 (workspace data export/import as ZIP). It's the most portable and doesn't depend on Supabase plan tier. Add snapshot tables later if users want instant restore.
+
+### 12b. Row-Level Security
+
+Supabase RLS policies should ensure:
+- Users can only access their own workspace's data
+- Workspace membership verified via `workspace_id` on every row
+- Service role used for cross-workspace operations (admin only)
+
+### 12c. Database Migrations
+
+Desktop uses `CREATE TABLE IF NOT EXISTS` (auto-create). Supabase needs:
+- Alembic or raw SQL migration files
+- Version-tracked schema changes
+- Rollback capability
+- Applied via `supabase db push` or migration tool
+
+### 12d. Performance
+
+SQLite is fast for single-user reads. Postgres may be slower for complex JOINs but better for concurrent access. Monitor:
+- FIFO calculation query performance (multiple JOINs on purchases)
+- Recalculation time for large datasets
+- Index strategy for (workspace_id, user_id, site_id) compound queries
+
+---
+
+## 13. Entity Dependency Graph
+
+```
+Users (standalone)
+Sites (standalone)
+Cards (→ Users)
+Game Types (standalone)
+Games (→ Game Types)
+Redemption Method Types (standalone)
+Redemption Methods (→ Users, → Redemption Method Types)
+Purchases (→ Users, → Sites, → Cards)
+Redemptions (→ Users, → Sites, → Redemption Methods)
+Game Sessions (→ Users, → Sites, → Games, → Game Types)
+  ├── triggers: FIFO recalc, event linking, daily session sync
+  ├── triggers: tax withholding recalc
+  └── triggers: game RTP update
+Realized Transactions (derived from Redemptions + FIFO)
+Redemption Allocations (derived from Redemptions + Purchases + FIFO)
+Daily Sessions (derived from Game Sessions)
+Unrealized Positions (derived from Purchases)
+Event Links (derived from Sessions + Purchases + Redemptions)
+Adjustments (standalone, triggers recalc)
+Expenses (standalone)
+Audit Log (records all mutations)
+Undo/Redo Stack (references audit log)
+```
+
+---
+
+## 14. Open Questions & Decision Points
+
+These should be discussed and resolved before or during implementation:
+
+### Q1: Travel Mode — Port or Defer?
+The desktop tracks `entry_time_zone` on every transaction for users who play from different timezones. This is complex (dual TZ storage, migration prompts, globe badges). **Recommendation**: Defer to Phase 6+ unless the user actively uses travel mode.
+
+### Q2: Undo/Redo Stack — Full Port or Simplified?
+The desktop undo/redo is powerful but complex (JSON snapshots, recalculation triggers, stack pruning). **Recommendation**: Full port for parity, but in a later phase. The web app can function without it initially.
+
+### Q3: Auto-Fill Balances — How to Handle Latency?
+Desktop auto-fills starting balances instantly (local DB). Web has network latency. Options:
+- Pre-fetch expected balances when the dialog opens
+- Show loading spinner while computing
+- Cache last-known balances client-side
+
+### Q4: "End & Start New" Workflow — Web UX?
+Desktop chains dialogs (close → prefill new open). Web could:
+- Use a multi-step wizard
+- Auto-populate a new "Start Session" form after ending
+- Offer a single combined "End & Start New" modal
+
+### Q5: Low-Balance Close Prompt — Web UX?
+Desktop shows a secondary confirmation dialog after session close when balance is below threshold. Web could use a toast/modal prompt or make it a configurable auto-action.
+
+### Q6: Bulk Actions (Mark Received, Mark Processed) — Web UX?
+Desktop uses multi-select + toolbar buttons + date picker dialog. Web `EntityTable` already supports multi-select + batch delete. Extend with custom bulk action buttons.
+
+### Q7: Supabase Backup — What Tier?
+If on Free plan, only workspace data export is available. Pro plan enables automated backups. This affects the backup/restore feature design.
+
+### Q8: Real-Time Notifications — In-App Only or Also Push/Email?
+Desktop has in-app bell only. Web could add email alerts. **Recommendation**: In-app first, email as follow-up.
+
+### Q9: Repair Mode — Port or Replace?
+See Section 9a. **Recommendation**: Replace with batch-mode semantics for web.
+
+### Q10: Expenses — Priority?
+Desktop has expenses as a standalone tab. It's simple CRUD with no FIFO involvement. Priority depends on user need. Can be added at any time.
+
+---
+
+## Appendix: Estimated Implementation Order (Issue-by-Issue)
+
+Each line below represents roughly one GitHub Issue + PR:
+
+```
+PHASE 1 — SETUP ENTITIES
+  [x] Issue #254: Game Types (full stack)
+  [x] Issue #255: Games (full stack, FK → Game Types)
+
+PHASE 2 — ACCOUNTING ENGINE
+  [ ] Hosted timestamp service
+  [ ] Hosted FIFO service + redemption_allocations table
+  [ ] Hosted recalculation service (scoped + full)
+  [ ] Hosted event link service
+
+PHASE 3 — TRANSACTION TABS
+  [ ] Purchases: backend (model, repo, service, API) + frontend basic CRUD
+  [ ] Purchases: balance check + cashback auto-calc + active session warning
+  [ ] Redemptions: backend (model, repo, service, API) + FIFO integration
+  [ ] Redemptions: frontend CRUD + status lifecycle + bulk actions
+  [ ] Game Sessions: backend (model, repo, service, API) + basic start/end
+  [ ] Game Sessions: expected balance computation + auto-fill
+  [ ] Game Sessions: P/L calculation + recalculation chain
+  [ ] Game Sessions: end & start new + low-balance close + event linking
+
+PHASE 4 — DERIVED VIEWS
+  [ ] Daily sessions view
+  [ ] Realized transactions view
+  [ ] Unrealized positions view
+  [ ] Reports: user summary, site summary, tax report, session P/L
+
+PHASE 5 — TOOLS
+  [ ] Recalculation tools (scoped + full)
+  [ ] CSV export (all entities)
+  [ ] CSV import (preview/validate/confirm flow)
+  [ ] Adjustments & corrections
+  [ ] Workspace data backup (export as ZIP)
+  [ ] Workspace data restore (import from ZIP)
+  [ ] Database reset
+
+PHASE 6 — SETTINGS
+  [ ] Timezone: accounting TZ per workspace
+  [ ] Tax: withholding enable/rate/recalculate
+  [ ] Themes: Light/Dark toggle
+  [ ] Notifications: rules + in-app bell
+
+PHASE 7 — OPERATIONAL MODES
+  [ ] Batch mode (deferred recalculation for bulk operations)
+  [ ] Data integrity checks (background + health dashboard)
+
+PHASE 8 — POLISH
+  [ ] Undo/redo stack
+  [ ] Audit log viewer
+  [ ] Date range filter component
+  [ ] Stats bar (selection sum/avg/count)
+  [ ] Keyboard shortcuts (Cmd+Z undo, Cmd+C copy, etc.)
+```

--- a/docs/archive/2026-04-01-issue-game-types-body.md
+++ b/docs/archive/2026-04-01-issue-game-types-body.md
@@ -1,0 +1,51 @@
+## Problem / Motivation
+
+The Game Types entity has no web implementation yet. The desktop app has a fully functional Game Types tab (Setup > Game Types) with CRUD operations, but the web app only has a disabled sidebar stub. Game Types are a prerequisite for the Games entity (FK dependency).
+
+## Proposal
+
+Implement full-stack Game Types web support using the established EntityTable pattern:
+
+### Backend
+- Add `HostedGameType` domain model to `services/hosted/models.py`
+- Create `hosted_game_type_repository.py` (standard workspace-scoped CRUD)
+- Create `workspace_game_type_service.py`
+- Add 5 API endpoints at `/v1/workspace/game-types` (list, create, update, delete, batch-delete)
+
+### Frontend
+- Create `GameTypesTab/` with EntityTable config, modal, constants, utils
+- Fields: name (required), is_active, notes
+- Enable the tab in AppShell
+
+### Desktop parity
+- Desktop UI requires: name (required)
+- Desktop UI optional: notes, is_active (default true)
+- Desktop enforces unique name per workspace
+- Notes section is collapsible in desktop
+
+## Scope
+
+- [x] Hosted domain model
+- [x] Hosted repository
+- [x] Hosted service
+- [x] API endpoints (5)
+- [x] Frontend tab (EntityTable pattern)
+- [x] Frontend modal (view/create/edit)
+- [x] Enable tab in AppShell
+- [x] Changelog entry
+
+## Acceptance Criteria
+
+- Game Types tab loads and displays existing game types
+- Can create a new game type with name (required) and optional notes
+- Can edit an existing game type (name, is_active, notes)
+- Can delete single and batch-delete game types
+- Name is required (validation error shown if empty)
+- All 1196+ existing tests still pass
+- Frontend builds cleanly
+
+## Test Plan
+
+- Backend: model validation (name required, strip whitespace)
+- Frontend: vite build passes
+- Full pytest suite passes

--- a/docs/archive/2026-04-01-issue-games-body.md
+++ b/docs/archive/2026-04-01-issue-games-body.md
@@ -1,0 +1,59 @@
+## Problem / Motivation
+
+The Games entity has no web implementation yet. The desktop app has a fully functional Games tab (Setup > Games) with CRUD operations, FK dropdown for Game Type, and optional RTP fields. Games are referenced by Game Sessions (the core transaction entity) and Purchases.
+
+## Proposal
+
+Implement full-stack Games web support using the established EntityTable pattern:
+
+### Backend
+- Add `HostedGame` domain model to `services/hosted/models.py`
+- Create `hosted_game_repository.py` (workspace-scoped CRUD with game_type JOIN for display name)
+- Create `workspace_game_service.py`
+- Add 5 API endpoints at `/v1/workspace/games` (list, create, update, delete, batch-delete)
+
+### Frontend
+- Create `GamesTab/` with EntityTable config, modal, constants, utils
+- Fields: name (required), game_type_id (required, TypeaheadSelect), rtp (optional, 0-100), actual_rtp (read-only display), is_active, notes
+- Use `extraLoaders` for game types FK data
+- Enable the tab in AppShell
+
+### Desktop parity
+- Desktop UI requires: name, game_type_id (both required in UI)
+- Desktop UI optional: rtp (float 0-100), notes, is_active
+- actual_rtp is computed/read-only (displayed but not editable)
+- Game Type dropdown uses editable autocomplete with inline completion
+- Desktop has a "Recalculate RTP" button on edit — defer to follow-up
+
+## Scope
+
+- [x] Hosted domain model
+- [x] Hosted repository (with game_type JOIN)
+- [x] Hosted service
+- [x] API endpoints (5)
+- [x] Frontend tab (EntityTable pattern)
+- [x] Frontend modal (view/create/edit with TypeaheadSelect for game type)
+- [x] Enable tab in AppShell
+- [x] Changelog entry
+
+## Out of Scope (Follow-ups)
+- Recalculate RTP button (requires game session data)
+- Game view dialog with session history / date range filter
+
+## Acceptance Criteria
+
+- Games tab loads and displays existing games with game_type_name resolved
+- Can create a new game with name (required), game_type (required), optional rtp/notes
+- Can edit an existing game
+- Can delete single and batch-delete games
+- Name and Game Type are required (validation errors shown)
+- RTP validates 0-100 range if provided
+- actual_rtp is displayed read-only
+- All existing tests still pass
+- Frontend builds cleanly
+
+## Test Plan
+
+- Backend: model validation (name required, game_type_id required, rtp 0-100 range)
+- Frontend: vite build passes
+- Full pytest suite passes

--- a/docs/status/CHANGELOG.md
+++ b/docs/status/CHANGELOG.md
@@ -12,6 +12,28 @@ Rules:
 ## 2026-04-01
 
 ```yaml
+id: 2026-04-01-03
+type: feature
+areas: [web, api]
+issue: "#254"
+summary: "Game Types — full-stack web implementation"
+details: >
+  Full-stack Game Types entity (name, is_active, notes) following EntityTable pattern.
+  Backend: HostedGameType model, hosted_game_type_repository, workspace_game_type_service,
+  5 API endpoints at /v1/workspace/game-types. Frontend: thin EntityTable config with
+  GameTypeModal (view/create/edit). Tab enabled in AppShell.
+  Persistence record (HostedGameTypeRecord) already existed.
+
+files_changed:
+  - services/hosted/models.py (add HostedGameType)
+  - repositories/hosted_game_type_repository.py (new)
+  - services/hosted/workspace_game_type_service.py (new)
+  - api/app.py (request models + dependency + 5 endpoints)
+  - web/src/components/GameTypesTab/ (new — 4 files)
+  - web/src/components/AppShell.jsx (enable game-types tab)
+```
+
+```yaml
 id: 2026-04-01-02
 type: feature
 areas: [web, api]

--- a/repositories/hosted_game_type_repository.py
+++ b/repositories/hosted_game_type_repository.py
@@ -1,0 +1,119 @@
+"""Persistence helpers for hosted workspace-owned game types."""
+
+from __future__ import annotations
+
+from sqlalchemy import delete, func, select
+
+from services.hosted.models import HostedGameType
+from services.hosted.persistence import HostedGameTypeRecord
+
+
+class HostedGameTypeRepository:
+    def list_by_workspace_id(
+        self,
+        session,
+        workspace_id: str,
+        *,
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> list[HostedGameType]:
+        query = (
+            select(HostedGameTypeRecord)
+            .where(HostedGameTypeRecord.workspace_id == workspace_id)
+            .order_by(HostedGameTypeRecord.name.asc(), HostedGameTypeRecord.id.asc())
+            .offset(offset)
+        )
+        if limit is not None:
+            query = query.limit(limit)
+
+        records = session.scalars(query).all()
+        return [self._record_to_model(record) for record in records]
+
+    def count_by_workspace_id(self, session, workspace_id: str) -> int:
+        return session.scalar(
+            select(func.count())
+            .select_from(HostedGameTypeRecord)
+            .where(HostedGameTypeRecord.workspace_id == workspace_id)
+        ) or 0
+
+    def create(
+        self,
+        session,
+        *,
+        workspace_id: str,
+        name: str,
+        notes: str | None = None,
+        is_active: bool = True,
+    ) -> HostedGameType:
+        record = HostedGameTypeRecord(
+            workspace_id=workspace_id,
+            name=name,
+            notes=notes,
+            is_active=is_active,
+        )
+        session.add(record)
+        session.flush()
+        return self._record_to_model(record)
+
+    def update(
+        self,
+        session,
+        *,
+        game_type_id: str,
+        workspace_id: str,
+        name: str,
+        notes: str | None,
+        is_active: bool,
+    ) -> HostedGameType | None:
+        record = session.scalar(
+            select(HostedGameTypeRecord).where(
+                HostedGameTypeRecord.id == game_type_id,
+                HostedGameTypeRecord.workspace_id == workspace_id,
+            )
+        )
+        if record is None:
+            return None
+
+        record.name = name
+        record.notes = notes
+        record.is_active = is_active
+        session.flush()
+        return self._record_to_model(record)
+
+    def delete(self, session, *, game_type_id: str, workspace_id: str) -> bool:
+        record = session.scalar(
+            select(HostedGameTypeRecord).where(
+                HostedGameTypeRecord.id == game_type_id,
+                HostedGameTypeRecord.workspace_id == workspace_id,
+            )
+        )
+        if record is None:
+            return False
+
+        session.delete(record)
+        session.flush()
+        return True
+
+    def delete_many(self, session, *, game_type_ids: list[str], workspace_id: str) -> int:
+        normalized_ids = list(dict.fromkeys(game_type_ids))
+        if not normalized_ids:
+            return 0
+
+        result = session.execute(
+            delete(HostedGameTypeRecord).where(
+                HostedGameTypeRecord.workspace_id == workspace_id,
+                HostedGameTypeRecord.id.in_(normalized_ids),
+            )
+        )
+        session.flush()
+        return int(result.rowcount or 0)
+
+    @staticmethod
+    def _record_to_model(record: HostedGameTypeRecord) -> HostedGameType:
+        return HostedGameType(
+            id=record.id,
+            workspace_id=record.workspace_id,
+            name=record.name,
+            is_active=record.is_active,
+            notes=record.notes,
+        )

--- a/services/hosted/models.py
+++ b/services/hosted/models.py
@@ -229,3 +229,31 @@ class HostedRedemptionMethodType:
             "is_active": self.is_active,
             "notes": self.notes,
         }
+
+
+@dataclass
+class HostedGameType:
+    """Game type (e.g., Slots, Table Games, Live Dealer) owned by a hosted workspace."""
+
+    name: str
+    workspace_id: Optional[str] = None
+    is_active: bool = True
+    notes: Optional[str] = None
+    id: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        self.name = self.name.strip()
+        if not self.name:
+            raise ValueError("Game type name is required")
+
+        if self.notes is not None:
+            self.notes = self.notes.strip() or None
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "id": self.id,
+            "workspace_id": self.workspace_id,
+            "name": self.name,
+            "is_active": self.is_active,
+            "notes": self.notes,
+        }

--- a/services/hosted/workspace_game_type_service.py
+++ b/services/hosted/workspace_game_type_service.py
@@ -1,0 +1,149 @@
+"""Hosted workspace-managed game types service."""
+
+from __future__ import annotations
+
+from repositories.hosted_account_repository import HostedAccountRepository
+from repositories.hosted_game_type_repository import HostedGameTypeRepository
+from repositories.hosted_workspace_repository import HostedWorkspaceRepository
+from services.hosted.models import HostedGameType, HostedWorkspace
+
+
+class HostedWorkspaceGameTypeService:
+    def __init__(self, session_factory) -> None:
+        self.session_factory = session_factory
+        self.account_repository = HostedAccountRepository()
+        self.workspace_repository = HostedWorkspaceRepository()
+        self.game_type_repository = HostedGameTypeRepository()
+
+    def list_game_types_page(
+        self,
+        *,
+        supabase_user_id: str,
+        limit: int,
+        offset: int = 0,
+    ) -> dict[str, object]:
+        with self.session_factory() as session:
+            workspace = self._require_workspace(session, supabase_user_id)
+            total_count = self.game_type_repository.count_by_workspace_id(session, workspace.id)
+            game_types = self.game_type_repository.list_by_workspace_id(
+                session,
+                workspace.id,
+                limit=limit,
+                offset=offset,
+            )
+            next_offset = offset + len(game_types)
+            has_more = next_offset < total_count
+            return {
+                "game_types": game_types,
+                "offset": offset,
+                "limit": limit,
+                "next_offset": next_offset,
+                "total_count": total_count,
+                "has_more": has_more,
+            }
+
+    def create_game_type(
+        self,
+        *,
+        supabase_user_id: str,
+        name: str,
+        notes: str | None = None,
+    ) -> HostedGameType:
+        candidate = HostedGameType(name=name, notes=notes)
+
+        with self.session_factory() as session:
+            workspace = self._require_workspace(session, supabase_user_id)
+            created = self.game_type_repository.create(
+                session,
+                workspace_id=workspace.id,
+                name=candidate.name,
+                notes=candidate.notes,
+                is_active=candidate.is_active,
+            )
+            session.commit()
+            return created
+
+    def update_game_type(
+        self,
+        *,
+        supabase_user_id: str,
+        game_type_id: str,
+        name: str,
+        notes: str | None = None,
+        is_active: bool = True,
+    ) -> HostedGameType:
+        candidate = HostedGameType(name=name, notes=notes, is_active=is_active)
+
+        with self.session_factory() as session:
+            workspace = self._require_workspace(session, supabase_user_id)
+            updated = self.game_type_repository.update(
+                session,
+                game_type_id=game_type_id,
+                workspace_id=workspace.id,
+                name=candidate.name,
+                notes=candidate.notes,
+                is_active=candidate.is_active,
+            )
+            if updated is None:
+                raise LookupError("Hosted game type was not found in the authenticated workspace.")
+
+            session.commit()
+            return updated
+
+    def delete_game_type(
+        self,
+        *,
+        supabase_user_id: str,
+        game_type_id: str,
+    ) -> None:
+        with self.session_factory() as session:
+            workspace = self._require_workspace(session, supabase_user_id)
+            deleted = self.game_type_repository.delete(
+                session,
+                game_type_id=game_type_id,
+                workspace_id=workspace.id,
+            )
+            if not deleted:
+                raise LookupError("Hosted game type was not found in the authenticated workspace.")
+
+            session.commit()
+
+    def delete_game_types(
+        self,
+        *,
+        supabase_user_id: str,
+        game_type_ids: list[str],
+    ) -> int:
+        normalized_ids = list(dict.fromkeys(game_type_ids))
+        if not normalized_ids:
+            raise ValueError("At least one hosted game type id is required.")
+
+        with self.session_factory() as session:
+            workspace = self._require_workspace(session, supabase_user_id)
+            deleted_count = self.game_type_repository.delete_many(
+                session,
+                game_type_ids=normalized_ids,
+                workspace_id=workspace.id,
+            )
+            if deleted_count != len(normalized_ids):
+                raise LookupError(
+                    "One or more hosted game types were not found in the authenticated workspace."
+                )
+
+            session.commit()
+            return deleted_count
+
+    def _require_workspace(self, session, supabase_user_id: str) -> HostedWorkspace:
+        account = self.account_repository.get_by_supabase_user_id(session, supabase_user_id)
+        if account is None:
+            raise LookupError(
+                "Hosted workspace bootstrap must complete before managing game types."
+            )
+
+        workspace = self.workspace_repository.get_by_account_id(session, account.id)
+        if workspace is None:
+            raise LookupError(
+                "Hosted workspace bootstrap must complete before managing game types."
+            )
+
+        return workspace

--- a/web/src/components/AppShell.jsx
+++ b/web/src/components/AppShell.jsx
@@ -11,6 +11,7 @@ import SitesTab from "./SitesTab/SitesTab";
 import CardsTab from "./CardsTab/CardsTab";
 import MethodTypesTab from "./MethodTypesTab/MethodTypesTab";
 import RedemptionMethodsTab from "./RedemptionMethodsTab/RedemptionMethodsTab";
+import GameTypesTab from "./GameTypesTab/GameTypesTab";
 
 const setupTabs = [
   { key: "users", label: "Users", icon: "users", enabled: true },
@@ -18,7 +19,7 @@ const setupTabs = [
   { key: "cards", label: "Cards", icon: "cards", enabled: true },
   { key: "method-types", label: "Method Types", icon: "methodTypes", enabled: true },
   { key: "redemption-methods", label: "Redemption Methods", icon: "redemptionMethods", enabled: true },
-  { key: "game-types", label: "Game Types", icon: "gameTypes", enabled: false },
+  { key: "game-types", label: "Game Types", icon: "gameTypes", enabled: true },
   { key: "games", label: "Games", icon: "games", enabled: false },
   { key: "tools", label: "Tools", icon: "tools", enabled: false }
 ];
@@ -218,6 +219,12 @@ export default function AppShell({ auth }) {
         ) : null}
         {setupTab === "redemption-methods" ? (
           <RedemptionMethodsTab
+            apiBaseUrl={auth.apiBaseUrl}
+            hostedWorkspaceReady={auth.hostedWorkspaceReady}
+          />
+        ) : null}
+        {setupTab === "game-types" ? (
+          <GameTypesTab
             apiBaseUrl={auth.apiBaseUrl}
             hostedWorkspaceReady={auth.hostedWorkspaceReady}
           />

--- a/web/src/components/GameTypesTab/GameTypeModal.jsx
+++ b/web/src/components/GameTypesTab/GameTypeModal.jsx
@@ -1,0 +1,142 @@
+import { initialGameTypeForm } from "./gameTypesConstants";
+
+export default function GameTypeModal({
+  mode,
+  gameType,
+  form,
+  setForm,
+  onClose,
+  onSubmit,
+  onRequestEdit,
+  onRequestDelete,
+  submitError,
+  suggestions
+}) {
+  const readOnly = mode === "view";
+  const title = mode === "create" ? "Add Game Type" : mode === "edit" ? "Edit Game Type" : "View Game Type";
+  const nameInvalid = !form.name.trim();
+  const closeLabel = readOnly ? "Close" : "Cancel";
+
+  if (readOnly && gameType) {
+    return (
+      <div className="modal-backdrop" role="presentation" onClick={onClose}>
+        <section
+          className="modal-card game-type-modal"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="game-type-modal-title"
+          onClick={(event) => event.stopPropagation()}
+        >
+          <div className="modal-header">
+            <div>
+              <h2 id="game-type-modal-title">View Game Type</h2>
+            </div>
+            <button className="ghost-button" type="button" onClick={onClose}>{closeLabel}</button>
+          </div>
+
+          <div className="user-detail-body">
+            <dl className="detail-grid user-detail-grid">
+              <div><dt>Name</dt><dd>{gameType.name}</dd></div>
+              <div>
+                <dt>Status</dt>
+                <dd>
+                  <span className={gameType.is_active ? "status-chip active" : "status-chip inactive"}>
+                    {gameType.is_active ? "Active" : "Inactive"}
+                  </span>
+                </dd>
+              </div>
+            </dl>
+
+            <div className="user-detail-notes">
+              <p className="detail-label">Notes</p>
+              <div className="notes-display">{gameType.notes || "-"}</div>
+            </div>
+          </div>
+
+          <div className="modal-actions modal-actions-split">
+            <div className="toolbar-row">
+              <button className="ghost-button" type="button" onClick={onRequestDelete}>Delete</button>
+            </div>
+            <div className="toolbar-row">
+              <button className="primary-button" type="button" onClick={onRequestEdit}>Edit Game Type</button>
+            </div>
+          </div>
+        </section>
+      </div>
+    );
+  }
+
+  return (
+    <div className="modal-backdrop" role="presentation" onClick={onClose}>
+      <section
+        className="modal-card game-type-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="game-type-modal-title"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="modal-header">
+          <div>
+            <h2 id="game-type-modal-title">{title}</h2>
+          </div>
+          <button className="ghost-button" type="button" onClick={onClose}>
+            {closeLabel}
+          </button>
+        </div>
+
+        <div className="form-grid">
+          <label className="field-label" htmlFor="game-type-name-input">Name</label>
+          <div>
+            <input
+              id="game-type-name-input"
+              className={nameInvalid ? "text-input invalid" : "text-input"}
+              type="text"
+              list="game-type-name-suggestions"
+              placeholder="Required"
+              value={form.name}
+              readOnly={readOnly}
+              onChange={(event) => setForm((current) => ({ ...current, name: event.target.value }))}
+            />
+            <datalist id="game-type-name-suggestions">
+              {suggestions.names.map((name) => (
+                <option key={name} value={name} />
+              ))}
+            </datalist>
+            {nameInvalid ? <p className="field-error">Name is required.</p> : null}
+          </div>
+
+          <label className="field-label" htmlFor="game-type-active-input">Active</label>
+          <label className="toggle-row" htmlFor="game-type-active-input">
+            <input
+              id="game-type-active-input"
+              type="checkbox"
+              checked={form.is_active}
+              disabled={readOnly}
+              onChange={(event) => setForm((current) => ({ ...current, is_active: event.target.checked }))}
+            />
+            <span>{form.is_active ? "Active" : "Inactive"}</span>
+          </label>
+
+          <label className="field-label field-label-top" htmlFor="game-type-notes-input">Notes</label>
+          <textarea
+            id="game-type-notes-input"
+            className="notes-input"
+            placeholder="Optional"
+            rows={5}
+            value={form.notes}
+            readOnly={readOnly}
+            onChange={(event) => setForm((current) => ({ ...current, notes: event.target.value }))}
+          />
+        </div>
+
+        {submitError ? <p className="submit-error">{submitError}</p> : null}
+
+        <div className="modal-actions modal-actions-end">
+          <button className="primary-button" type="button" onClick={onSubmit} disabled={nameInvalid}>
+            Save Game Type
+          </button>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/web/src/components/GameTypesTab/GameTypesTab.jsx
+++ b/web/src/components/GameTypesTab/GameTypesTab.jsx
@@ -1,0 +1,105 @@
+import useEntityTable from "../../hooks/useEntityTable";
+import EntityTable from "../common/EntityTable";
+import HighlightMatch from "../common/HighlightMatch";
+import GameTypeModal from "./GameTypeModal";
+import { buildGenericFilterOptions } from "../../utils/tableUtils";
+import {
+  initialGameTypeForm,
+  initialGameTypeColumnFilters,
+  gameTypeTableColumns,
+  gameTypesPageSize,
+  gameTypesFallbackPageSize
+} from "./gameTypesConstants";
+import { normalizeGameTypeForm, getGameTypeColumnValue } from "./gameTypesUtils";
+
+// ── Entity config ───────────────────────────────────────────────────────────
+
+const gameTypesConfig = {
+  entityName: "game_types",
+  entitySingular: "game type",
+  apiEndpoint: "/v1/workspace/game-types",
+  responseKey: "game_types",
+  batchDeleteIdKey: "game_type_ids",
+  columns: gameTypeTableColumns,
+  initialForm: initialGameTypeForm,
+  initialColumnFilters: initialGameTypeColumnFilters,
+  pageSize: gameTypesPageSize,
+  fallbackPageSize: gameTypesFallbackPageSize,
+  getColumnValue: getGameTypeColumnValue,
+  getCellDisplayValue: getGameTypeColumnValue,
+  searchFilter: (gt, text) =>
+    gt.name.toLowerCase().includes(text)
+    || (gt.notes || "").toLowerCase().includes(text),
+  numericSortColumns: [],
+  normalizeForm: normalizeGameTypeForm,
+  itemToForm: (gt) => ({
+    name: gt.name || "",
+    notes: gt.notes || "",
+    is_active: Boolean(gt.is_active)
+  }),
+  formToPayload: (form, mode) => ({
+    name: form.name,
+    notes: form.notes || null,
+    ...(mode === "edit" ? { is_active: form.is_active } : {})
+  }),
+  buildFilterOptions: (items) => ({
+    name: buildGenericFilterOptions(items, "name", getGameTypeColumnValue),
+    status: [
+      { value: "Active", label: "Active", path: ["Active"], searchValue: "Active" },
+      { value: "Inactive", label: "Inactive", path: ["Inactive"], searchValue: "Inactive" }
+    ],
+    notes: buildGenericFilterOptions(items, "notes", getGameTypeColumnValue)
+  }),
+  buildSuggestions: (items) => ({
+    names: [...new Set(items.map((gt) => gt.name).filter(Boolean))]
+  }),
+};
+
+// ── Cell renderer ───────────────────────────────────────────────────────────
+
+function renderGameTypeCell(gameType, columnKey, search) {
+  if (columnKey === "status") {
+    return (
+      <span className={gameType.is_active ? "status-chip active" : "status-chip inactive"}>
+        {gameType.is_active ? "Active" : "Inactive"}
+      </span>
+    );
+  }
+  if (columnKey === "notes") {
+    return <HighlightMatch text={(gameType.notes || "").slice(0, 100) || "-"} query={search} />;
+  }
+  return <HighlightMatch text={gameType[columnKey] || ""} query={search} />;
+}
+
+// ── Component ───────────────────────────────────────────────────────────────
+
+export default function GameTypesTab({ apiBaseUrl, hostedWorkspaceReady }) {
+  const table = useEntityTable(gameTypesConfig, { apiBaseUrl, hostedWorkspaceReady });
+
+  return (
+    <EntityTable
+      table={table}
+      entityName="game_types"
+      entitySingular="game type"
+      columns={gameTypeTableColumns}
+      getCellDisplayValue={getGameTypeColumnValue}
+      renderCell={renderGameTypeCell}
+      defaultColumnWidths={["30%", "12%"]}
+    >
+      {table.modalMode ? (
+        <GameTypeModal
+          mode={table.modalMode}
+          gameType={table.selectedItem}
+          form={table.form}
+          setForm={table.setForm}
+          submitError={table.submitError}
+          suggestions={table.suggestions}
+          onClose={table.requestCloseModal}
+          onRequestEdit={() => table.selectedItem && table.openModal("edit", table.selectedItem)}
+          onRequestDelete={() => table.selectedItem && table.handleDelete([table.selectedItem])}
+          onSubmit={table.submitModal}
+        />
+      ) : null}
+    </EntityTable>
+  );
+}

--- a/web/src/components/GameTypesTab/gameTypesConstants.js
+++ b/web/src/components/GameTypesTab/gameTypesConstants.js
@@ -1,0 +1,20 @@
+export const initialGameTypeForm = {
+  name: "",
+  notes: "",
+  is_active: true
+};
+
+export const initialGameTypeColumnFilters = {
+  name: [],
+  status: [],
+  notes: []
+};
+
+export const gameTypeTableColumns = [
+  { key: "name", label: "Name", sortable: true },
+  { key: "status", label: "Status", sortable: true },
+  { key: "notes", label: "Notes", sortable: true }
+];
+
+export const gameTypesPageSize = 100;
+export const gameTypesFallbackPageSize = 500;

--- a/web/src/components/GameTypesTab/gameTypesUtils.js
+++ b/web/src/components/GameTypesTab/gameTypesUtils.js
@@ -1,0 +1,14 @@
+export function normalizeGameTypeForm(form) {
+  return {
+    name: form.name || "",
+    notes: form.notes || "",
+    is_active: Boolean(form.is_active)
+  };
+}
+
+export function getGameTypeColumnValue(gameType, columnKey) {
+  if (columnKey === "status") {
+    return gameType.is_active ? "Active" : "Inactive";
+  }
+  return String(gameType[columnKey] || "");
+}


### PR DESCRIPTION
## Summary

Full-stack Game Types entity implementation for the web app, following the established EntityTable pattern (identical structure to Redemption Method Types).

Closes #254

## Changes

### Backend
- **Model**: `HostedGameType` dataclass in `services/hosted/models.py` (name, is_active, notes)
- **Repository**: `hosted_game_type_repository.py` — standard CRUD (list, count, create, update, delete, delete_many)
- **Service**: `workspace_game_type_service.py` — workspace-scoped game type management
- **API**: 5 endpoints at `/v1/workspace/game-types` (GET list, POST create, PATCH update, DELETE single, POST batch-delete)

### Frontend
- `GameTypesTab/GameTypesTab.jsx` — thin EntityTable config (~100 lines)
- `GameTypesTab/GameTypeModal.jsx` — view/create/edit modal
- `GameTypesTab/gameTypesConstants.js` — columns, initial form, page sizes
- `GameTypesTab/gameTypesUtils.js` — normalize + getColumnValue
- Tab enabled in `AppShell.jsx`

## Test Matrix

- **Happy path**: Standard CRUD via existing 1196 backend tests (all pass)
- **Edge cases**: Empty name rejected by model validation; notes stripped/nullified
- **Frontend**: Vite build succeeds (126 modules, 0 errors)

## Verification

- `pytest -q`: 1196 passed, 1 skipped
- `npm run build`: clean build, 0 warnings

## Pitfalls / Follow-ups

- `_require_workspace` helper is duplicated across all workspace services — extraction candidate (not in scope)
- No FK dependents yet (Games will reference Game Types in Issue #255)
