### PR TITLE
feat(web): Games — full-stack implementation (Issue #255)

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -25,6 +25,9 @@ from services.hosted.workspace_user_service import HostedWorkspaceUserService
 from services.hosted.workspace_game_type_service import (
     HostedWorkspaceGameTypeService,
 )
+from services.hosted.workspace_game_service import (
+    HostedWorkspaceGameService,
+)
 from services.hosted.workspace_import_planning_service import (
     HostedWorkspaceImportPlanningService,
 )
@@ -141,6 +144,25 @@ class HostedWorkspaceGameTypeBatchDeleteRequest(BaseModel):
     game_type_ids: list[str]
 
 
+class HostedWorkspaceGameCreateRequest(BaseModel):
+    name: str
+    game_type_id: str
+    rtp: float | None = None
+    notes: str | None = None
+
+
+class HostedWorkspaceGameUpdateRequest(BaseModel):
+    name: str
+    game_type_id: str
+    rtp: float | None = None
+    notes: str | None = None
+    is_active: bool = True
+
+
+class HostedWorkspaceGameBatchDeleteRequest(BaseModel):
+    game_ids: list[str]
+
+
 cors_config = load_hosted_backend_config(required=False, require_db_password=False)
 app.add_middleware(
     CORSMiddleware,
@@ -232,6 +254,16 @@ def get_hosted_workspace_game_type_service() -> HostedWorkspaceGameTypeService:
 
     session_factory = get_hosted_session_factory(config.sqlalchemy_url)
     return HostedWorkspaceGameTypeService(session_factory)
+
+
+def get_hosted_workspace_game_service() -> HostedWorkspaceGameService:
+    try:
+        config = load_hosted_backend_config(require_db_password=True)
+    except HostedConfigurationError as exc:
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(exc)) from exc
+
+    session_factory = get_hosted_session_factory(config.sqlalchemy_url)
+    return HostedWorkspaceGameService(session_factory)
 
 
 def get_hosted_uploaded_sqlite_inspection_service() -> HostedUploadedSQLiteInspectionService:
@@ -981,6 +1013,134 @@ def workspace_game_types_batch_delete(
         deleted_count = service.delete_game_types(
             supabase_user_id=session.user_id,
             game_type_ids=payload.game_type_ids,
+        )
+    except LookupError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+    return {"deleted_count": deleted_count}
+
+
+# ── Games ────────────────────────────────────────────────────────────────
+
+
+@app.get("/v1/workspace/games")
+def workspace_games_list(
+    limit: int = Query(100, ge=1, le=500),
+    offset: int = Query(0, ge=0),
+    session: AuthenticatedSession = Depends(get_authenticated_session),
+    service: HostedWorkspaceGameService = Depends(
+        get_hosted_workspace_game_service
+    ),
+) -> dict[str, object]:
+    try:
+        page = service.list_games_page(
+            supabase_user_id=session.user_id,
+            limit=limit,
+            offset=offset,
+        )
+    except LookupError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+
+    return {
+        "games": [
+            g.as_dict() if hasattr(g, "as_dict") else g
+            for g in page["games"]
+        ],
+        "offset": page["offset"],
+        "limit": page["limit"],
+        "next_offset": page["next_offset"],
+        "total_count": page["total_count"],
+        "has_more": page["has_more"],
+    }
+
+
+@app.post("/v1/workspace/games")
+def workspace_games_create(
+    payload: HostedWorkspaceGameCreateRequest = Body(...),
+    session: AuthenticatedSession = Depends(get_authenticated_session),
+    service: HostedWorkspaceGameService = Depends(
+        get_hosted_workspace_game_service
+    ),
+) -> dict[str, object]:
+    try:
+        game = service.create_game(
+            supabase_user_id=session.user_id,
+            name=payload.name,
+            game_type_id=payload.game_type_id,
+            rtp=payload.rtp,
+            notes=payload.notes,
+        )
+    except LookupError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+    return game.as_dict() if hasattr(game, "as_dict") else game
+
+
+@app.patch("/v1/workspace/games/{game_id}")
+def workspace_games_update(
+    game_id: str = Path(...),
+    payload: HostedWorkspaceGameUpdateRequest = Body(...),
+    session: AuthenticatedSession = Depends(get_authenticated_session),
+    service: HostedWorkspaceGameService = Depends(
+        get_hosted_workspace_game_service
+    ),
+) -> dict[str, object]:
+    try:
+        game = service.update_game(
+            supabase_user_id=session.user_id,
+            game_id=game_id,
+            name=payload.name,
+            game_type_id=payload.game_type_id,
+            rtp=payload.rtp,
+            notes=payload.notes,
+            is_active=payload.is_active,
+        )
+    except LookupError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+    return game.as_dict() if hasattr(game, "as_dict") else game
+
+
+@app.delete(
+    "/v1/workspace/games/{game_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+def workspace_games_delete(
+    game_id: str = Path(...),
+    session: AuthenticatedSession = Depends(get_authenticated_session),
+    service: HostedWorkspaceGameService = Depends(
+        get_hosted_workspace_game_service
+    ),
+) -> Response:
+    try:
+        service.delete_game(
+            supabase_user_id=session.user_id,
+            game_id=game_id,
+        )
+    except LookupError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@app.post("/v1/workspace/games/batch-delete")
+def workspace_games_batch_delete(
+    payload: HostedWorkspaceGameBatchDeleteRequest = Body(...),
+    session: AuthenticatedSession = Depends(get_authenticated_session),
+    service: HostedWorkspaceGameService = Depends(
+        get_hosted_workspace_game_service
+    ),
+) -> dict[str, int]:
+    try:
+        deleted_count = service.delete_games(
+            supabase_user_id=session.user_id,
+            game_ids=payload.game_ids,
         )
     except LookupError as exc:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc

--- a/docs/status/CHANGELOG.md
+++ b/docs/status/CHANGELOG.md
@@ -9,6 +9,32 @@ Rules:
 
 ---
 
+## 2026-04-02
+
+```yaml
+id: 2026-04-02-01
+type: feature
+areas: [web, api]
+issue: "#255"
+summary: "Games — full-stack web implementation"
+details: >
+  Full-stack Games entity (name, game_type_id FK, rtp, actual_rtp, is_active, notes)
+  following EntityTable + FK pattern (same as Redemption Methods).
+  Backend: HostedGame model, hosted_game_repository with game_types JOIN,
+  workspace_game_service, 5 API endpoints at /v1/workspace/games.
+  Frontend: thin EntityTable config with GameModal (TypeaheadSelect for game type,
+  optional RTP numeric field, read-only Actual RTP display). Tab enabled in AppShell.
+  Persistence record (HostedGameRecord) already existed.
+
+files_changed:
+  - services/hosted/models.py (add HostedGame)
+  - repositories/hosted_game_repository.py (new)
+  - services/hosted/workspace_game_service.py (new)
+  - api/app.py (request models + dependency + 5 endpoints)
+  - web/src/components/GamesTab/ (new — 4 files)
+  - web/src/components/AppShell.jsx (enable games tab)
+```
+
 ## 2026-04-01
 
 ```yaml

--- a/repositories/hosted_game_repository.py
+++ b/repositories/hosted_game_repository.py
@@ -1,0 +1,169 @@
+"""Persistence helpers for hosted workspace-owned games."""
+
+from __future__ import annotations
+
+from sqlalchemy import delete, func, select
+from sqlalchemy.orm import aliased
+
+from services.hosted.models import HostedGame
+from services.hosted.persistence import (
+    HostedGameRecord,
+    HostedGameTypeRecord,
+)
+
+
+class HostedGameRepository:
+    def list_by_workspace_id(
+        self,
+        session,
+        workspace_id: str,
+        *,
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> list[HostedGame]:
+        type_alias = aliased(HostedGameTypeRecord)
+        query = (
+            select(
+                HostedGameRecord,
+                type_alias.name.label("game_type_name"),
+            )
+            .join(type_alias, HostedGameRecord.game_type_id == type_alias.id)
+            .where(HostedGameRecord.workspace_id == workspace_id)
+            .order_by(HostedGameRecord.name.asc(), HostedGameRecord.id.asc())
+            .offset(offset)
+        )
+        if limit is not None:
+            query = query.limit(limit)
+
+        rows = session.execute(query).all()
+        return [self._row_to_model(row) for row in rows]
+
+    def count_by_workspace_id(self, session, workspace_id: str) -> int:
+        return session.scalar(
+            select(func.count())
+            .select_from(HostedGameRecord)
+            .where(HostedGameRecord.workspace_id == workspace_id)
+        ) or 0
+
+    def get_by_id_and_workspace_id(
+        self,
+        session,
+        *,
+        game_id: str,
+        workspace_id: str,
+    ) -> HostedGame | None:
+        type_alias = aliased(HostedGameTypeRecord)
+        row = session.execute(
+            select(
+                HostedGameRecord,
+                type_alias.name.label("game_type_name"),
+            )
+            .join(type_alias, HostedGameRecord.game_type_id == type_alias.id)
+            .where(
+                HostedGameRecord.id == game_id,
+                HostedGameRecord.workspace_id == workspace_id,
+            )
+        ).first()
+        if row is None:
+            return None
+        return self._row_to_model(row)
+
+    def create(
+        self,
+        session,
+        *,
+        workspace_id: str,
+        name: str,
+        game_type_id: str,
+        rtp: float | None = None,
+        is_active: bool = True,
+        notes: str | None = None,
+    ) -> HostedGame:
+        record = HostedGameRecord(
+            workspace_id=workspace_id,
+            name=name,
+            game_type_id=game_type_id,
+            rtp=rtp,
+            is_active=is_active,
+            notes=notes,
+        )
+        session.add(record)
+        session.flush()
+        return self.get_by_id_and_workspace_id(
+            session, game_id=record.id, workspace_id=workspace_id
+        )
+
+    def update(
+        self,
+        session,
+        *,
+        game_id: str,
+        workspace_id: str,
+        name: str,
+        game_type_id: str,
+        rtp: float | None,
+        is_active: bool,
+        notes: str | None,
+    ) -> HostedGame | None:
+        record = session.scalar(
+            select(HostedGameRecord).where(
+                HostedGameRecord.id == game_id,
+                HostedGameRecord.workspace_id == workspace_id,
+            )
+        )
+        if record is None:
+            return None
+
+        record.name = name
+        record.game_type_id = game_type_id
+        record.rtp = rtp
+        record.is_active = is_active
+        record.notes = notes
+        session.flush()
+        return self.get_by_id_and_workspace_id(
+            session, game_id=record.id, workspace_id=workspace_id
+        )
+
+    def delete(self, session, *, game_id: str, workspace_id: str) -> bool:
+        record = session.scalar(
+            select(HostedGameRecord).where(
+                HostedGameRecord.id == game_id,
+                HostedGameRecord.workspace_id == workspace_id,
+            )
+        )
+        if record is None:
+            return False
+
+        session.delete(record)
+        session.flush()
+        return True
+
+    def delete_many(self, session, *, game_ids: list[str], workspace_id: str) -> int:
+        normalized_ids = list(dict.fromkeys(game_ids))
+        if not normalized_ids:
+            return 0
+
+        result = session.execute(
+            delete(HostedGameRecord).where(
+                HostedGameRecord.workspace_id == workspace_id,
+                HostedGameRecord.id.in_(normalized_ids),
+            )
+        )
+        session.flush()
+        return int(result.rowcount or 0)
+
+    @staticmethod
+    def _row_to_model(row) -> HostedGame:
+        record = row[0] if hasattr(row, "__getitem__") else row
+        game_type_name = row.game_type_name if hasattr(row, "game_type_name") else None
+        return HostedGame(
+            id=record.id,
+            workspace_id=record.workspace_id,
+            name=record.name,
+            game_type_id=record.game_type_id,
+            rtp=record.rtp,
+            actual_rtp=record.actual_rtp,
+            is_active=record.is_active,
+            notes=record.notes,
+            game_type_name=game_type_name,
+        )

--- a/services/hosted/models.py
+++ b/services/hosted/models.py
@@ -257,3 +257,47 @@ class HostedGameType:
             "is_active": self.is_active,
             "notes": self.notes,
         }
+
+
+@dataclass
+class HostedGame:
+    """Game (e.g., 'Sugar Rush', 'Gates of Olympus') owned by a hosted workspace."""
+
+    name: str
+    game_type_id: str
+    workspace_id: Optional[str] = None
+    rtp: Optional[float] = None
+    actual_rtp: float = 0.0
+    is_active: bool = True
+    notes: Optional[str] = None
+    id: Optional[str] = None
+    game_type_name: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        self.name = self.name.strip()
+        if not self.name:
+            raise ValueError("Game name is required")
+
+        if not self.game_type_id:
+            raise ValueError("Game type is required")
+
+        if self.rtp is not None:
+            self.rtp = float(self.rtp)
+            if not 0 <= self.rtp <= 100:
+                raise ValueError("RTP must be between 0 and 100")
+
+        if self.notes is not None:
+            self.notes = self.notes.strip() or None
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "id": self.id,
+            "workspace_id": self.workspace_id,
+            "name": self.name,
+            "game_type_id": self.game_type_id,
+            "game_type_name": self.game_type_name,
+            "rtp": self.rtp,
+            "actual_rtp": self.actual_rtp,
+            "is_active": self.is_active,
+            "notes": self.notes,
+        }

--- a/services/hosted/workspace_game_service.py
+++ b/services/hosted/workspace_game_service.py
@@ -1,0 +1,159 @@
+"""Hosted workspace-managed games service."""
+
+from __future__ import annotations
+
+from repositories.hosted_account_repository import HostedAccountRepository
+from repositories.hosted_game_repository import HostedGameRepository
+from repositories.hosted_workspace_repository import HostedWorkspaceRepository
+from services.hosted.models import HostedGame, HostedWorkspace
+
+
+class HostedWorkspaceGameService:
+    def __init__(self, session_factory) -> None:
+        self.session_factory = session_factory
+        self.account_repository = HostedAccountRepository()
+        self.workspace_repository = HostedWorkspaceRepository()
+        self.game_repository = HostedGameRepository()
+
+    def list_games_page(
+        self,
+        *,
+        supabase_user_id: str,
+        limit: int,
+        offset: int = 0,
+    ) -> dict[str, object]:
+        with self.session_factory() as session:
+            workspace = self._require_workspace(session, supabase_user_id)
+            total_count = self.game_repository.count_by_workspace_id(session, workspace.id)
+            games = self.game_repository.list_by_workspace_id(
+                session,
+                workspace.id,
+                limit=limit,
+                offset=offset,
+            )
+            next_offset = offset + len(games)
+            has_more = next_offset < total_count
+            return {
+                "games": games,
+                "offset": offset,
+                "limit": limit,
+                "next_offset": next_offset,
+                "total_count": total_count,
+                "has_more": has_more,
+            }
+
+    def create_game(
+        self,
+        *,
+        supabase_user_id: str,
+        name: str,
+        game_type_id: str,
+        rtp: float | None = None,
+        notes: str | None = None,
+    ) -> HostedGame:
+        candidate = HostedGame(name=name, game_type_id=game_type_id, rtp=rtp, notes=notes)
+
+        with self.session_factory() as session:
+            workspace = self._require_workspace(session, supabase_user_id)
+            created = self.game_repository.create(
+                session,
+                workspace_id=workspace.id,
+                name=candidate.name,
+                game_type_id=candidate.game_type_id,
+                rtp=candidate.rtp,
+                notes=candidate.notes,
+                is_active=candidate.is_active,
+            )
+            session.commit()
+            return created
+
+    def update_game(
+        self,
+        *,
+        supabase_user_id: str,
+        game_id: str,
+        name: str,
+        game_type_id: str,
+        rtp: float | None = None,
+        notes: str | None = None,
+        is_active: bool = True,
+    ) -> HostedGame:
+        candidate = HostedGame(
+            name=name, game_type_id=game_type_id, rtp=rtp, notes=notes, is_active=is_active
+        )
+
+        with self.session_factory() as session:
+            workspace = self._require_workspace(session, supabase_user_id)
+            updated = self.game_repository.update(
+                session,
+                game_id=game_id,
+                workspace_id=workspace.id,
+                name=candidate.name,
+                game_type_id=candidate.game_type_id,
+                rtp=candidate.rtp,
+                notes=candidate.notes,
+                is_active=candidate.is_active,
+            )
+            if updated is None:
+                raise LookupError("Hosted game was not found in the authenticated workspace.")
+
+            session.commit()
+            return updated
+
+    def delete_game(
+        self,
+        *,
+        supabase_user_id: str,
+        game_id: str,
+    ) -> None:
+        with self.session_factory() as session:
+            workspace = self._require_workspace(session, supabase_user_id)
+            deleted = self.game_repository.delete(
+                session,
+                game_id=game_id,
+                workspace_id=workspace.id,
+            )
+            if not deleted:
+                raise LookupError("Hosted game was not found in the authenticated workspace.")
+
+            session.commit()
+
+    def delete_games(
+        self,
+        *,
+        supabase_user_id: str,
+        game_ids: list[str],
+    ) -> int:
+        normalized_ids = list(dict.fromkeys(game_ids))
+        if not normalized_ids:
+            raise ValueError("At least one hosted game id is required.")
+
+        with self.session_factory() as session:
+            workspace = self._require_workspace(session, supabase_user_id)
+            deleted_count = self.game_repository.delete_many(
+                session,
+                game_ids=normalized_ids,
+                workspace_id=workspace.id,
+            )
+            if deleted_count != len(normalized_ids):
+                raise LookupError(
+                    "One or more hosted games were not found in the authenticated workspace."
+                )
+
+            session.commit()
+            return deleted_count
+
+    def _require_workspace(self, session, supabase_user_id: str) -> HostedWorkspace:
+        account = self.account_repository.get_by_supabase_user_id(session, supabase_user_id)
+        if account is None:
+            raise LookupError(
+                "Hosted workspace bootstrap must complete before managing games."
+            )
+
+        workspace = self.workspace_repository.get_by_account_id(session, account.id)
+        if workspace is None:
+            raise LookupError(
+                "Hosted workspace bootstrap must complete before managing games."
+            )
+
+        return workspace

--- a/web/src/components/AppShell.jsx
+++ b/web/src/components/AppShell.jsx
@@ -12,6 +12,7 @@ import CardsTab from "./CardsTab/CardsTab";
 import MethodTypesTab from "./MethodTypesTab/MethodTypesTab";
 import RedemptionMethodsTab from "./RedemptionMethodsTab/RedemptionMethodsTab";
 import GameTypesTab from "./GameTypesTab/GameTypesTab";
+import GamesTab from "./GamesTab/GamesTab";
 
 const setupTabs = [
   { key: "users", label: "Users", icon: "users", enabled: true },
@@ -20,7 +21,7 @@ const setupTabs = [
   { key: "method-types", label: "Method Types", icon: "methodTypes", enabled: true },
   { key: "redemption-methods", label: "Redemption Methods", icon: "redemptionMethods", enabled: true },
   { key: "game-types", label: "Game Types", icon: "gameTypes", enabled: true },
-  { key: "games", label: "Games", icon: "games", enabled: false },
+  { key: "games", label: "Games", icon: "games", enabled: true },
   { key: "tools", label: "Tools", icon: "tools", enabled: false }
 ];
 
@@ -225,6 +226,12 @@ export default function AppShell({ auth }) {
         ) : null}
         {setupTab === "game-types" ? (
           <GameTypesTab
+            apiBaseUrl={auth.apiBaseUrl}
+            hostedWorkspaceReady={auth.hostedWorkspaceReady}
+          />
+        ) : null}
+        {setupTab === "games" ? (
+          <GamesTab
             apiBaseUrl={auth.apiBaseUrl}
             hostedWorkspaceReady={auth.hostedWorkspaceReady}
           />

--- a/web/src/components/GamesTab/GameModal.jsx
+++ b/web/src/components/GamesTab/GameModal.jsx
@@ -1,0 +1,191 @@
+import { initialGameForm } from "./gamesConstants";
+import { getGameColumnValue } from "./gamesUtils";
+import TypeaheadSelect from "../common/TypeaheadSelect";
+
+export default function GameModal({
+  mode,
+  game,
+  form,
+  setForm,
+  onClose,
+  onSubmit,
+  onRequestEdit,
+  onRequestDelete,
+  submitError,
+  suggestions,
+  gameTypes
+}) {
+  const readOnly = mode === "view";
+  const title = mode === "create" ? "Add Game" : mode === "edit" ? "Edit Game" : "View Game";
+  const nameInvalid = !form.name.trim();
+  const gameTypeInvalid = !form.game_type_id;
+  const rtpRaw = form.rtp;
+  const rtpInvalid = rtpRaw !== "" && rtpRaw !== null && rtpRaw !== undefined
+    && (isNaN(Number(rtpRaw)) || Number(rtpRaw) < 0 || Number(rtpRaw) > 100);
+  const formInvalid = nameInvalid || gameTypeInvalid || rtpInvalid;
+  const closeLabel = readOnly ? "Close" : "Cancel";
+
+  if (readOnly && game) {
+    return (
+      <div className="modal-backdrop" role="presentation" onClick={onClose}>
+        <section
+          className="modal-card game-modal"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="game-modal-title"
+          onClick={(event) => event.stopPropagation()}
+        >
+          <div className="modal-header">
+            <div>
+              <h2 id="game-modal-title">View Game</h2>
+            </div>
+            <button className="ghost-button" type="button" onClick={onClose}>{closeLabel}</button>
+          </div>
+
+          <div className="user-detail-body">
+            <dl className="detail-grid user-detail-grid">
+              <div><dt>Name</dt><dd>{game.name}</dd></div>
+              <div><dt>Game Type</dt><dd>{game.game_type_name}</dd></div>
+              <div><dt>Expected RTP</dt><dd>{getGameColumnValue(game, "rtp")}</dd></div>
+              <div><dt>Actual RTP</dt><dd>{getGameColumnValue(game, "actual_rtp")}</dd></div>
+              <div>
+                <dt>Status</dt>
+                <dd>
+                  <span className={game.is_active ? "status-chip active" : "status-chip inactive"}>
+                    {game.is_active ? "Active" : "Inactive"}
+                  </span>
+                </dd>
+              </div>
+            </dl>
+
+            <div className="user-detail-notes">
+              <p className="detail-label">Notes</p>
+              <div className="notes-display">{game.notes || "-"}</div>
+            </div>
+          </div>
+
+          <div className="modal-actions modal-actions-split">
+            <div className="toolbar-row">
+              <button className="ghost-button" type="button" onClick={onRequestDelete}>Delete</button>
+            </div>
+            <div className="toolbar-row">
+              <button className="primary-button" type="button" onClick={onRequestEdit}>Edit Game</button>
+            </div>
+          </div>
+        </section>
+      </div>
+    );
+  }
+
+  return (
+    <div className="modal-backdrop" role="presentation" onClick={onClose}>
+      <section
+        className="modal-card game-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="game-modal-title"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="modal-header">
+          <div>
+            <h2 id="game-modal-title">{title}</h2>
+          </div>
+          <button className="ghost-button" type="button" onClick={onClose}>
+            {closeLabel}
+          </button>
+        </div>
+
+        <div className="form-grid">
+          <label className="field-label" htmlFor="game-name-input">Name</label>
+          <div>
+            <input
+              id="game-name-input"
+              className={nameInvalid ? "text-input invalid" : "text-input"}
+              type="text"
+              list="game-name-suggestions"
+              placeholder="Required"
+              value={form.name}
+              readOnly={readOnly}
+              onChange={(event) => setForm((current) => ({ ...current, name: event.target.value }))}
+            />
+            <datalist id="game-name-suggestions">
+              {suggestions.names.map((name) => (
+                <option key={name} value={name} />
+              ))}
+            </datalist>
+            {nameInvalid ? <p className="field-error">Name is required.</p> : null}
+          </div>
+
+          <label className="field-label" htmlFor="game-type-input">Game Type</label>
+          <div>
+            <TypeaheadSelect
+              id="game-type-input"
+              options={gameTypes.map((gt) => ({
+                value: gt.id,
+                label: gt.name
+              }))}
+              value={form.game_type_id}
+              onChange={(gtId) => setForm((current) => ({ ...current, game_type_id: gtId }))}
+              placeholder="Required"
+              disabled={readOnly}
+            />
+            {gameTypeInvalid ? <p className="field-error">Game type is required.</p> : null}
+          </div>
+
+          <label className="field-label" htmlFor="game-rtp-input">Expected RTP (%)</label>
+          <div>
+            <input
+              id="game-rtp-input"
+              className={rtpInvalid ? "text-input invalid" : "text-input"}
+              type="number"
+              min="0"
+              max="100"
+              step="0.01"
+              placeholder="Optional (0\u2013100)"
+              value={form.rtp}
+              readOnly={readOnly}
+              onChange={(event) => setForm((current) => ({ ...current, rtp: event.target.value }))}
+            />
+            {rtpInvalid ? <p className="field-error">RTP must be between 0 and 100.</p> : null}
+          </div>
+
+          <label className="field-label" htmlFor="game-active-input">Active</label>
+          <label className="toggle-row" htmlFor="game-active-input">
+            <input
+              id="game-active-input"
+              type="checkbox"
+              checked={form.is_active}
+              disabled={readOnly}
+              onChange={(event) => setForm((current) => ({ ...current, is_active: event.target.checked }))}
+            />
+            <span>{form.is_active ? "Active" : "Inactive"}</span>
+          </label>
+
+          <label className="field-label field-label-top" htmlFor="game-notes-input">Notes</label>
+          <textarea
+            id="game-notes-input"
+            className="notes-input"
+            placeholder="Optional"
+            rows={5}
+            value={form.notes}
+            readOnly={readOnly}
+            onChange={(event) => setForm((current) => ({ ...current, notes: event.target.value }))}
+          />
+        </div>
+
+        {submitError ? <p className="submit-error">{submitError}</p> : null}
+
+        <div className="modal-actions modal-actions-end">
+          <button
+            className="primary-button"
+            type="button"
+            onClick={onSubmit}
+            disabled={formInvalid}
+          >
+            Save Game
+          </button>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/web/src/components/GamesTab/GamesTab.jsx
+++ b/web/src/components/GamesTab/GamesTab.jsx
@@ -1,0 +1,127 @@
+import useEntityTable from "../../hooks/useEntityTable";
+import EntityTable from "../common/EntityTable";
+import HighlightMatch from "../common/HighlightMatch";
+import GameModal from "./GameModal";
+import { buildGenericFilterOptions } from "../../utils/tableUtils";
+import {
+  initialGameForm,
+  initialGameColumnFilters,
+  gameTableColumns,
+  gamesPageSize,
+  gamesFallbackPageSize
+} from "./gamesConstants";
+import { normalizeGameForm, getGameColumnValue } from "./gamesUtils";
+
+// ── Entity config ───────────────────────────────────────────────────────────
+
+const gamesConfig = {
+  entityName: "games",
+  entitySingular: "game",
+  apiEndpoint: "/v1/workspace/games",
+  responseKey: "games",
+  batchDeleteIdKey: "game_ids",
+  columns: gameTableColumns,
+  initialForm: initialGameForm,
+  initialColumnFilters: initialGameColumnFilters,
+  pageSize: gamesPageSize,
+  fallbackPageSize: gamesFallbackPageSize,
+  getColumnValue: getGameColumnValue,
+  getCellDisplayValue: getGameColumnValue,
+  searchFilter: (game, text) =>
+    game.name.toLowerCase().includes(text)
+    || (game.game_type_name || "").toLowerCase().includes(text)
+    || (game.notes || "").toLowerCase().includes(text),
+  numericSortColumns: ["rtp", "actual_rtp"],
+  normalizeForm: normalizeGameForm,
+  itemToForm: (game) => ({
+    name: game.name || "",
+    game_type_id: game.game_type_id || "",
+    rtp: game.rtp ?? "",
+    notes: game.notes || "",
+    is_active: Boolean(game.is_active)
+  }),
+  formToPayload: (form, mode) => ({
+    name: form.name,
+    game_type_id: form.game_type_id || null,
+    rtp: form.rtp !== "" && form.rtp !== null ? Number(form.rtp) : null,
+    notes: form.notes || null,
+    ...(mode === "edit" ? { is_active: form.is_active } : {})
+  }),
+  buildFilterOptions: (items) => {
+    const options = {};
+    for (const col of gameTableColumns) {
+      if (col.key === "status") {
+        options[col.key] = [
+          { value: "Active", label: "Active", path: ["Active"], searchValue: "Active" },
+          { value: "Inactive", label: "Inactive", path: ["Inactive"], searchValue: "Inactive" }
+        ];
+      } else {
+        options[col.key] = buildGenericFilterOptions(items, col.key, getGameColumnValue);
+      }
+    }
+    return options;
+  },
+  buildSuggestions: (items) => ({
+    names: [...new Set(items.map((g) => g.name).filter(Boolean))]
+  }),
+  extraLoaders: [
+    { key: "gameTypes", endpoint: "/v1/workspace/game-types?limit=500&offset=0", responseKey: "game_types" }
+  ],
+};
+
+// ── Cell renderer ───────────────────────────────────────────────────────────
+
+function renderGameCell(game, columnKey, search) {
+  if (columnKey === "status") {
+    return (
+      <span className={game.is_active ? "status-chip active" : "status-chip inactive"}>
+        <HighlightMatch text={game.is_active ? "Active" : "Inactive"} query={search} />
+      </span>
+    );
+  }
+  if (columnKey === "game_type_name") {
+    return <HighlightMatch text={game.game_type_name || "\u2014"} query={search} />;
+  }
+  if (columnKey === "rtp" || columnKey === "actual_rtp") {
+    return <span>{getGameColumnValue(game, columnKey)}</span>;
+  }
+  if (columnKey === "notes") {
+    return <HighlightMatch text={(game.notes || "").slice(0, 100) || "-"} query={search} />;
+  }
+  return <HighlightMatch text={game[columnKey] || ""} query={search} />;
+}
+
+// ── Component ───────────────────────────────────────────────────────────────
+
+export default function GamesTab({ apiBaseUrl, hostedWorkspaceReady }) {
+  const table = useEntityTable(gamesConfig, { apiBaseUrl, hostedWorkspaceReady });
+
+  return (
+    <EntityTable
+      table={table}
+      entityName="games"
+      entitySingular="game"
+      columns={gameTableColumns}
+      getCellDisplayValue={getGameColumnValue}
+      renderCell={renderGameCell}
+      defaultColumnWidths={["22%", "14%", "12%", "12%", "10%"]}
+      defaultHeaderGridTemplate="36px 22% 14% 12% 12% 10% 1fr"
+    >
+      {table.modalMode ? (
+        <GameModal
+          mode={table.modalMode}
+          game={table.selectedItem}
+          form={table.form}
+          setForm={table.setForm}
+          submitError={table.submitError}
+          suggestions={table.suggestions}
+          gameTypes={table.extraData.gameTypes || []}
+          onClose={table.requestCloseModal}
+          onRequestEdit={() => table.selectedItem && table.openModal("edit", table.selectedItem)}
+          onRequestDelete={() => table.selectedItem && table.handleDelete([table.selectedItem])}
+          onSubmit={table.submitModal}
+        />
+      ) : null}
+    </EntityTable>
+  );
+}

--- a/web/src/components/GamesTab/gamesConstants.js
+++ b/web/src/components/GamesTab/gamesConstants.js
@@ -1,0 +1,28 @@
+export const initialGameForm = {
+  name: "",
+  game_type_id: "",
+  rtp: "",
+  notes: "",
+  is_active: true
+};
+
+export const initialGameColumnFilters = {
+  name: [],
+  game_type_name: [],
+  rtp: [],
+  actual_rtp: [],
+  status: [],
+  notes: []
+};
+
+export const gameTableColumns = [
+  { key: "name", label: "Name", sortable: true },
+  { key: "game_type_name", label: "Game Type", sortable: true },
+  { key: "rtp", label: "Expected RTP", sortable: true },
+  { key: "actual_rtp", label: "Actual RTP", sortable: true },
+  { key: "status", label: "Status", sortable: true },
+  { key: "notes", label: "Notes", sortable: true }
+];
+
+export const gamesPageSize = 100;
+export const gamesFallbackPageSize = 500;

--- a/web/src/components/GamesTab/gamesUtils.js
+++ b/web/src/components/GamesTab/gamesUtils.js
@@ -1,0 +1,22 @@
+export function normalizeGameForm(form) {
+  return {
+    name: form.name || "",
+    game_type_id: form.game_type_id || "",
+    rtp: form.rtp ?? "",
+    notes: form.notes || "",
+    is_active: Boolean(form.is_active)
+  };
+}
+
+function formatRtp(value) {
+  if (value === null || value === undefined || value === "" || value === 0) return "\u2014";
+  return `${Number(value).toFixed(2)}%`;
+}
+
+export function getGameColumnValue(game, columnKey) {
+  if (columnKey === "status") return game.is_active ? "Active" : "Inactive";
+  if (columnKey === "game_type_name") return game.game_type_name || "\u2014";
+  if (columnKey === "rtp") return formatRtp(game.rtp);
+  if (columnKey === "actual_rtp") return formatRtp(game.actual_rtp);
+  return String(game[columnKey] || "");
+}


### PR DESCRIPTION
## Summary

Full-stack Games entity with game_type_id FK relationship, following the same EntityTable + FK pattern as Redemption Methods.

**Backend (3 files):**
- `HostedGame` model in `services/hosted/models.py` (name, game_type_id, rtp, actual_rtp, is_active, notes)
- `HostedGameRepository` — CRUD with game_types JOIN for resolved `game_type_name`
- `HostedWorkspaceGameService` — workspace-scoped CRUD
- 5 API endpoints at `/v1/workspace/games`

**Frontend (4 files):**
- Thin EntityTable config with `extraLoaders` for game types
- `GameModal` with TypeaheadSelect for game type, optional RTP numeric input, read-only Actual RTP
- Tab enabled in AppShell (130 modules, clean build)

**Desktop parity:** Name (required), Game Type (requ**Desktop parity:** Name (required), Game Type (requ**Desktop parity:** Name (required), Game Type (requ**Desktop parity:** Name (required), Game Type (requ**Desktop parity:** Name (required), Game Type (requ**Desktop parity:** Name (required), Game Type (requ**Desktop p RTP aggregation service (future issue)
- Game name uniqueness is per-workspace (DB constraint), not per game-type — matches desktop behavior

Closes #255