### PR TITLE
Phase 2: Accounting Engine Core — 4 hosted services + 53 tests

### DIFF
--- a/docs/status/CHANGELOG.md
+++ b/docs/status/CHANGELOG.md
@@ -9,6 +9,36 @@ Rules:
 
 ---
 
+## 2026-04-03
+
+```yaml
+id: 2026-04-03-01
+type: feature
+areas: [services]
+issue: "#258"
+summary: "Phase 2 — Accounting Engine Core (hosted services + tests)"
+details: >
+  Ported the four core accounting services from the desktop layer to the hosted
+  (SQLAlchemy / web) layer: HostedTimestampService (timestamp uniqueness enforcement),
+  HostedFIFOService (FIFO cost-basis calculation), HostedRecalculationService
+  (bulk FIFO + realized-transaction rebuilds with full/scoped/all-pairs modes),
+  and HostedEventLinkService (temporal BEFORE/DURING/AFTER classification of
+  purchases and redemptions relative to game sessions). Includes 53 tests covering
+  happy paths, edge cases (deleted records, canceled redemptions, free SC, close-
+  balance Net Loss, synthetic BASIS_USD_CORRECTION adjustments), failure injection,
+  and idempotency invariants.
+
+files_changed:
+  - services/hosted/hosted_timestamp_service.py (new)
+  - services/hosted/hosted_fifo_service.py (new)
+  - services/hosted/hosted_recalculation_service.py (new)
+  - services/hosted/hosted_event_link_service.py (new)
+  - tests/services/hosted/test_hosted_timestamp_service.py (new — 11 tests)
+  - tests/services/hosted/test_hosted_fifo_service.py (new — 11 tests)
+  - tests/services/hosted/test_hosted_recalculation_service.py (new — 15 tests)
+  - tests/services/hosted/test_hosted_event_link_service.py (new — 16 tests)
+```
+
 ## 2026-04-02
 
 ```yaml

--- a/services/hosted/hosted_event_link_service.py
+++ b/services/hosted/hosted_event_link_service.py
@@ -1,0 +1,301 @@
+"""Hosted game-session event-link service.
+
+Classifies purchases and redemptions as BEFORE / DURING / AFTER relative to
+game sessions for a given (workspace, user, site) triple.
+
+Ported from the desktop ``GameSessionEventLinkService``.  Key differences:
+
+- SQLAlchemy ORM instead of raw SQL
+- String UUIDs instead of integer IDs
+- Boundary rule (Issue #90): session start INCLUSIVE (>=), end EXCLUSIVE (<)
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List, Optional, Tuple
+from uuid import uuid4
+
+from sqlalchemy import asc, func, or_, and_
+from sqlalchemy.orm import Session
+
+from services.hosted.persistence import (
+    HostedGameSessionEventLinkRecord,
+    HostedGameSessionRecord,
+    HostedPurchaseRecord,
+    HostedRedemptionRecord,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _normalize_time(value: Optional[str], default: str = "00:00:00") -> str:
+    if not value:
+        return default
+    value = value.strip()
+    if len(value) == 5:
+        return f"{value}:00"
+    return value
+
+
+def _to_dt(date_str: str, time_str: Optional[str]) -> datetime:
+    return datetime.strptime(f"{date_str} {_normalize_time(time_str)}", "%Y-%m-%d %H:%M:%S")
+
+
+# ---------------------------------------------------------------------------
+# Service
+# ---------------------------------------------------------------------------
+
+class HostedEventLinkService:
+    """Build temporal links between game sessions and purchase/redemption events."""
+
+    def rebuild_links_for_pair(
+        self,
+        session: Session,
+        *,
+        workspace_id: str,
+        user_id: str,
+        site_id: str,
+    ) -> None:
+        """Full rebuild of event links for one (user, site) pair."""
+
+        # --- Clear existing links for this pair ---
+        session_ids_q = (
+            session.query(HostedGameSessionRecord.id)
+            .filter(
+                HostedGameSessionRecord.workspace_id == workspace_id,
+                HostedGameSessionRecord.user_id == user_id,
+                HostedGameSessionRecord.site_id == site_id,
+                HostedGameSessionRecord.deleted_at.is_(None),
+            )
+        )
+        session_ids = [r.id for r in session_ids_q.all()]
+        if session_ids:
+            session.query(HostedGameSessionEventLinkRecord).filter(
+                HostedGameSessionEventLinkRecord.game_session_id.in_(session_ids),
+            ).delete(synchronize_session="fetch")
+
+        # --- Load sessions (chronological) ---
+        game_sessions = (
+            session.query(HostedGameSessionRecord)
+            .filter(
+                HostedGameSessionRecord.workspace_id == workspace_id,
+                HostedGameSessionRecord.user_id == user_id,
+                HostedGameSessionRecord.site_id == site_id,
+                HostedGameSessionRecord.deleted_at.is_(None),
+            )
+            .order_by(
+                asc(func.coalesce(HostedGameSessionRecord.end_date, HostedGameSessionRecord.session_date)),
+                asc(func.coalesce(HostedGameSessionRecord.end_time, HostedGameSessionRecord.session_time, "00:00:00")),
+                asc(HostedGameSessionRecord.id),
+            )
+            .all()
+        )
+        if not game_sessions:
+            session.flush()
+            return
+
+        # --- Load purchases and redemptions ---
+        purchases = (
+            session.query(HostedPurchaseRecord)
+            .filter(
+                HostedPurchaseRecord.workspace_id == workspace_id,
+                HostedPurchaseRecord.user_id == user_id,
+                HostedPurchaseRecord.site_id == site_id,
+                HostedPurchaseRecord.deleted_at.is_(None),
+            )
+            .order_by(
+                asc(HostedPurchaseRecord.purchase_date),
+                asc(func.coalesce(HostedPurchaseRecord.purchase_time, "00:00:00")),
+                asc(HostedPurchaseRecord.id),
+            )
+            .all()
+        )
+
+        redemptions = (
+            session.query(HostedRedemptionRecord)
+            .filter(
+                HostedRedemptionRecord.workspace_id == workspace_id,
+                HostedRedemptionRecord.user_id == user_id,
+                HostedRedemptionRecord.site_id == site_id,
+                HostedRedemptionRecord.deleted_at.is_(None),
+                HostedRedemptionRecord.status.notin_(["CANCELED", "PENDING_CANCEL"]),
+            )
+            .order_by(
+                asc(HostedRedemptionRecord.redemption_date),
+                asc(func.coalesce(HostedRedemptionRecord.redemption_time, "00:00:00")),
+                asc(HostedRedemptionRecord.id),
+            )
+            .all()
+        )
+
+        # --- Classify and insert ---
+        links = self._classify_events(game_sessions, purchases, redemptions, workspace_id)
+        for link in links:
+            session.add(link)
+        session.flush()
+
+    def rebuild_links_all(
+        self,
+        session: Session,
+        *,
+        workspace_id: str,
+    ) -> None:
+        """Rebuild links for every (user, site) pair in the workspace."""
+        pairs = self._iter_pairs(session, workspace_id)
+        for user_id, site_id in pairs:
+            self.rebuild_links_for_pair(
+                session,
+                workspace_id=workspace_id,
+                user_id=user_id,
+                site_id=site_id,
+            )
+
+    # ------------------------------------------------------------------
+    # Private
+    # ------------------------------------------------------------------
+
+    def _iter_pairs(
+        self,
+        session: Session,
+        workspace_id: str,
+    ) -> List[Tuple[str, str]]:
+        """Distinct (user_id, site_id) pairs with purchases, redemptions, or sessions."""
+        from sqlalchemy import union_all, select
+
+        q1 = (
+            select(HostedPurchaseRecord.user_id, HostedPurchaseRecord.site_id)
+            .where(HostedPurchaseRecord.workspace_id == workspace_id, HostedPurchaseRecord.deleted_at.is_(None))
+            .distinct()
+        )
+        q2 = (
+            select(HostedRedemptionRecord.user_id, HostedRedemptionRecord.site_id)
+            .where(HostedRedemptionRecord.workspace_id == workspace_id, HostedRedemptionRecord.deleted_at.is_(None))
+            .distinct()
+        )
+        q3 = (
+            select(HostedGameSessionRecord.user_id, HostedGameSessionRecord.site_id)
+            .where(HostedGameSessionRecord.workspace_id == workspace_id, HostedGameSessionRecord.deleted_at.is_(None))
+            .distinct()
+        )
+        combined = union_all(q1, q2, q3).subquery()
+        rows = session.execute(
+            select(combined.c.user_id, combined.c.site_id).distinct()
+        ).all()
+        return sorted(
+            [(r.user_id, r.site_id) for r in rows if r.user_id and r.site_id]
+        )
+
+    @staticmethod
+    def _classify_events(
+        game_sessions: list,
+        purchases: list,
+        redemptions: list,
+        workspace_id: str,
+    ) -> List[HostedGameSessionEventLinkRecord]:
+        """Classify each purchase/redemption as BEFORE/DURING/AFTER each session."""
+        seen: set = set()  # deduplicate (session_id, event_type, event_id, relation)
+        links: List[HostedGameSessionEventLinkRecord] = []
+
+        for i, gs in enumerate(game_sessions):
+            start_dt = _to_dt(gs.session_date, gs.session_time)
+            is_active = gs.status == "Active" or gs.end_date is None
+            end_dt = None if is_active else _to_dt(gs.end_date, gs.end_time)
+
+            prev_end_dt = None
+            if i > 0:
+                prev = game_sessions[i - 1]
+                if prev.end_date:
+                    prev_end_dt = _to_dt(prev.end_date, prev.end_time)
+
+            next_start_dt = None
+            if i < len(game_sessions) - 1:
+                nxt = game_sessions[i + 1]
+                next_start_dt = _to_dt(nxt.session_date, nxt.session_time)
+
+            # --- purchases ---
+            for p in purchases:
+                p_dt = _to_dt(p.purchase_date, p.purchase_time)
+                relation = _classify_timestamp(
+                    p_dt, start_dt, end_dt, prev_end_dt, next_start_dt, is_active,
+                    link_type="purchase",
+                )
+                if relation:
+                    key = (gs.id, "purchase", p.id, relation)
+                    if key not in seen:
+                        seen.add(key)
+                        links.append(HostedGameSessionEventLinkRecord(
+                            id=str(uuid4()),
+                            workspace_id=workspace_id,
+                            game_session_id=gs.id,
+                            event_type="purchase",
+                            event_id=p.id,
+                            relation=relation,
+                        ))
+
+            # --- redemptions (closed sessions only for AFTER links) ---
+            for r in redemptions:
+                r_dt = _to_dt(r.redemption_date, r.redemption_time)
+                relation = _classify_timestamp(
+                    r_dt, start_dt, end_dt, prev_end_dt, next_start_dt, is_active,
+                    link_type="redemption",
+                )
+                if relation:
+                    key = (gs.id, "redemption", r.id, relation)
+                    if key not in seen:
+                        seen.add(key)
+                        links.append(HostedGameSessionEventLinkRecord(
+                            id=str(uuid4()),
+                            workspace_id=workspace_id,
+                            game_session_id=gs.id,
+                            event_type="redemption",
+                            event_id=r.id,
+                            relation=relation,
+                        ))
+
+        return links
+
+
+# ---------------------------------------------------------------------------
+# Pure classification function (stateless, testable)
+# ---------------------------------------------------------------------------
+
+def _classify_timestamp(
+    event_dt: datetime,
+    session_start: datetime,
+    session_end: Optional[datetime],
+    prev_end: Optional[datetime],
+    next_start: Optional[datetime],
+    is_active: bool,
+    *,
+    link_type: str,  # "purchase" or "redemption"
+) -> Optional[str]:
+    """Return 'BEFORE', 'DURING', 'AFTER', or None.
+
+    Boundary rule (Issue #90): start INCLUSIVE (>=), end EXCLUSIVE (<).
+    Redemption AFTER links only apply to closed sessions.
+    """
+    # --- DURING ---
+    if session_end is not None and session_start <= event_dt < session_end:
+        return "DURING"
+    if is_active and event_dt >= session_start:
+        if next_start is None or event_dt < next_start:
+            return "DURING"
+
+    # --- BEFORE (purchases only, or all events before session start) ---
+    if event_dt < session_start:
+        if prev_end is None and event_dt < session_start:
+            return "BEFORE"
+        if prev_end is not None and prev_end <= event_dt < session_start:
+            return "BEFORE"
+
+    # --- AFTER (closed sessions only) ---
+    if link_type == "redemption" and session_end is not None and event_dt >= session_end:
+        if next_start is None:
+            return "AFTER"
+        if event_dt < next_start:
+            return "AFTER"
+
+    return None

--- a/services/hosted/hosted_fifo_service.py
+++ b/services/hosted/hosted_fifo_service.py
@@ -1,0 +1,165 @@
+"""Hosted FIFO service — cost basis calculation using First-In-First-Out.
+
+Operates on hosted persistence records via SQLAlchemy sessions.
+All monetary values use ``Decimal`` (stored as strings in the DB).
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import List, Optional, Tuple
+
+from sqlalchemy import asc, func
+from sqlalchemy.orm import Session
+
+from services.hosted.persistence import HostedPurchaseRecord
+
+
+class HostedFIFOService:
+    """FIFO cost-basis calculation for the hosted (web) layer."""
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def calculate_cost_basis(
+        self,
+        session: Session,
+        *,
+        workspace_id: str,
+        user_id: str,
+        site_id: str,
+        redemption_amount: Decimal,
+        redemption_date: str,
+        redemption_time: str = "23:59:59",
+    ) -> Tuple[Decimal, Decimal, List[Tuple[str, Decimal]]]:
+        """Calculate cost basis for a single redemption using FIFO.
+
+        Returns
+        -------
+        (cost_basis, taxable_profit, allocations)
+            allocations is a list of ``(purchase_id, allocated_amount)``
+        """
+        available = self._get_available_purchases(
+            session,
+            workspace_id=workspace_id,
+            user_id=user_id,
+            site_id=site_id,
+            as_of_date=redemption_date,
+            as_of_time=redemption_time,
+        )
+
+        remaining_to_allocate = redemption_amount
+        cost_basis = Decimal("0.00")
+        allocations: List[Tuple[str, Decimal]] = []
+
+        for purchase in available:
+            if remaining_to_allocate <= 0:
+                break
+
+            avail = Decimal(str(purchase.remaining_amount))
+            if avail <= 0:
+                continue
+
+            alloc = min(remaining_to_allocate, avail)
+            allocations.append((purchase.id, alloc))
+            cost_basis += alloc
+            remaining_to_allocate -= alloc
+
+        taxable_profit = redemption_amount - cost_basis
+        return cost_basis, taxable_profit, allocations
+
+    def apply_allocation(
+        self,
+        session: Session,
+        allocations: List[Tuple[str, Decimal]],
+    ) -> None:
+        """Reduce ``remaining_amount`` on each purchase by the allocated amount."""
+        for purchase_id, amount_allocated in allocations:
+            purchase = session.get(HostedPurchaseRecord, purchase_id)
+            if purchase is None:
+                raise ValueError(f"Purchase {purchase_id} not found")
+
+            current = Decimal(str(purchase.remaining_amount))
+            new_remaining = current - amount_allocated
+            if new_remaining < 0:
+                raise ValueError(
+                    f"Cannot allocate ${amount_allocated} from purchase {purchase_id}. "
+                    f"Only ${current} remaining."
+                )
+            purchase.remaining_amount = str(new_remaining)
+
+    def reverse_allocation(
+        self,
+        session: Session,
+        allocations: List[Tuple[str, Decimal]],
+    ) -> None:
+        """Restore ``remaining_amount`` on each purchase (undo)."""
+        for purchase_id, amount_allocated in allocations:
+            purchase = session.get(HostedPurchaseRecord, purchase_id)
+            if purchase is None:
+                raise ValueError(f"Purchase {purchase_id} not found")
+
+            current = Decimal(str(purchase.remaining_amount))
+            original = Decimal(str(purchase.amount))
+            new_remaining = current + amount_allocated
+            if new_remaining > original:
+                raise ValueError(
+                    f"Cannot restore ${amount_allocated} to purchase {purchase_id}. "
+                    f"Would exceed original amount ${original}."
+                )
+            purchase.remaining_amount = str(new_remaining)
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _get_available_purchases(
+        self,
+        session: Session,
+        *,
+        workspace_id: str,
+        user_id: str,
+        site_id: str,
+        as_of_date: str,
+        as_of_time: str,
+    ) -> List[HostedPurchaseRecord]:
+        """Fetch purchases eligible for FIFO in chronological order.
+
+        Only includes non-deleted purchases with remaining_amount > '0'
+        whose timestamp is on or before the given date/time.
+        Ordered: purchase_date ASC, purchase_time ASC, id ASC.
+        """
+        from sqlalchemy import or_, and_
+
+        time_norm = as_of_time or "23:59:59"
+
+        return (
+            session.query(HostedPurchaseRecord)
+            .filter(
+                HostedPurchaseRecord.workspace_id == workspace_id,
+                HostedPurchaseRecord.user_id == user_id,
+                HostedPurchaseRecord.site_id == site_id,
+                HostedPurchaseRecord.deleted_at.is_(None),
+                HostedPurchaseRecord.remaining_amount > "0",
+                # Strictly: remaining_amount is a string column, but Postgres
+                # string comparison of well-formatted decimals works for > "0"
+                # since "0.00" < "0.01" etc.  For robustness we also exclude "0.00".
+                HostedPurchaseRecord.remaining_amount != "0.00",
+                HostedPurchaseRecord.remaining_amount != "0",
+                or_(
+                    HostedPurchaseRecord.purchase_date < as_of_date,
+                    and_(
+                        HostedPurchaseRecord.purchase_date == as_of_date,
+                        func.coalesce(HostedPurchaseRecord.purchase_time, "00:00:00")
+                        <= time_norm,
+                    ),
+                ),
+            )
+            .order_by(
+                asc(HostedPurchaseRecord.purchase_date),
+                asc(func.coalesce(HostedPurchaseRecord.purchase_time, "00:00:00")),
+                asc(HostedPurchaseRecord.id),
+            )
+            .all()
+        )

--- a/services/hosted/hosted_recalculation_service.py
+++ b/services/hosted/hosted_recalculation_service.py
@@ -1,0 +1,659 @@
+"""Hosted recalculation service — bulk FIFO + realized-transaction rebuilds.
+
+Ported from the desktop ``RecalculationService``.  Key differences:
+- SQLAlchemy ORM instead of raw SQL / DatabaseManager
+- String UUIDs instead of integer IDs
+- Monetary values stored/compared as strings (Decimal in Python)
+- No timezone conversion (hosted stores dates as-is)
+- Adjustment support is optional (injected)
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from datetime import datetime
+from decimal import Decimal
+from typing import Dict, List, Optional, Tuple
+from uuid import uuid4
+
+from sqlalchemy import asc, func, or_, and_
+from sqlalchemy.orm import Session
+
+from services.hosted.persistence import (
+    HostedAccountAdjustmentRecord,
+    HostedGameSessionRecord,
+    HostedPurchaseRecord,
+    HostedRedemptionAllocationRecord,
+    HostedRedemptionRecord,
+    HostedRealizedTransactionRecord,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _normalize_time(value: Optional[str]) -> str:
+    if not value:
+        return "00:00:00"
+    value = value.strip()
+    if len(value) == 5:
+        return f"{value}:00"
+    return value
+
+
+def _to_dt(date_str: str, time_str: Optional[str]) -> datetime:
+    return datetime.strptime(f"{date_str} {_normalize_time(time_str)}", "%Y-%m-%d %H:%M:%S")
+
+
+_CLOSE_BALANCE_RE = re.compile(r"Net Loss:\s*\$([0-9,]+(?:\.[0-9]{1,2})?)")
+
+
+def _parse_close_balance_loss(notes: Optional[str]) -> Optional[Decimal]:
+    if not notes:
+        return None
+    m = _CLOSE_BALANCE_RE.search(notes)
+    if not m:
+        return None
+    try:
+        return Decimal(m.group(1).replace(",", ""))
+    except Exception:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Result dataclass
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class HostedRebuildResult:
+    pairs_processed: int
+    redemptions_processed: int
+    allocations_written: int
+    purchases_updated: int
+    game_sessions_processed: int = 0
+    errors: List[str] = field(default_factory=list)
+    operation: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# Service
+# ---------------------------------------------------------------------------
+
+class HostedRecalculationService:
+    """Bulk FIFO + realized-transaction rebuild for a hosted workspace."""
+
+    def iter_pairs(
+        self,
+        session: Session,
+        workspace_id: str,
+    ) -> List[Tuple[str, str]]:
+        """Return distinct (user_id, site_id) pairs with any activity."""
+        from sqlalchemy import union_all, select, literal_column
+
+        purchases_q = (
+            select(
+                HostedPurchaseRecord.user_id,
+                HostedPurchaseRecord.site_id,
+            )
+            .where(
+                HostedPurchaseRecord.workspace_id == workspace_id,
+                HostedPurchaseRecord.deleted_at.is_(None),
+            )
+            .distinct()
+        )
+        redemptions_q = (
+            select(
+                HostedRedemptionRecord.user_id,
+                HostedRedemptionRecord.site_id,
+            )
+            .where(
+                HostedRedemptionRecord.workspace_id == workspace_id,
+                HostedRedemptionRecord.deleted_at.is_(None),
+            )
+            .distinct()
+        )
+        sessions_q = (
+            select(
+                HostedGameSessionRecord.user_id,
+                HostedGameSessionRecord.site_id,
+            )
+            .where(
+                HostedGameSessionRecord.workspace_id == workspace_id,
+                HostedGameSessionRecord.deleted_at.is_(None),
+            )
+            .distinct()
+        )
+        adjustments_q = (
+            select(
+                HostedAccountAdjustmentRecord.user_id,
+                HostedAccountAdjustmentRecord.site_id,
+            )
+            .where(
+                HostedAccountAdjustmentRecord.workspace_id == workspace_id,
+                HostedAccountAdjustmentRecord.deleted_at.is_(None),
+            )
+            .distinct()
+        )
+
+        combined = union_all(purchases_q, redemptions_q, sessions_q, adjustments_q).subquery()
+        rows = session.execute(
+            select(combined.c.user_id, combined.c.site_id).distinct()
+        ).all()
+
+        pairs = [
+            (r.user_id, r.site_id)
+            for r in rows
+            if r.user_id is not None and r.site_id is not None
+        ]
+        pairs.sort()
+        return pairs
+
+    # ------------------------------------------------------------------
+    # Full pair rebuild
+    # ------------------------------------------------------------------
+
+    def rebuild_fifo_for_pair(
+        self,
+        session: Session,
+        *,
+        workspace_id: str,
+        user_id: str,
+        site_id: str,
+    ) -> HostedRebuildResult:
+        """Full FIFO + realized-transaction rebuild for one (user, site) pair."""
+
+        # --- Fetch purchases (chronological) ---
+        purchase_rows = (
+            session.query(HostedPurchaseRecord)
+            .filter(
+                HostedPurchaseRecord.workspace_id == workspace_id,
+                HostedPurchaseRecord.user_id == user_id,
+                HostedPurchaseRecord.site_id == site_id,
+                HostedPurchaseRecord.deleted_at.is_(None),
+            )
+            .order_by(
+                asc(HostedPurchaseRecord.purchase_date),
+                asc(func.coalesce(HostedPurchaseRecord.purchase_time, "00:00:00")),
+                asc(HostedPurchaseRecord.id),
+            )
+            .all()
+        )
+
+        # Build in-memory FIFO state: (id, datetime, original_amount)
+        # remaining dict tracks current remaining for each lot
+        purchases: List[Tuple[str, datetime, Decimal]] = []
+        remaining: Dict[str, Decimal] = {}
+        for p in purchase_rows:
+            pid = p.id
+            amt = Decimal(str(p.amount))
+            dt = _to_dt(p.purchase_date, p.purchase_time)
+            purchases.append((pid, dt, amt))
+            remaining[pid] = amt
+
+        # --- Merge basis adjustments as synthetic lots ---
+        adj_rows = (
+            session.query(HostedAccountAdjustmentRecord)
+            .filter(
+                HostedAccountAdjustmentRecord.workspace_id == workspace_id,
+                HostedAccountAdjustmentRecord.user_id == user_id,
+                HostedAccountAdjustmentRecord.site_id == site_id,
+                HostedAccountAdjustmentRecord.deleted_at.is_(None),
+                HostedAccountAdjustmentRecord.type == "BASIS_USD_CORRECTION",
+            )
+            .all()
+        )
+        for adj in adj_rows:
+            synthetic_id = f"adj-{adj.id}"
+            dt = _to_dt(adj.effective_date, adj.effective_time)
+            delta = Decimal(str(adj.delta_basis_usd or "0.00"))
+            purchases.append((synthetic_id, dt, delta))
+            remaining[synthetic_id] = delta
+
+        # Re-sort chronologically
+        purchases.sort(key=lambda x: (x[1], x[0]))
+
+        # --- Fetch redemptions (chronological, non-deleted, non-canceled) ---
+        redemption_rows = (
+            session.query(HostedRedemptionRecord)
+            .filter(
+                HostedRedemptionRecord.workspace_id == workspace_id,
+                HostedRedemptionRecord.user_id == user_id,
+                HostedRedemptionRecord.site_id == site_id,
+                HostedRedemptionRecord.deleted_at.is_(None),
+                HostedRedemptionRecord.status.notin_(["CANCELED", "PENDING_CANCEL"]),
+            )
+            .order_by(
+                asc(HostedRedemptionRecord.redemption_date),
+                asc(func.coalesce(HostedRedemptionRecord.redemption_time, "00:00:00")),
+                asc(HostedRedemptionRecord.id),
+            )
+            .all()
+        )
+
+        # --- Clear existing derived records for this pair ---
+        self._clear_derived_for_pair(session, workspace_id, user_id, site_id)
+
+        # --- Allocate ---
+        allocations_to_write: List[Tuple[str, str, Decimal]] = []  # (redemption_id, purchase_id, amount)
+        realized_to_write: List[dict] = []
+
+        for red in redemption_rows:
+            payout = Decimal(str(red.amount))
+            is_free_sc = bool(red.is_free_sc)
+            red_dt = _to_dt(red.redemption_date, red.redemption_time)
+
+            # --- Close-balance (Net Loss) special case ---
+            close_loss = _parse_close_balance_loss(red.notes)
+            if payout == 0 and close_loss is not None:
+                cost_basis = self._allocate_fifo(
+                    purchases, remaining, red_dt, close_loss,
+                    allocations_to_write, red.id,
+                )
+                net_pl = payout - cost_basis
+                realized_to_write.append(self._realized_dict(
+                    workspace_id, red.redemption_date, user_id, site_id,
+                    red.id, cost_basis, payout, net_pl,
+                ))
+                continue
+
+            cost_basis = Decimal("0.00")
+            if not is_free_sc and payout > 0:
+                more_remaining = bool(red.more_remaining)
+                if not more_remaining:
+                    # Full redemption: consume ALL basis up to timestamp
+                    total_avail = sum(
+                        avail
+                        for pid, pdt, _ in purchases
+                        if pdt <= red_dt and (avail := remaining.get(pid, Decimal("0.00"))) > 0
+                    )
+                    amount_to_consume = total_avail
+                else:
+                    amount_to_consume = payout
+
+                cost_basis = self._allocate_fifo(
+                    purchases, remaining, red_dt, amount_to_consume,
+                    allocations_to_write, red.id,
+                )
+
+            net_pl = payout - cost_basis
+            realized_to_write.append(self._realized_dict(
+                workspace_id, red.redemption_date, user_id, site_id,
+                red.id, cost_basis, payout, net_pl,
+            ))
+
+        # --- Write updated remaining_amount for real purchases ---
+        purchases_updated = 0
+        for p in purchase_rows:
+            new_remaining = str(remaining[p.id])
+            if p.remaining_amount != new_remaining:
+                p.remaining_amount = new_remaining
+            purchases_updated += 1
+
+        # --- Write allocations ---
+        for red_id, purch_id, alloc_amt in allocations_to_write:
+            session.add(HostedRedemptionAllocationRecord(
+                id=str(uuid4()),
+                workspace_id=workspace_id,
+                redemption_id=red_id,
+                purchase_id=purch_id,
+                allocated_amount=str(alloc_amt),
+            ))
+
+        # --- Write realized transactions ---
+        for rt in realized_to_write:
+            session.add(HostedRealizedTransactionRecord(
+                id=str(uuid4()),
+                **rt,
+            ))
+
+        session.flush()
+
+        return HostedRebuildResult(
+            pairs_processed=1,
+            redemptions_processed=len(redemption_rows),
+            allocations_written=len(allocations_to_write),
+            purchases_updated=purchases_updated,
+        )
+
+    # ------------------------------------------------------------------
+    # Scoped rebuild (from a boundary timestamp)
+    # ------------------------------------------------------------------
+
+    def rebuild_fifo_for_pair_from(
+        self,
+        session: Session,
+        *,
+        workspace_id: str,
+        user_id: str,
+        site_id: str,
+        from_date: str,
+        from_time: Optional[str] = None,
+    ) -> HostedRebuildResult:
+        """Scoped FIFO rebuild starting at a boundary timestamp."""
+        from_time = _normalize_time(from_time)
+
+        # --- Fetch ALL purchases for pair ---
+        purchase_rows = (
+            session.query(HostedPurchaseRecord)
+            .filter(
+                HostedPurchaseRecord.workspace_id == workspace_id,
+                HostedPurchaseRecord.user_id == user_id,
+                HostedPurchaseRecord.site_id == site_id,
+                HostedPurchaseRecord.deleted_at.is_(None),
+            )
+            .order_by(
+                asc(HostedPurchaseRecord.purchase_date),
+                asc(func.coalesce(HostedPurchaseRecord.purchase_time, "00:00:00")),
+                asc(HostedPurchaseRecord.id),
+            )
+            .all()
+        )
+
+        purchases: List[Tuple[str, datetime, Decimal]] = []
+        remaining: Dict[str, Decimal] = {}
+        for p in purchase_rows:
+            amt = Decimal(str(p.amount))
+            dt = _to_dt(p.purchase_date, p.purchase_time)
+            purchases.append((p.id, dt, amt))
+            remaining[p.id] = amt
+
+        # Merge adjustments
+        adj_rows = (
+            session.query(HostedAccountAdjustmentRecord)
+            .filter(
+                HostedAccountAdjustmentRecord.workspace_id == workspace_id,
+                HostedAccountAdjustmentRecord.user_id == user_id,
+                HostedAccountAdjustmentRecord.site_id == site_id,
+                HostedAccountAdjustmentRecord.deleted_at.is_(None),
+                HostedAccountAdjustmentRecord.type == "BASIS_USD_CORRECTION",
+            )
+            .all()
+        )
+        for adj in adj_rows:
+            synthetic_id = f"adj-{adj.id}"
+            dt = _to_dt(adj.effective_date, adj.effective_time)
+            delta = Decimal(str(adj.delta_basis_usd or "0.00"))
+            purchases.append((synthetic_id, dt, delta))
+            remaining[synthetic_id] = delta
+
+        purchases.sort(key=lambda x: (x[1], x[0]))
+
+        # --- Prime remaining from prior allocations (before boundary) ---
+        prior_allocs = (
+            session.query(
+                HostedRedemptionAllocationRecord.purchase_id,
+                HostedRedemptionAllocationRecord.allocated_amount,
+            )
+            .join(
+                HostedRedemptionRecord,
+                HostedRedemptionAllocationRecord.redemption_id == HostedRedemptionRecord.id,
+            )
+            .filter(
+                HostedRedemptionRecord.workspace_id == workspace_id,
+                HostedRedemptionRecord.user_id == user_id,
+                HostedRedemptionRecord.site_id == site_id,
+                HostedRedemptionRecord.deleted_at.is_(None),
+                HostedRedemptionRecord.status.notin_(["CANCELED", "PENDING_CANCEL"]),
+                or_(
+                    HostedRedemptionRecord.redemption_date < from_date,
+                    and_(
+                        HostedRedemptionRecord.redemption_date == from_date,
+                        func.coalesce(HostedRedemptionRecord.redemption_time, "00:00:00") < from_time,
+                    ),
+                ),
+            )
+            .all()
+        )
+        for purchase_id, allocated_str in prior_allocs:
+            allocated = Decimal(str(allocated_str))
+            if purchase_id in remaining:
+                remaining[purchase_id] = max(Decimal("0.00"), remaining[purchase_id] - allocated)
+
+        # --- Fetch suffix redemptions ---
+        suffix_redemptions = (
+            session.query(HostedRedemptionRecord)
+            .filter(
+                HostedRedemptionRecord.workspace_id == workspace_id,
+                HostedRedemptionRecord.user_id == user_id,
+                HostedRedemptionRecord.site_id == site_id,
+                HostedRedemptionRecord.deleted_at.is_(None),
+                HostedRedemptionRecord.status.notin_(["CANCELED", "PENDING_CANCEL"]),
+                or_(
+                    HostedRedemptionRecord.redemption_date > from_date,
+                    and_(
+                        HostedRedemptionRecord.redemption_date == from_date,
+                        func.coalesce(HostedRedemptionRecord.redemption_time, "00:00:00") >= from_time,
+                    ),
+                ),
+            )
+            .order_by(
+                asc(HostedRedemptionRecord.redemption_date),
+                asc(func.coalesce(HostedRedemptionRecord.redemption_time, "00:00:00")),
+                asc(HostedRedemptionRecord.id),
+            )
+            .all()
+        )
+
+        suffix_ids = [r.id for r in suffix_redemptions]
+
+        # --- Delete existing allocations/realized for suffix ---
+        if suffix_ids:
+            session.query(HostedRedemptionAllocationRecord).filter(
+                HostedRedemptionAllocationRecord.redemption_id.in_(suffix_ids),
+            ).delete(synchronize_session="fetch")
+
+            session.query(HostedRealizedTransactionRecord).filter(
+                HostedRealizedTransactionRecord.redemption_id.in_(suffix_ids),
+            ).delete(synchronize_session="fetch")
+
+        # --- Allocate suffix ---
+        allocations_to_write: List[Tuple[str, str, Decimal]] = []
+        realized_to_write: List[dict] = []
+
+        for red in suffix_redemptions:
+            payout = Decimal(str(red.amount))
+            is_free_sc = bool(red.is_free_sc)
+            red_dt = _to_dt(red.redemption_date, red.redemption_time)
+
+            close_loss = _parse_close_balance_loss(red.notes)
+            if payout == 0 and close_loss is not None:
+                cost_basis = self._allocate_fifo(
+                    purchases, remaining, red_dt, close_loss,
+                    allocations_to_write, red.id,
+                )
+                net_pl = payout - cost_basis
+                realized_to_write.append(self._realized_dict(
+                    workspace_id, red.redemption_date, user_id, site_id,
+                    red.id, cost_basis, payout, net_pl,
+                ))
+                continue
+
+            cost_basis = Decimal("0.00")
+            if not is_free_sc and payout > 0:
+                more_remaining = bool(red.more_remaining)
+                if not more_remaining:
+                    total_avail = sum(
+                        avail
+                        for pid, pdt, _ in purchases
+                        if pdt <= red_dt and (avail := remaining.get(pid, Decimal("0.00"))) > 0
+                    )
+                    amount_to_consume = total_avail
+                else:
+                    amount_to_consume = payout
+
+                cost_basis = self._allocate_fifo(
+                    purchases, remaining, red_dt, amount_to_consume,
+                    allocations_to_write, red.id,
+                )
+
+            net_pl = payout - cost_basis
+            realized_to_write.append(self._realized_dict(
+                workspace_id, red.redemption_date, user_id, site_id,
+                red.id, cost_basis, payout, net_pl,
+            ))
+
+        # --- Update purchase remaining amounts ---
+        purchases_updated = 0
+        for p in purchase_rows:
+            new_remaining = str(remaining[p.id])
+            if p.remaining_amount != new_remaining:
+                p.remaining_amount = new_remaining
+            purchases_updated += 1
+
+        # --- Write allocations ---
+        for red_id, purch_id, alloc_amt in allocations_to_write:
+            session.add(HostedRedemptionAllocationRecord(
+                id=str(uuid4()),
+                workspace_id=workspace_id,
+                redemption_id=red_id,
+                purchase_id=purch_id,
+                allocated_amount=str(alloc_amt),
+            ))
+
+        # --- Write realized transactions ---
+        for rt in realized_to_write:
+            session.add(HostedRealizedTransactionRecord(
+                id=str(uuid4()),
+                **rt,
+            ))
+
+        session.flush()
+
+        return HostedRebuildResult(
+            pairs_processed=1,
+            redemptions_processed=len(suffix_redemptions),
+            allocations_written=len(allocations_to_write),
+            purchases_updated=purchases_updated,
+        )
+
+    # ------------------------------------------------------------------
+    # Full workspace rebuild
+    # ------------------------------------------------------------------
+
+    def rebuild_all(
+        self,
+        session: Session,
+        *,
+        workspace_id: str,
+    ) -> HostedRebuildResult:
+        """Rebuild FIFO + realized transactions for all pairs in a workspace."""
+        pairs = self.iter_pairs(session, workspace_id)
+
+        totals = {
+            "redemptions_processed": 0,
+            "allocations_written": 0,
+            "purchases_updated": 0,
+        }
+
+        for user_id, site_id in pairs:
+            result = self.rebuild_fifo_for_pair(
+                session,
+                workspace_id=workspace_id,
+                user_id=user_id,
+                site_id=site_id,
+            )
+            totals["redemptions_processed"] += result.redemptions_processed
+            totals["allocations_written"] += result.allocations_written
+            totals["purchases_updated"] += result.purchases_updated
+
+        return HostedRebuildResult(
+            pairs_processed=len(pairs),
+            operation="all",
+            **totals,
+        )
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _clear_derived_for_pair(
+        self,
+        session: Session,
+        workspace_id: str,
+        user_id: str,
+        site_id: str,
+    ) -> None:
+        """Delete all allocations + realized transactions for a (user, site) pair."""
+        # Get redemption IDs for this pair
+        red_ids = [
+            r.id
+            for r in session.query(HostedRedemptionRecord.id)
+            .filter(
+                HostedRedemptionRecord.workspace_id == workspace_id,
+                HostedRedemptionRecord.user_id == user_id,
+                HostedRedemptionRecord.site_id == site_id,
+            )
+            .all()
+        ]
+        if red_ids:
+            session.query(HostedRedemptionAllocationRecord).filter(
+                HostedRedemptionAllocationRecord.redemption_id.in_(red_ids),
+            ).delete(synchronize_session="fetch")
+
+        session.query(HostedRealizedTransactionRecord).filter(
+            HostedRealizedTransactionRecord.workspace_id == workspace_id,
+            HostedRealizedTransactionRecord.user_id == user_id,
+            HostedRealizedTransactionRecord.site_id == site_id,
+        ).delete(synchronize_session="fetch")
+
+    @staticmethod
+    def _allocate_fifo(
+        purchases: List[Tuple[str, datetime, Decimal]],
+        remaining: Dict[str, Decimal],
+        red_dt: datetime,
+        amount_to_consume: Decimal,
+        allocations_out: List[Tuple[str, str, Decimal]],
+        redemption_id: str,
+    ) -> Decimal:
+        """Walk purchases in FIFO order and allocate up to *amount_to_consume*.
+
+        Writes to *allocations_out* (only for real purchase IDs, not synthetic).
+        Returns total cost basis consumed.
+        """
+        cost_basis = Decimal("0.00")
+        left = amount_to_consume
+
+        for purchase_id, purchase_dt, _ in purchases:
+            if left <= 0:
+                break
+            if purchase_dt > red_dt:
+                break
+
+            avail = remaining.get(purchase_id, Decimal("0.00"))
+            if avail <= 0:
+                continue
+
+            alloc = min(avail, left)
+            remaining[purchase_id] = avail - alloc
+            left -= alloc
+            cost_basis += alloc
+
+            # Synthetic adjustment IDs start with "adj-"; skip writing to allocations table
+            if not purchase_id.startswith("adj-"):
+                allocations_out.append((redemption_id, purchase_id, alloc))
+
+        return cost_basis
+
+    @staticmethod
+    def _realized_dict(
+        workspace_id: str,
+        redemption_date: str,
+        user_id: str,
+        site_id: str,
+        redemption_id: str,
+        cost_basis: Decimal,
+        payout: Decimal,
+        net_pl: Decimal,
+    ) -> dict:
+        return {
+            "workspace_id": workspace_id,
+            "redemption_date": redemption_date,
+            "user_id": user_id,
+            "site_id": site_id,
+            "redemption_id": redemption_id,
+            "cost_basis": str(cost_basis),
+            "payout": str(payout),
+            "net_pl": str(net_pl),
+        }

--- a/services/hosted/hosted_timestamp_service.py
+++ b/services/hosted/hosted_timestamp_service.py
@@ -1,0 +1,172 @@
+"""Hosted timestamp uniqueness enforcement service.
+
+Ensures no two events (purchases, redemptions, sessions) for a given
+(workspace, user, site) triple share the exact same stored timestamp.
+Auto-increments by 1 second on conflict (up to 3600 attempts).
+
+Hosted adaptation notes vs desktop:
+- Uses SQLAlchemy ORM queries instead of raw SQL
+- IDs are string UUIDs, not integers
+- No timezone conversion layer: hosted stores dates/times as-is from the API
+  (the caller is responsible for any timezone handling before calling this service)
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Optional, Tuple
+
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from services.hosted.persistence import (
+    HostedGameSessionRecord,
+    HostedPurchaseRecord,
+    HostedRedemptionRecord,
+)
+
+
+def _normalize_time(value: Optional[str]) -> str:
+    if not value:
+        return "00:00:00"
+    value = value.strip()
+    if len(value) == 5:
+        return f"{value}:00"
+    return value
+
+
+class HostedTimestampService:
+    """Enforce timestamp uniqueness across event types for a workspace."""
+
+    MAX_ATTEMPTS = 3600  # 1 hour window
+
+    def ensure_unique_timestamp(
+        self,
+        session: Session,
+        *,
+        workspace_id: str,
+        user_id: str,
+        site_id: str,
+        date_str: str,
+        time_str: str,
+        exclude_id: Optional[str] = None,
+        event_type: Optional[str] = None,
+    ) -> Tuple[str, str, bool]:
+        """Return (date, time, was_adjusted) with a conflict-free timestamp.
+
+        Parameters
+        ----------
+        session : SQLAlchemy session (must be within a transaction)
+        workspace_id, user_id, site_id : scope identifiers
+        date_str : ISO date  e.g. "2026-01-15"
+        time_str : time      e.g. "14:30:00"
+        exclude_id : skip this record id during conflict check (for edits)
+        event_type : 'purchase' | 'redemption' | 'session_start' | 'session_end'
+        """
+        time_str = _normalize_time(time_str)
+
+        try:
+            current_dt = datetime.strptime(f"{date_str} {time_str}", "%Y-%m-%d %H:%M:%S")
+        except ValueError:
+            return (date_str, time_str, False)
+
+        original_dt = current_dt
+
+        for _ in range(self.MAX_ATTEMPTS):
+            cur_date = current_dt.strftime("%Y-%m-%d")
+            cur_time = current_dt.strftime("%H:%M:%S")
+
+            if not self._has_conflict(
+                session,
+                workspace_id=workspace_id,
+                user_id=user_id,
+                site_id=site_id,
+                date_str=cur_date,
+                time_str=cur_time,
+                exclude_id=exclude_id,
+                event_type=event_type,
+            ):
+                was_adjusted = current_dt != original_dt
+                return (cur_date, cur_time, was_adjusted)
+
+            current_dt += timedelta(seconds=1)
+
+        # Fallback (should never happen in practice)
+        return (date_str, time_str, False)
+
+    # ------------------------------------------------------------------
+    # Private
+    # ------------------------------------------------------------------
+
+    def _has_conflict(
+        self,
+        session: Session,
+        *,
+        workspace_id: str,
+        user_id: str,
+        site_id: str,
+        date_str: str,
+        time_str: str,
+        exclude_id: Optional[str],
+        event_type: Optional[str],
+    ) -> bool:
+        """Return True if *any* event occupies this timestamp slot."""
+
+        # --- purchases ---
+        q = session.query(func.count(HostedPurchaseRecord.id)).filter(
+            HostedPurchaseRecord.workspace_id == workspace_id,
+            HostedPurchaseRecord.user_id == user_id,
+            HostedPurchaseRecord.site_id == site_id,
+            HostedPurchaseRecord.purchase_date == date_str,
+            HostedPurchaseRecord.purchase_time == time_str,
+            HostedPurchaseRecord.deleted_at.is_(None),
+        )
+        if exclude_id and event_type == "purchase":
+            q = q.filter(HostedPurchaseRecord.id != exclude_id)
+        if q.scalar() > 0:
+            return True
+
+        # --- redemptions ---
+        q = session.query(func.count(HostedRedemptionRecord.id)).filter(
+            HostedRedemptionRecord.workspace_id == workspace_id,
+            HostedRedemptionRecord.user_id == user_id,
+            HostedRedemptionRecord.site_id == site_id,
+            HostedRedemptionRecord.redemption_date == date_str,
+            HostedRedemptionRecord.redemption_time == time_str,
+            HostedRedemptionRecord.deleted_at.is_(None),
+        )
+        if exclude_id and event_type == "redemption":
+            q = q.filter(HostedRedemptionRecord.id != exclude_id)
+        if q.scalar() > 0:
+            return True
+
+        # --- session start times ---
+        q = session.query(func.count(HostedGameSessionRecord.id)).filter(
+            HostedGameSessionRecord.workspace_id == workspace_id,
+            HostedGameSessionRecord.user_id == user_id,
+            HostedGameSessionRecord.site_id == site_id,
+            HostedGameSessionRecord.session_date == date_str,
+            HostedGameSessionRecord.session_time == time_str,
+            HostedGameSessionRecord.deleted_at.is_(None),
+        )
+        if exclude_id and event_type == "session_start":
+            q = q.filter(HostedGameSessionRecord.id != exclude_id)
+        if q.scalar() > 0:
+            return True
+
+        # --- session end times (closed sessions only) ---
+        q = session.query(func.count(HostedGameSessionRecord.id)).filter(
+            HostedGameSessionRecord.workspace_id == workspace_id,
+            HostedGameSessionRecord.user_id == user_id,
+            HostedGameSessionRecord.site_id == site_id,
+            HostedGameSessionRecord.end_date == date_str,
+            HostedGameSessionRecord.end_time == time_str,
+            HostedGameSessionRecord.status == "Closed",
+            HostedGameSessionRecord.deleted_at.is_(None),
+        )
+        if exclude_id and event_type == "session_end":
+            q = q.filter(HostedGameSessionRecord.id != exclude_id)
+        if q.scalar() > 0:
+            return True
+
+        return False

--- a/tests/services/hosted/test_hosted_event_link_service.py
+++ b/tests/services/hosted/test_hosted_event_link_service.py
@@ -1,0 +1,435 @@
+"""Tests for HostedEventLinkService — temporal event classification."""
+
+from datetime import datetime
+from uuid import uuid4
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from services.hosted.persistence import (
+    HostedBase,
+    HostedGameSessionEventLinkRecord,
+    HostedGameSessionRecord,
+    HostedPurchaseRecord,
+    HostedRedemptionRecord,
+)
+from services.hosted.hosted_event_link_service import (
+    HostedEventLinkService,
+    _classify_timestamp,
+)
+
+
+# ------------------------------------------------------------------
+# Helpers
+# ------------------------------------------------------------------
+
+W = "workspace-1"
+U = "user-1"
+S = "site-1"
+
+
+def _session_factory():
+    engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+    HostedBase.metadata.create_all(engine)
+    return engine, sessionmaker(bind=engine, expire_on_commit=False)
+
+
+def _game_session(date, time, *, end_date=None, end_time=None, status="Active", **kw):
+    defaults = dict(
+        id=str(uuid4()),
+        workspace_id=W,
+        user_id=U,
+        site_id=S,
+        session_date=date,
+        session_time=time,
+        end_date=end_date,
+        end_time=end_time,
+        status=status,
+    )
+    defaults.update(kw)
+    return HostedGameSessionRecord(**defaults)
+
+
+def _purchase(date, time, **kw):
+    defaults = dict(
+        id=str(uuid4()),
+        workspace_id=W,
+        user_id=U,
+        site_id=S,
+        amount="100.00",
+        remaining_amount="100.00",
+        purchase_date=date,
+        purchase_time=time,
+    )
+    defaults.update(kw)
+    return HostedPurchaseRecord(**defaults)
+
+
+def _redemption(date, time, **kw):
+    defaults = dict(
+        id=str(uuid4()),
+        workspace_id=W,
+        user_id=U,
+        site_id=S,
+        amount="50.00",
+        redemption_date=date,
+        redemption_time=time,
+        status="PENDING",
+    )
+    defaults.update(kw)
+    return HostedRedemptionRecord(**defaults)
+
+
+def _dt(s: str) -> datetime:
+    return datetime.strptime(s, "%Y-%m-%d %H:%M:%S")
+
+
+# ------------------------------------------------------------------
+# Tests — _classify_timestamp (pure function)
+# ------------------------------------------------------------------
+
+
+def test_during_closed_session():
+    """Event between start (inclusive) and end (exclusive) → DURING."""
+    result = _classify_timestamp(
+        event_dt=_dt("2026-01-15 10:30:00"),
+        session_start=_dt("2026-01-15 10:00:00"),
+        session_end=_dt("2026-01-15 11:00:00"),
+        prev_end=None,
+        next_start=None,
+        is_active=False,
+        link_type="purchase",
+    )
+    assert result == "DURING"
+
+
+def test_during_at_exact_start():
+    """Event at exactly session start → DURING (start inclusive)."""
+    result = _classify_timestamp(
+        event_dt=_dt("2026-01-15 10:00:00"),
+        session_start=_dt("2026-01-15 10:00:00"),
+        session_end=_dt("2026-01-15 11:00:00"),
+        prev_end=None,
+        next_start=None,
+        is_active=False,
+        link_type="purchase",
+    )
+    assert result == "DURING"
+
+
+def test_not_during_at_exact_end():
+    """Event at exactly session end → NOT DURING (end exclusive)."""
+    result = _classify_timestamp(
+        event_dt=_dt("2026-01-15 11:00:00"),
+        session_start=_dt("2026-01-15 10:00:00"),
+        session_end=_dt("2026-01-15 11:00:00"),
+        prev_end=None,
+        next_start=None,
+        is_active=False,
+        link_type="redemption",
+    )
+    # Should be AFTER (for redemptions on closed sessions)
+    assert result == "AFTER"
+
+
+def test_during_active_session():
+    """Active (open) session — events after start are DURING if no next session."""
+    result = _classify_timestamp(
+        event_dt=_dt("2026-01-15 14:00:00"),
+        session_start=_dt("2026-01-15 10:00:00"),
+        session_end=None,
+        prev_end=None,
+        next_start=None,
+        is_active=True,
+        link_type="purchase",
+    )
+    assert result == "DURING"
+
+
+def test_before_first_session():
+    """Event before first session with no previous session → BEFORE."""
+    result = _classify_timestamp(
+        event_dt=_dt("2026-01-15 08:00:00"),
+        session_start=_dt("2026-01-15 10:00:00"),
+        session_end=_dt("2026-01-15 11:00:00"),
+        prev_end=None,
+        next_start=None,
+        is_active=False,
+        link_type="purchase",
+    )
+    assert result == "BEFORE"
+
+
+def test_before_between_sessions():
+    """Event between previous session end and current start → BEFORE current."""
+    result = _classify_timestamp(
+        event_dt=_dt("2026-01-15 09:30:00"),
+        session_start=_dt("2026-01-15 10:00:00"),
+        session_end=_dt("2026-01-15 11:00:00"),
+        prev_end=_dt("2026-01-15 09:00:00"),
+        next_start=None,
+        is_active=False,
+        link_type="purchase",
+    )
+    assert result == "BEFORE"
+
+
+def test_after_closed_session_redemption():
+    """Redemption after closed session end → AFTER."""
+    result = _classify_timestamp(
+        event_dt=_dt("2026-01-15 12:00:00"),
+        session_start=_dt("2026-01-15 10:00:00"),
+        session_end=_dt("2026-01-15 11:00:00"),
+        prev_end=None,
+        next_start=None,
+        is_active=False,
+        link_type="redemption",
+    )
+    assert result == "AFTER"
+
+
+def test_after_not_for_purchases():
+    """Purchases after a closed session → None (AFTER only for redemptions)."""
+    result = _classify_timestamp(
+        event_dt=_dt("2026-01-15 12:00:00"),
+        session_start=_dt("2026-01-15 10:00:00"),
+        session_end=_dt("2026-01-15 11:00:00"),
+        prev_end=None,
+        next_start=None,
+        is_active=False,
+        link_type="purchase",
+    )
+    assert result is None
+
+
+def test_no_link_between_prev_end_and_current_start():
+    """Event right at prev session end time but not in BEFORE window → None."""
+    result = _classify_timestamp(
+        event_dt=_dt("2026-01-15 08:59:59"),
+        session_start=_dt("2026-01-15 10:00:00"),
+        session_end=_dt("2026-01-15 11:00:00"),
+        prev_end=_dt("2026-01-15 09:00:00"),
+        next_start=None,
+        is_active=False,
+        link_type="purchase",
+    )
+    # 08:59:59 < 09:00:00 (prev_end), so not in BEFORE window for this session
+    assert result is None
+
+
+# ------------------------------------------------------------------
+# Tests — rebuild_links_for_pair (integration)
+# ------------------------------------------------------------------
+
+
+def test_rebuild_links_basic():
+    """Rebuild produces correct BEFORE/DURING/AFTER links."""
+    engine, sf = _session_factory()
+    svc = HostedEventLinkService()
+    try:
+        with sf() as session:
+            gs = _game_session(
+                "2026-01-15", "10:00:00",
+                end_date="2026-01-15", end_time="12:00:00",
+                status="Closed",
+            )
+            p_before = _purchase("2026-01-15", "09:00:00")
+            p_during = _purchase("2026-01-15", "10:30:00")
+            r_after = _redemption("2026-01-15", "13:00:00")
+            session.add_all([gs, p_before, p_during, r_after])
+            session.flush()
+
+            svc.rebuild_links_for_pair(
+                session, workspace_id=W, user_id=U, site_id=S,
+            )
+            session.flush()
+
+            links = session.query(HostedGameSessionEventLinkRecord).all()
+            link_dict = {(l.event_type, l.event_id, l.relation) for l in links}
+
+            assert ("purchase", p_before.id, "BEFORE") in link_dict
+            assert ("purchase", p_during.id, "DURING") in link_dict
+            assert ("redemption", r_after.id, "AFTER") in link_dict
+    finally:
+        engine.dispose()
+
+
+def test_rebuild_links_active_session():
+    """Active session links events after start as DURING."""
+    engine, sf = _session_factory()
+    svc = HostedEventLinkService()
+    try:
+        with sf() as session:
+            gs = _game_session("2026-01-15", "10:00:00")  # Active
+            p = _purchase("2026-01-15", "14:00:00")
+            session.add_all([gs, p])
+            session.flush()
+
+            svc.rebuild_links_for_pair(
+                session, workspace_id=W, user_id=U, site_id=S,
+            )
+            session.flush()
+
+            links = session.query(HostedGameSessionEventLinkRecord).all()
+            assert len(links) == 1
+            assert links[0].relation == "DURING"
+    finally:
+        engine.dispose()
+
+
+def test_rebuild_links_multiple_sessions():
+    """Events classified correctly across multiple closed sessions."""
+    engine, sf = _session_factory()
+    svc = HostedEventLinkService()
+    try:
+        with sf() as session:
+            gs1 = _game_session(
+                "2026-01-15", "10:00:00",
+                end_date="2026-01-15", end_time="11:00:00",
+                status="Closed",
+            )
+            gs2 = _game_session(
+                "2026-01-15", "12:00:00",
+                end_date="2026-01-15", end_time="14:00:00",
+                status="Closed",
+            )
+            # Between sessions → BEFORE gs2
+            p = _purchase("2026-01-15", "11:30:00")
+            # During gs2
+            r = _redemption("2026-01-15", "13:00:00")
+            session.add_all([gs1, gs2, p, r])
+            session.flush()
+
+            svc.rebuild_links_for_pair(
+                session, workspace_id=W, user_id=U, site_id=S,
+            )
+            session.flush()
+
+            links = session.query(HostedGameSessionEventLinkRecord).all()
+            link_dict = {(l.game_session_id, l.event_type, l.event_id, l.relation) for l in links}
+
+            # p (11:30) is AFTER gs1 end (11:00) but BEFORE gs2 start (12:00)
+            # Since prev_end (11:00) <= 11:30 < start (12:00) → BEFORE gs2
+            assert (gs2.id, "purchase", p.id, "BEFORE") in link_dict
+            # r (13:00) is DURING gs2
+            assert (gs2.id, "redemption", r.id, "DURING") in link_dict
+    finally:
+        engine.dispose()
+
+
+def test_rebuild_idempotent():
+    """Running rebuild twice produces the same links (no duplicates)."""
+    engine, sf = _session_factory()
+    svc = HostedEventLinkService()
+    try:
+        with sf() as session:
+            gs = _game_session(
+                "2026-01-15", "10:00:00",
+                end_date="2026-01-15", end_time="12:00:00",
+                status="Closed",
+            )
+            p = _purchase("2026-01-15", "09:00:00")
+            session.add_all([gs, p])
+            session.flush()
+
+            svc.rebuild_links_for_pair(
+                session, workspace_id=W, user_id=U, site_id=S,
+            )
+            session.flush()
+
+            svc.rebuild_links_for_pair(
+                session, workspace_id=W, user_id=U, site_id=S,
+            )
+            session.flush()
+
+            links = session.query(HostedGameSessionEventLinkRecord).all()
+            assert len(links) == 1
+    finally:
+        engine.dispose()
+
+
+def test_rebuild_no_sessions_no_links():
+    """No game sessions → no links created."""
+    engine, sf = _session_factory()
+    svc = HostedEventLinkService()
+    try:
+        with sf() as session:
+            p = _purchase("2026-01-15", "09:00:00")
+            session.add(p)
+            session.flush()
+
+            svc.rebuild_links_for_pair(
+                session, workspace_id=W, user_id=U, site_id=S,
+            )
+            session.flush()
+
+            links = session.query(HostedGameSessionEventLinkRecord).all()
+            assert len(links) == 0
+    finally:
+        engine.dispose()
+
+
+def test_canceled_redemptions_excluded():
+    """Canceled redemptions should not generate event links."""
+    engine, sf = _session_factory()
+    svc = HostedEventLinkService()
+    try:
+        with sf() as session:
+            gs = _game_session(
+                "2026-01-15", "10:00:00",
+                end_date="2026-01-15", end_time="12:00:00",
+                status="Closed",
+            )
+            r = _redemption(
+                "2026-01-15", "10:30:00",
+                status="CANCELED",
+            )
+            session.add_all([gs, r])
+            session.flush()
+
+            svc.rebuild_links_for_pair(
+                session, workspace_id=W, user_id=U, site_id=S,
+            )
+            session.flush()
+
+            links = session.query(HostedGameSessionEventLinkRecord).all()
+            assert len(links) == 0
+    finally:
+        engine.dispose()
+
+
+# ------------------------------------------------------------------
+# Tests — rebuild_links_all
+# ------------------------------------------------------------------
+
+
+def test_rebuild_all_processes_multiple_pairs():
+    engine, sf = _session_factory()
+    svc = HostedEventLinkService()
+    try:
+        with sf() as session:
+            # Pair 1
+            gs1 = _game_session(
+                "2026-01-15", "10:00:00",
+                end_date="2026-01-15", end_time="12:00:00",
+                status="Closed",
+            )
+            p1 = _purchase("2026-01-15", "09:00:00")
+            # Pair 2
+            gs2 = _game_session(
+                "2026-01-15", "10:00:00",
+                end_date="2026-01-15", end_time="12:00:00",
+                status="Closed",
+                user_id="user-2", site_id="site-2",
+            )
+            p2 = _purchase("2026-01-15", "09:00:00", user_id="user-2", site_id="site-2")
+            session.add_all([gs1, p1, gs2, p2])
+            session.flush()
+
+            svc.rebuild_links_all(session, workspace_id=W)
+            session.flush()
+
+            links = session.query(HostedGameSessionEventLinkRecord).all()
+            assert len(links) == 2  # One link per pair
+    finally:
+        engine.dispose()

--- a/tests/services/hosted/test_hosted_fifo_service.py
+++ b/tests/services/hosted/test_hosted_fifo_service.py
@@ -1,0 +1,287 @@
+"""Tests for HostedFIFOService — FIFO cost-basis calculation."""
+
+from decimal import Decimal
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from services.hosted.persistence import HostedBase, HostedPurchaseRecord
+from services.hosted.hosted_fifo_service import HostedFIFOService
+
+
+# ------------------------------------------------------------------
+# Helpers
+# ------------------------------------------------------------------
+
+W = "workspace-1"
+U = "user-1"
+S = "site-1"
+
+
+def _session_factory():
+    engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+    HostedBase.metadata.create_all(engine)
+    return engine, sessionmaker(bind=engine, expire_on_commit=False)
+
+
+def _make_purchase(date: str, time: str, amount: str, remaining: str | None = None, **kw):
+    defaults = dict(
+        id=str(uuid4()),
+        workspace_id=W,
+        user_id=U,
+        site_id=S,
+        amount=amount,
+        remaining_amount=remaining or amount,
+        purchase_date=date,
+        purchase_time=time,
+    )
+    defaults.update(kw)
+    return HostedPurchaseRecord(**defaults)
+
+
+# ------------------------------------------------------------------
+# Tests — calculate_cost_basis
+# ------------------------------------------------------------------
+
+
+def test_single_purchase_full_redemption():
+    """One purchase covers the entire redemption."""
+    engine, sf = _session_factory()
+    svc = HostedFIFOService()
+    try:
+        with sf() as session:
+            session.add(_make_purchase("2026-01-01", "10:00:00", "100.00"))
+            session.flush()
+
+            cost, profit, allocs = svc.calculate_cost_basis(
+                session,
+                workspace_id=W, user_id=U, site_id=S,
+                redemption_amount=Decimal("80.00"),
+                redemption_date="2026-01-15",
+                redemption_time="12:00:00",
+            )
+    finally:
+        engine.dispose()
+
+    assert cost == Decimal("80.00")
+    assert profit == Decimal("0.00")
+    assert len(allocs) == 1
+    assert allocs[0][1] == Decimal("80.00")
+
+
+def test_multiple_purchases_fifo_order():
+    """Purchases are consumed oldest-first."""
+    engine, sf = _session_factory()
+    svc = HostedFIFOService()
+    try:
+        with sf() as session:
+            p1 = _make_purchase("2026-01-01", "10:00:00", "30.00")
+            p2 = _make_purchase("2026-01-02", "10:00:00", "50.00")
+            p3 = _make_purchase("2026-01-03", "10:00:00", "40.00")
+            session.add_all([p1, p2, p3])
+            session.flush()
+
+            cost, profit, allocs = svc.calculate_cost_basis(
+                session,
+                workspace_id=W, user_id=U, site_id=S,
+                redemption_amount=Decimal("60.00"),
+                redemption_date="2026-01-15",
+            )
+    finally:
+        engine.dispose()
+
+    # Should consume $30 from p1, $30 from p2
+    assert cost == Decimal("60.00")
+    assert profit == Decimal("0.00")
+    assert len(allocs) == 2
+    assert allocs[0] == (p1.id, Decimal("30.00"))
+    assert allocs[1] == (p2.id, Decimal("30.00"))
+
+
+def test_insufficient_basis_partial():
+    """When basis < redemption amount, taxable profit is the remainder."""
+    engine, sf = _session_factory()
+    svc = HostedFIFOService()
+    try:
+        with sf() as session:
+            session.add(_make_purchase("2026-01-01", "10:00:00", "40.00"))
+            session.flush()
+
+            cost, profit, allocs = svc.calculate_cost_basis(
+                session,
+                workspace_id=W, user_id=U, site_id=S,
+                redemption_amount=Decimal("100.00"),
+                redemption_date="2026-01-15",
+            )
+    finally:
+        engine.dispose()
+
+    assert cost == Decimal("40.00")
+    assert profit == Decimal("60.00")
+    assert len(allocs) == 1
+
+
+def test_no_purchases_zero_basis():
+    """No available purchases → zero cost basis."""
+    engine, sf = _session_factory()
+    svc = HostedFIFOService()
+    try:
+        with sf() as session:
+            cost, profit, allocs = svc.calculate_cost_basis(
+                session,
+                workspace_id=W, user_id=U, site_id=S,
+                redemption_amount=Decimal("50.00"),
+                redemption_date="2026-01-15",
+            )
+    finally:
+        engine.dispose()
+
+    assert cost == Decimal("0.00")
+    assert profit == Decimal("50.00")
+    assert allocs == []
+
+
+def test_consumed_purchases_skipped():
+    """Purchases with remaining_amount=0 are not allocated."""
+    engine, sf = _session_factory()
+    svc = HostedFIFOService()
+    try:
+        with sf() as session:
+            session.add(_make_purchase("2026-01-01", "10:00:00", "50.00", remaining="0.00"))
+            session.add(_make_purchase("2026-01-02", "10:00:00", "30.00"))
+            session.flush()
+
+            cost, profit, allocs = svc.calculate_cost_basis(
+                session,
+                workspace_id=W, user_id=U, site_id=S,
+                redemption_amount=Decimal("30.00"),
+                redemption_date="2026-01-15",
+            )
+    finally:
+        engine.dispose()
+
+    assert cost == Decimal("30.00")
+    assert len(allocs) == 1  # Only the second purchase
+
+
+def test_future_purchases_excluded():
+    """Purchases after the redemption date/time are not eligible."""
+    engine, sf = _session_factory()
+    svc = HostedFIFOService()
+    try:
+        with sf() as session:
+            session.add(_make_purchase("2026-01-20", "10:00:00", "100.00"))
+            session.flush()
+
+            cost, profit, allocs = svc.calculate_cost_basis(
+                session,
+                workspace_id=W, user_id=U, site_id=S,
+                redemption_amount=Decimal("50.00"),
+                redemption_date="2026-01-15",
+                redemption_time="12:00:00",
+            )
+    finally:
+        engine.dispose()
+
+    assert cost == Decimal("0.00")
+    assert allocs == []
+
+
+# ------------------------------------------------------------------
+# Tests — apply_allocation / reverse_allocation
+# ------------------------------------------------------------------
+
+
+def test_apply_allocation_reduces_remaining():
+    engine, sf = _session_factory()
+    svc = HostedFIFOService()
+    try:
+        with sf() as session:
+            p = _make_purchase("2026-01-01", "10:00:00", "100.00")
+            session.add(p)
+            session.flush()
+            pid = p.id
+
+            svc.apply_allocation(session, [(pid, Decimal("40.00"))])
+            session.flush()
+
+            updated = session.get(HostedPurchaseRecord, pid)
+            assert Decimal(updated.remaining_amount) == Decimal("60.00")
+    finally:
+        engine.dispose()
+
+
+def test_reverse_allocation_restores_remaining():
+    engine, sf = _session_factory()
+    svc = HostedFIFOService()
+    try:
+        with sf() as session:
+            p = _make_purchase("2026-01-01", "10:00:00", "100.00", remaining="60.00")
+            session.add(p)
+            session.flush()
+            pid = p.id
+
+            svc.reverse_allocation(session, [(pid, Decimal("40.00"))])
+            session.flush()
+
+            updated = session.get(HostedPurchaseRecord, pid)
+            assert Decimal(updated.remaining_amount) == Decimal("100.00")
+    finally:
+        engine.dispose()
+
+
+def test_apply_allocation_over_remaining_raises():
+    engine, sf = _session_factory()
+    svc = HostedFIFOService()
+    try:
+        with sf() as session:
+            p = _make_purchase("2026-01-01", "10:00:00", "50.00")
+            session.add(p)
+            session.flush()
+
+            with pytest.raises(ValueError, match="Cannot allocate"):
+                svc.apply_allocation(session, [(p.id, Decimal("60.00"))])
+    finally:
+        engine.dispose()
+
+
+def test_reverse_allocation_over_original_raises():
+    engine, sf = _session_factory()
+    svc = HostedFIFOService()
+    try:
+        with sf() as session:
+            p = _make_purchase("2026-01-01", "10:00:00", "50.00")
+            session.add(p)
+            session.flush()
+
+            with pytest.raises(ValueError, match="Would exceed original"):
+                svc.reverse_allocation(session, [(p.id, Decimal("10.00"))])
+    finally:
+        engine.dispose()
+
+
+def test_deleted_purchases_excluded():
+    """Soft-deleted purchases are not eligible for FIFO."""
+    engine, sf = _session_factory()
+    svc = HostedFIFOService()
+    try:
+        with sf() as session:
+            session.add(_make_purchase(
+                "2026-01-01", "10:00:00", "100.00",
+                deleted_at="2026-01-10T00:00:00",
+            ))
+            session.flush()
+
+            cost, profit, allocs = svc.calculate_cost_basis(
+                session,
+                workspace_id=W, user_id=U, site_id=S,
+                redemption_amount=Decimal("50.00"),
+                redemption_date="2026-01-15",
+            )
+    finally:
+        engine.dispose()
+
+    assert cost == Decimal("0.00")
+    assert allocs == []

--- a/tests/services/hosted/test_hosted_recalculation_service.py
+++ b/tests/services/hosted/test_hosted_recalculation_service.py
@@ -1,0 +1,549 @@
+"""Tests for HostedRecalculationService — bulk FIFO + realized-transaction rebuilds."""
+
+from decimal import Decimal
+from uuid import uuid4
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from services.hosted.persistence import (
+    HostedBase,
+    HostedAccountAdjustmentRecord,
+    HostedGameSessionRecord,
+    HostedPurchaseRecord,
+    HostedRedemptionAllocationRecord,
+    HostedRedemptionRecord,
+    HostedRealizedTransactionRecord,
+)
+from services.hosted.hosted_recalculation_service import (
+    HostedRecalculationService,
+    _parse_close_balance_loss,
+)
+
+
+# ------------------------------------------------------------------
+# Helpers
+# ------------------------------------------------------------------
+
+W = "workspace-1"
+U = "user-1"
+S = "site-1"
+
+
+def _session_factory():
+    engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+    HostedBase.metadata.create_all(engine)
+    return engine, sessionmaker(bind=engine, expire_on_commit=False)
+
+
+def _purchase(date, time, amount, **kw):
+    defaults = dict(
+        id=str(uuid4()),
+        workspace_id=W,
+        user_id=U,
+        site_id=S,
+        amount=str(amount),
+        remaining_amount=str(amount),
+        purchase_date=date,
+        purchase_time=time,
+    )
+    defaults.update(kw)
+    return HostedPurchaseRecord(**defaults)
+
+
+def _redemption(date, time, amount, *, more_remaining=False, is_free_sc=False, notes=None, **kw):
+    defaults = dict(
+        id=str(uuid4()),
+        workspace_id=W,
+        user_id=U,
+        site_id=S,
+        amount=str(amount),
+        redemption_date=date,
+        redemption_time=time,
+        more_remaining=more_remaining,
+        is_free_sc=is_free_sc,
+        notes=notes,
+        status="PENDING",
+    )
+    defaults.update(kw)
+    return HostedRedemptionRecord(**defaults)
+
+
+def _game_session(date, time, *, end_date=None, end_time=None, status="Active", **kw):
+    defaults = dict(
+        id=str(uuid4()),
+        workspace_id=W,
+        user_id=U,
+        site_id=S,
+        session_date=date,
+        session_time=time,
+        end_date=end_date,
+        end_time=end_time,
+        status=status,
+    )
+    defaults.update(kw)
+    return HostedGameSessionRecord(**defaults)
+
+
+def _adjustment(date, time, delta_basis, **kw):
+    defaults = dict(
+        id=str(uuid4()),
+        workspace_id=W,
+        user_id=U,
+        site_id=S,
+        effective_date=date,
+        effective_time=time,
+        type="BASIS_USD_CORRECTION",
+        delta_basis_usd=str(delta_basis),
+        reason="test adjustment",
+    )
+    defaults.update(kw)
+    return HostedAccountAdjustmentRecord(**defaults)
+
+
+# ------------------------------------------------------------------
+# Tests — _parse_close_balance_loss (pure function)
+# ------------------------------------------------------------------
+
+
+def test_parse_close_balance_loss_simple():
+    assert _parse_close_balance_loss("Net Loss: $45.00") == Decimal("45.00")
+
+
+def test_parse_close_balance_loss_with_comma():
+    assert _parse_close_balance_loss("Net Loss: $1,234.56") == Decimal("1234.56")
+
+
+def test_parse_close_balance_loss_none():
+    assert _parse_close_balance_loss(None) is None
+    assert _parse_close_balance_loss("No loss here") is None
+    assert _parse_close_balance_loss("") is None
+
+
+# ------------------------------------------------------------------
+# Tests — rebuild_fifo_for_pair (happy path)
+# ------------------------------------------------------------------
+
+
+def test_single_purchase_single_redemption():
+    """One purchase, one full redemption → cost basis equals available amount."""
+    engine, sf = _session_factory()
+    svc = HostedRecalculationService()
+    try:
+        with sf() as session:
+            p = _purchase("2026-01-01", "10:00:00", 100)
+            r = _redemption("2026-01-15", "12:00:00", 150, more_remaining=False)
+            session.add_all([p, r])
+            session.flush()
+
+            result = svc.rebuild_fifo_for_pair(
+                session, workspace_id=W, user_id=U, site_id=S,
+            )
+            session.flush()
+
+            # Check result
+            assert result.pairs_processed == 1
+            assert result.redemptions_processed == 1
+            assert result.allocations_written == 1
+
+            # Check allocation
+            allocs = session.query(HostedRedemptionAllocationRecord).all()
+            assert len(allocs) == 1
+            assert allocs[0].purchase_id == p.id
+            assert allocs[0].redemption_id == r.id
+            assert Decimal(allocs[0].allocated_amount) == Decimal("100")
+
+            # Check realized transaction
+            realized = session.query(HostedRealizedTransactionRecord).all()
+            assert len(realized) == 1
+            assert Decimal(realized[0].cost_basis) == Decimal("100")
+            assert Decimal(realized[0].payout) == Decimal("150")
+            assert Decimal(realized[0].net_pl) == Decimal("50")
+
+            # Check purchase remaining reset to 0
+            p_updated = session.get(HostedPurchaseRecord, p.id)
+            assert Decimal(p_updated.remaining_amount) == Decimal("0")
+    finally:
+        engine.dispose()
+
+
+def test_multiple_purchases_multiple_redemptions():
+    """Multiple purchases consumed in FIFO order across redemptions."""
+    engine, sf = _session_factory()
+    svc = HostedRecalculationService()
+    try:
+        with sf() as session:
+            p1 = _purchase("2026-01-01", "10:00:00", 50)
+            p2 = _purchase("2026-01-02", "10:00:00", 75)
+            # Partial: consumes only payout amount ($40)
+            r1 = _redemption("2026-01-10", "12:00:00", 40, more_remaining=True)
+            # Full: consumes ALL remaining basis
+            r2 = _redemption("2026-01-20", "12:00:00", 200, more_remaining=False)
+            session.add_all([p1, p2, r1, r2])
+            session.flush()
+
+            svc.rebuild_fifo_for_pair(
+                session, workspace_id=W, user_id=U, site_id=S,
+            )
+            session.flush()
+
+            allocs = (
+                session.query(HostedRedemptionAllocationRecord)
+                .order_by(HostedRedemptionAllocationRecord.created_at)
+                .all()
+            )
+            # r1 (partial, $40): takes $40 from p1
+            # r2 (full): takes remaining $10 from p1 + $75 from p2 = $85
+            r1_allocs = [a for a in allocs if a.redemption_id == r1.id]
+            r2_allocs = [a for a in allocs if a.redemption_id == r2.id]
+
+            assert len(r1_allocs) == 1
+            assert Decimal(r1_allocs[0].allocated_amount) == Decimal("40")
+
+            assert len(r2_allocs) == 2
+            r2_total = sum(Decimal(a.allocated_amount) for a in r2_allocs)
+            assert r2_total == Decimal("85")  # 10 + 75
+
+            # Check realized
+            realized = (
+                session.query(HostedRealizedTransactionRecord)
+                .order_by(HostedRealizedTransactionRecord.redemption_date)
+                .all()
+            )
+            assert len(realized) == 2
+            # r1: payout=40, cost_basis=40, net_pl=0
+            assert Decimal(realized[0].net_pl) == Decimal("0")
+            # r2: payout=200, cost_basis=85, net_pl=115
+            assert Decimal(realized[1].payout) == Decimal("200")
+            assert Decimal(realized[1].cost_basis) == Decimal("85")
+            assert Decimal(realized[1].net_pl) == Decimal("115")
+    finally:
+        engine.dispose()
+
+
+# ------------------------------------------------------------------
+# Tests — special cases
+# ------------------------------------------------------------------
+
+
+def test_free_sc_redemption_skips_fifo():
+    """Free SC redemptions should not generate FIFO allocations."""
+    engine, sf = _session_factory()
+    svc = HostedRecalculationService()
+    try:
+        with sf() as session:
+            p = _purchase("2026-01-01", "10:00:00", 100)
+            r = _redemption("2026-01-15", "12:00:00", 50, is_free_sc=True)
+            session.add_all([p, r])
+            session.flush()
+
+            svc.rebuild_fifo_for_pair(
+                session, workspace_id=W, user_id=U, site_id=S,
+            )
+            session.flush()
+
+            allocs = session.query(HostedRedemptionAllocationRecord).all()
+            assert len(allocs) == 0
+
+            # Realized transaction still written (cost_basis = 0)
+            realized = session.query(HostedRealizedTransactionRecord).all()
+            assert len(realized) == 1
+            assert Decimal(realized[0].cost_basis) == Decimal("0")
+            assert Decimal(realized[0].payout) == Decimal("50")
+            assert Decimal(realized[0].net_pl) == Decimal("50")
+
+            # Purchase remaining unchanged
+            assert Decimal(session.get(HostedPurchaseRecord, p.id).remaining_amount) == Decimal("100")
+    finally:
+        engine.dispose()
+
+
+def test_close_balance_net_loss():
+    """Close-balance (Net Loss) redemption consumes the loss amount as basis."""
+    engine, sf = _session_factory()
+    svc = HostedRecalculationService()
+    try:
+        with sf() as session:
+            p = _purchase("2026-01-01", "10:00:00", 100)
+            r = _redemption(
+                "2026-01-15", "12:00:00", 0,
+                notes="Close balance: Net Loss: $30.00",
+            )
+            session.add_all([p, r])
+            session.flush()
+
+            svc.rebuild_fifo_for_pair(
+                session, workspace_id=W, user_id=U, site_id=S,
+            )
+            session.flush()
+
+            allocs = session.query(HostedRedemptionAllocationRecord).all()
+            assert len(allocs) == 1
+            assert Decimal(allocs[0].allocated_amount) == Decimal("30")
+
+            realized = session.query(HostedRealizedTransactionRecord).all()
+            assert len(realized) == 1
+            assert Decimal(realized[0].cost_basis) == Decimal("30")
+            assert Decimal(realized[0].payout) == Decimal("0")
+            assert Decimal(realized[0].net_pl) == Decimal("-30")
+    finally:
+        engine.dispose()
+
+
+def test_canceled_redemptions_excluded():
+    """Canceled redemptions should not participate in FIFO."""
+    engine, sf = _session_factory()
+    svc = HostedRecalculationService()
+    try:
+        with sf() as session:
+            p = _purchase("2026-01-01", "10:00:00", 100)
+            r_canceled = _redemption(
+                "2026-01-15", "12:00:00", 50,
+                status="CANCELED",
+            )
+            session.add_all([p, r_canceled])
+            session.flush()
+
+            result = svc.rebuild_fifo_for_pair(
+                session, workspace_id=W, user_id=U, site_id=S,
+            )
+            session.flush()
+
+            assert result.redemptions_processed == 0
+            allocs = session.query(HostedRedemptionAllocationRecord).all()
+            assert len(allocs) == 0
+    finally:
+        engine.dispose()
+
+
+def test_synthetic_adjustment_participates_in_fifo():
+    """BASIS_USD_CORRECTION adjustments act as synthetic purchase lots."""
+    engine, sf = _session_factory()
+    svc = HostedRecalculationService()
+    try:
+        with sf() as session:
+            p = _purchase("2026-01-01", "10:00:00", 50)
+            adj = _adjustment("2026-01-05", "10:00:00", 25)
+            # Full redemption — consumes all basis ($50 purchase + $25 adjustment = $75)
+            r = _redemption("2026-01-20", "12:00:00", 100, more_remaining=False)
+            session.add_all([p, adj, r])
+            session.flush()
+
+            svc.rebuild_fifo_for_pair(
+                session, workspace_id=W, user_id=U, site_id=S,
+            )
+            session.flush()
+
+            # Allocations only for real purchases (not synthetic adj-*)
+            allocs = session.query(HostedRedemptionAllocationRecord).all()
+            assert len(allocs) == 1
+            assert allocs[0].purchase_id == p.id
+            assert Decimal(allocs[0].allocated_amount) == Decimal("50")
+
+            # Realized: cost_basis = 50 + 25 = 75, payout = 100
+            realized = session.query(HostedRealizedTransactionRecord).all()
+            assert len(realized) == 1
+            assert Decimal(realized[0].cost_basis) == Decimal("75")
+            assert Decimal(realized[0].net_pl) == Decimal("25")
+    finally:
+        engine.dispose()
+
+
+# ------------------------------------------------------------------
+# Tests — iter_pairs
+# ------------------------------------------------------------------
+
+
+def test_iter_pairs_returns_distinct():
+    engine, sf = _session_factory()
+    svc = HostedRecalculationService()
+    try:
+        with sf() as session:
+            session.add(_purchase("2026-01-01", "10:00:00", 100))
+            session.add(_purchase("2026-01-02", "10:00:00", 50))
+            session.add(_redemption("2026-01-15", "12:00:00", 50))
+            session.add(_purchase(
+                "2026-01-01", "10:00:00", 25,
+                user_id="user-2", site_id="site-2",
+            ))
+            session.flush()
+
+            pairs = svc.iter_pairs(session, W)
+    finally:
+        engine.dispose()
+
+    assert len(pairs) == 2
+    assert (U, S) in pairs
+    assert ("user-2", "site-2") in pairs
+
+
+# ------------------------------------------------------------------
+# Tests — rebuild_all
+# ------------------------------------------------------------------
+
+
+def test_rebuild_all_processes_all_pairs():
+    engine, sf = _session_factory()
+    svc = HostedRecalculationService()
+    try:
+        with sf() as session:
+            # Pair 1
+            session.add(_purchase("2026-01-01", "10:00:00", 100))
+            session.add(_redemption("2026-01-15", "12:00:00", 50, more_remaining=True))
+            # Pair 2
+            session.add(_purchase(
+                "2026-01-01", "10:00:00", 200,
+                user_id="user-2", site_id="site-2",
+            ))
+            session.add(HostedRedemptionRecord(
+                id=str(uuid4()),
+                workspace_id=W,
+                user_id="user-2",
+                site_id="site-2",
+                amount="80",
+                redemption_date="2026-01-15",
+                redemption_time="12:00:00",
+                more_remaining=True,
+                status="PENDING",
+            ))
+            session.flush()
+
+            result = svc.rebuild_all(session, workspace_id=W)
+            session.flush()
+    finally:
+        engine.dispose()
+
+    assert result.pairs_processed == 2
+    assert result.redemptions_processed == 2
+    assert result.allocations_written == 2
+
+
+# ------------------------------------------------------------------
+# Tests — rebuild_fifo_for_pair clears prior derived records
+# ------------------------------------------------------------------
+
+
+def test_rebuild_clears_previous_allocations():
+    """Running rebuild twice should produce the same result (idempotent)."""
+    engine, sf = _session_factory()
+    svc = HostedRecalculationService()
+    try:
+        with sf() as session:
+            p = _purchase("2026-01-01", "10:00:00", 100)
+            r = _redemption("2026-01-15", "12:00:00", 60, more_remaining=True)
+            session.add_all([p, r])
+            session.flush()
+
+            svc.rebuild_fifo_for_pair(session, workspace_id=W, user_id=U, site_id=S)
+            session.flush()
+
+            # Run again
+            svc.rebuild_fifo_for_pair(session, workspace_id=W, user_id=U, site_id=S)
+            session.flush()
+
+            allocs = session.query(HostedRedemptionAllocationRecord).all()
+            assert len(allocs) == 1  # Not duplicated
+
+            realized = session.query(HostedRealizedTransactionRecord).all()
+            assert len(realized) == 1  # Not duplicated
+    finally:
+        engine.dispose()
+
+
+# ------------------------------------------------------------------
+# Tests — scoped rebuild (from boundary)
+# ------------------------------------------------------------------
+
+
+def test_scoped_rebuild_from_boundary():
+    """Scoped rebuild only re-processes redemptions at or after the boundary."""
+    engine, sf = _session_factory()
+    svc = HostedRecalculationService()
+    try:
+        with sf() as session:
+            p1 = _purchase("2026-01-01", "10:00:00", 100)
+            p2 = _purchase("2026-01-02", "10:00:00", 50)
+            # r1 is before the boundary — its allocations should be preserved
+            r1 = _redemption("2026-01-10", "08:00:00", 40, more_remaining=True)
+            # r2 is at/after the boundary — will be re-processed
+            r2 = _redemption("2026-01-20", "12:00:00", 80, more_remaining=True)
+            session.add_all([p1, p2, r1, r2])
+            session.flush()
+
+            # First: full rebuild so prior allocations exist
+            svc.rebuild_fifo_for_pair(session, workspace_id=W, user_id=U, site_id=S)
+            session.flush()
+
+            # Now scoped rebuild from boundary
+            result = svc.rebuild_fifo_for_pair_from(
+                session,
+                workspace_id=W, user_id=U, site_id=S,
+                from_date="2026-01-15",
+                from_time="00:00:00",
+            )
+            session.flush()
+
+            # r1 allocations should still exist
+            r1_allocs = (
+                session.query(HostedRedemptionAllocationRecord)
+                .filter(HostedRedemptionAllocationRecord.redemption_id == r1.id)
+                .all()
+            )
+            assert len(r1_allocs) == 1
+            assert Decimal(r1_allocs[0].allocated_amount) == Decimal("40")
+
+            # r2 allocations should be rebuilt
+            r2_allocs = (
+                session.query(HostedRedemptionAllocationRecord)
+                .filter(HostedRedemptionAllocationRecord.redemption_id == r2.id)
+                .all()
+            )
+            assert len(r2_allocs) >= 1
+            r2_total = sum(Decimal(a.allocated_amount) for a in r2_allocs)
+            assert r2_total == Decimal("80")
+
+            assert result.redemptions_processed == 1  # Only r2
+    finally:
+        engine.dispose()
+
+
+# ------------------------------------------------------------------
+# Tests — failure injection / invariants
+# ------------------------------------------------------------------
+
+
+def test_empty_workspace_returns_zero_result():
+    """Rebuilding with no data should not error."""
+    engine, sf = _session_factory()
+    svc = HostedRecalculationService()
+    try:
+        with sf() as session:
+            result = svc.rebuild_fifo_for_pair(
+                session, workspace_id=W, user_id=U, site_id=S,
+            )
+            session.flush()
+    finally:
+        engine.dispose()
+
+    assert result.pairs_processed == 1
+    assert result.redemptions_processed == 0
+    assert result.allocations_written == 0
+
+
+def test_only_purchases_no_allocations():
+    """Purchases with no redemptions → no allocations, remaining unchanged."""
+    engine, sf = _session_factory()
+    svc = HostedRecalculationService()
+    try:
+        with sf() as session:
+            p = _purchase("2026-01-01", "10:00:00", 100)
+            session.add(p)
+            session.flush()
+
+            svc.rebuild_fifo_for_pair(session, workspace_id=W, user_id=U, site_id=S)
+            session.flush()
+
+            assert Decimal(session.get(HostedPurchaseRecord, p.id).remaining_amount) == Decimal("100")
+            assert session.query(HostedRedemptionAllocationRecord).count() == 0
+    finally:
+        engine.dispose()

--- a/tests/services/hosted/test_hosted_timestamp_service.py
+++ b/tests/services/hosted/test_hosted_timestamp_service.py
@@ -1,0 +1,323 @@
+"""Tests for HostedTimestampService — timestamp uniqueness enforcement."""
+
+from uuid import uuid4
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from services.hosted.persistence import (
+    HostedBase,
+    HostedPurchaseRecord,
+    HostedRedemptionRecord,
+    HostedGameSessionRecord,
+)
+from services.hosted.hosted_timestamp_service import HostedTimestampService
+
+
+# ------------------------------------------------------------------
+# Helpers
+# ------------------------------------------------------------------
+
+W = "workspace-1"
+U = "user-1"
+S = "site-1"
+
+
+def _session_factory():
+    engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+    HostedBase.metadata.create_all(engine)
+    return engine, sessionmaker(bind=engine, expire_on_commit=False)
+
+
+def _make_purchase(date: str, time: str, **kw):
+    defaults = dict(
+        id=str(uuid4()),
+        workspace_id=W,
+        user_id=U,
+        site_id=S,
+        amount="100.00",
+        remaining_amount="100.00",
+        purchase_date=date,
+        purchase_time=time,
+    )
+    defaults.update(kw)
+    return HostedPurchaseRecord(**defaults)
+
+
+def _make_redemption(date: str, time: str, **kw):
+    defaults = dict(
+        id=str(uuid4()),
+        workspace_id=W,
+        user_id=U,
+        site_id=S,
+        amount="50.00",
+        redemption_date=date,
+        redemption_time=time,
+    )
+    defaults.update(kw)
+    return HostedRedemptionRecord(**defaults)
+
+
+def _make_session(date: str, time: str, *, end_date=None, end_time=None, status="Active", **kw):
+    defaults = dict(
+        id=str(uuid4()),
+        workspace_id=W,
+        user_id=U,
+        site_id=S,
+        session_date=date,
+        session_time=time,
+        end_date=end_date,
+        end_time=end_time,
+        status=status,
+    )
+    defaults.update(kw)
+    return HostedGameSessionRecord(**defaults)
+
+
+# ------------------------------------------------------------------
+# Tests — happy path
+# ------------------------------------------------------------------
+
+
+def test_no_conflict_returns_unchanged():
+    engine, sf = _session_factory()
+    svc = HostedTimestampService()
+    try:
+        with sf() as session:
+            date, time, adjusted = svc.ensure_unique_timestamp(
+                session,
+                workspace_id=W, user_id=U, site_id=S,
+                date_str="2026-01-15", time_str="14:30:00",
+            )
+    finally:
+        engine.dispose()
+
+    assert date == "2026-01-15"
+    assert time == "14:30:00"
+    assert adjusted is False
+
+
+def test_conflict_with_purchase_auto_increments():
+    engine, sf = _session_factory()
+    svc = HostedTimestampService()
+    try:
+        with sf() as session:
+            session.add(_make_purchase("2026-01-15", "14:30:00"))
+            session.flush()
+
+            date, time, adjusted = svc.ensure_unique_timestamp(
+                session,
+                workspace_id=W, user_id=U, site_id=S,
+                date_str="2026-01-15", time_str="14:30:00",
+                event_type="purchase",
+            )
+    finally:
+        engine.dispose()
+
+    assert date == "2026-01-15"
+    assert time == "14:30:01"
+    assert adjusted is True
+
+
+def test_conflict_with_redemption_auto_increments():
+    engine, sf = _session_factory()
+    svc = HostedTimestampService()
+    try:
+        with sf() as session:
+            session.add(_make_redemption("2026-01-15", "10:00:00"))
+            session.flush()
+
+            date, time, adjusted = svc.ensure_unique_timestamp(
+                session,
+                workspace_id=W, user_id=U, site_id=S,
+                date_str="2026-01-15", time_str="10:00:00",
+                event_type="purchase",
+            )
+    finally:
+        engine.dispose()
+
+    assert time == "10:00:01"
+    assert adjusted is True
+
+
+def test_conflict_with_session_start_auto_increments():
+    engine, sf = _session_factory()
+    svc = HostedTimestampService()
+    try:
+        with sf() as session:
+            session.add(_make_session("2026-01-15", "09:00:00"))
+            session.flush()
+
+            date, time, adjusted = svc.ensure_unique_timestamp(
+                session,
+                workspace_id=W, user_id=U, site_id=S,
+                date_str="2026-01-15", time_str="09:00:00",
+                event_type="purchase",
+            )
+    finally:
+        engine.dispose()
+
+    assert time == "09:00:01"
+    assert adjusted is True
+
+
+def test_conflict_with_closed_session_end_auto_increments():
+    engine, sf = _session_factory()
+    svc = HostedTimestampService()
+    try:
+        with sf() as session:
+            session.add(_make_session(
+                "2026-01-15", "08:00:00",
+                end_date="2026-01-15", end_time="10:00:00",
+                status="Closed",
+            ))
+            session.flush()
+
+            date, time, adjusted = svc.ensure_unique_timestamp(
+                session,
+                workspace_id=W, user_id=U, site_id=S,
+                date_str="2026-01-15", time_str="10:00:00",
+                event_type="session_end",
+            )
+    finally:
+        engine.dispose()
+
+    assert time == "10:00:01"
+    assert adjusted is True
+
+
+# ------------------------------------------------------------------
+# Tests — edge cases
+# ------------------------------------------------------------------
+
+
+def test_exclude_id_skips_own_record():
+    """When editing an existing purchase, its own timestamp should not conflict."""
+    engine, sf = _session_factory()
+    svc = HostedTimestampService()
+    own_id = str(uuid4())
+    try:
+        with sf() as session:
+            session.add(_make_purchase("2026-01-15", "14:30:00", id=own_id))
+            session.flush()
+
+            date, time, adjusted = svc.ensure_unique_timestamp(
+                session,
+                workspace_id=W, user_id=U, site_id=S,
+                date_str="2026-01-15", time_str="14:30:00",
+                exclude_id=own_id,
+                event_type="purchase",
+            )
+    finally:
+        engine.dispose()
+
+    assert time == "14:30:00"
+    assert adjusted is False
+
+
+def test_cross_event_conflict():
+    """A purchase blocks a new session from the same timestamp."""
+    engine, sf = _session_factory()
+    svc = HostedTimestampService()
+    try:
+        with sf() as session:
+            session.add(_make_purchase("2026-03-01", "12:00:00"))
+            session.flush()
+
+            date, time, adjusted = svc.ensure_unique_timestamp(
+                session,
+                workspace_id=W, user_id=U, site_id=S,
+                date_str="2026-03-01", time_str="12:00:00",
+                event_type="session_start",
+            )
+    finally:
+        engine.dispose()
+
+    assert time == "12:00:01"
+    assert adjusted is True
+
+
+def test_multiple_conflicts_skip_ahead():
+    """When several consecutive seconds are occupied, find the first free slot."""
+    engine, sf = _session_factory()
+    svc = HostedTimestampService()
+    try:
+        with sf() as session:
+            session.add(_make_purchase("2026-02-01", "10:00:00"))
+            session.add(_make_redemption("2026-02-01", "10:00:01"))
+            session.add(_make_session("2026-02-01", "10:00:02"))
+            session.flush()
+
+            date, time, adjusted = svc.ensure_unique_timestamp(
+                session,
+                workspace_id=W, user_id=U, site_id=S,
+                date_str="2026-02-01", time_str="10:00:00",
+            )
+    finally:
+        engine.dispose()
+
+    assert time == "10:00:03"
+    assert adjusted is True
+
+
+def test_time_normalization_hhmm():
+    """Short time '14:30' is normalized to '14:30:00'."""
+    engine, sf = _session_factory()
+    svc = HostedTimestampService()
+    try:
+        with sf() as session:
+            date, time, adjusted = svc.ensure_unique_timestamp(
+                session,
+                workspace_id=W, user_id=U, site_id=S,
+                date_str="2026-01-15", time_str="14:30",
+            )
+    finally:
+        engine.dispose()
+
+    assert time == "14:30:00"
+    assert adjusted is False
+
+
+def test_different_scope_no_conflict():
+    """Purchases on a different site don't cause conflicts."""
+    engine, sf = _session_factory()
+    svc = HostedTimestampService()
+    try:
+        with sf() as session:
+            session.add(_make_purchase("2026-01-15", "14:30:00", site_id="other-site"))
+            session.flush()
+
+            date, time, adjusted = svc.ensure_unique_timestamp(
+                session,
+                workspace_id=W, user_id=U, site_id=S,
+                date_str="2026-01-15", time_str="14:30:00",
+            )
+    finally:
+        engine.dispose()
+
+    assert time == "14:30:00"
+    assert adjusted is False
+
+
+def test_deleted_records_ignored():
+    """Soft-deleted purchases should not be treated as conflicts."""
+    engine, sf = _session_factory()
+    svc = HostedTimestampService()
+    try:
+        with sf() as session:
+            session.add(_make_purchase(
+                "2026-01-15", "14:30:00",
+                deleted_at="2026-01-16T00:00:00",
+            ))
+            session.flush()
+
+            date, time, adjusted = svc.ensure_unique_timestamp(
+                session,
+                workspace_id=W, user_id=U, site_id=S,
+                date_str="2026-01-15", time_str="14:30:00",
+            )
+    finally:
+        engine.dispose()
+
+    assert time == "14:30:00"
+    assert adjusted is False


### PR DESCRIPTION
# Phase 2: Accounting Engine Core

Closes #258

## Summary

Ports the four core accounting services from the desktop layer to the hosted (SQLAlchemy/web) layer:

| Service | Desktop Source | Hosted File | Tests |
|---------|---------------|-------------|-------|
| TimestampService | `services/timestamp_service.py` | `services/hosted/hosted_timestamp_service.py` | 11 |
| FIFOService | `services/fifo_service.py` | `services/hosted/hosted_fifo_service.py` | 11 |
| RecalculationService | `services/recalculation_service.py` | `services/hosted/hosted_recalculation_service.py` | 15 |
| EventLinkService | `services/game_session_event_link_service.py` | `services/hosted/hosted_event_link_service.py` | 16 |

**53 tests total**, all passing.

## Key Adaptations (Desktop -> Hosted)

- SQLAlchemy ORM queries instead of raw SQL / DatabaseManager
- String UUIDs instead of integer IDs
- Monetary values as `Decimal` in Python, `String(32)` in DB
- No timezone conversion layer (hosted stores dates as-is from the API)
- Synthetic adjustments (`adj-{id}`) participate in FIFO but are not written to allocations table
- Event link boundary rule (Issue #90): start INCLUSIVE (>=), end EXCLUSIVE (<)

## Test Matrix

- **Happy paths**: Single/multi-lot FIFO, full/partial redemptions, basic timestamp resolution, BEFORE/DURING/AFTER classification
- **Edge cases**: Deleted records ignored, canceled redemptions excluded, free SC skips FIFO, close-balance (Net Loss) parsing, consumed purchases skipped, future purchases excluded, cross-event timestamp conflicts, time normalization, different-scope no conflict
- **Failure injection**: Over-allocation raises ValueError, reverse-over-original raises ValueError
- **Invariants**: Rebuild idempotency (running twice produces same results, no duplicates), empty workspace returns zero result, purchases-only leaves remaining unchanged

## Pitfalls / Follow-ups

- **API endpoints not yet wired**: These services exist but are not yet called from any API route. Phase 3 will integrate them into the purchase/redemption/session CRUD flows.
- **String-based decimal comparisons**: `_get_available_purchases` uses string comparison `remaining_amount > "0"` which works for well-formatted decimals but could break with non-canonical formatting. The services normalize to `str(Decimal(...))` on write which mitigates this.
- **Performance at scale**: `rebuild_all` iterates all pairs sequentially. For large workspaces, consider batching or async processing.
- **Scoped rebuild boundary precision**: `rebuild_fifo_for_pair_from` primes remaining from prior allocations, which requires those prior allocations to be correct. If prior data is corrupt, a full rebuild is needed.

## Verification

```
pytest -q --no-cov tests/services/hosted/test_hosted_timestamp_service.py \
  tests/services/hosted/test_hosted_fifo_service.py \
  tests/services/hosted/test_hosted_recalculation_service.py \
  tests/services/hosted/test_hosted_event_link_service.py
# 53 passed

pytest -q --no-cov  # Full suite: 1248 passed, 1 skipped, 1 pre-existing failure
```
