### PR TITLE
Issue #267: Game Sessions complete web frontend + expected balances backend

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -1796,6 +1796,50 @@ def workspace_game_sessions_create(
     return game_session.as_dict() if hasattr(game_session, "as_dict") else game_session
 
 
+@app.get("/v1/workspace/game-sessions/expected-balances")
+def workspace_game_sessions_expected_balances(
+    user_id: str = Query(...),
+    site_id: str = Query(...),
+    session_date: str = Query(...),
+    session_time: str = Query("00:00:00"),
+    session: AuthenticatedSession = Depends(get_authenticated_session),
+    service: HostedWorkspaceGameSessionService = Depends(
+        get_hosted_workspace_game_session_service
+    ),
+) -> dict[str, str]:
+    try:
+        return service.compute_expected_balances(
+            supabase_user_id=session.user_id,
+            user_id=user_id,
+            site_id=site_id,
+            session_date=session_date,
+            session_time=session_time,
+        )
+    except LookupError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+
+
+@app.post("/v1/workspace/game-sessions/batch-delete")
+def workspace_game_sessions_batch_delete(
+    payload: HostedWorkspaceGameSessionBatchDeleteRequest = Body(...),
+    session: AuthenticatedSession = Depends(get_authenticated_session),
+    service: HostedWorkspaceGameSessionService = Depends(
+        get_hosted_workspace_game_session_service
+    ),
+) -> dict[str, int]:
+    try:
+        deleted_count = service.delete_game_sessions(
+            supabase_user_id=session.user_id,
+            game_session_ids=payload.game_session_ids,
+        )
+    except LookupError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+    return {"deleted_count": deleted_count}
+
+
 @app.patch("/v1/workspace/game-sessions/{game_session_id}")
 def workspace_game_sessions_update(
     game_session_id: str = Path(...),
@@ -1860,25 +1904,21 @@ def workspace_game_sessions_delete(
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
-@app.post("/v1/workspace/game-sessions/batch-delete")
-def workspace_game_sessions_batch_delete(
-    payload: HostedWorkspaceGameSessionBatchDeleteRequest = Body(...),
+@app.get("/v1/workspace/game-sessions/{game_session_id}/deletion-impact")
+def workspace_game_sessions_deletion_impact(
+    game_session_id: str = Path(...),
     session: AuthenticatedSession = Depends(get_authenticated_session),
     service: HostedWorkspaceGameSessionService = Depends(
         get_hosted_workspace_game_session_service
     ),
-) -> dict[str, int]:
+) -> dict[str, object]:
     try:
-        deleted_count = service.delete_game_sessions(
+        return service.get_deletion_impact(
             supabase_user_id=session.user_id,
-            game_session_ids=payload.game_session_ids,
+            game_session_id=game_session_id,
         )
     except LookupError as exc:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
-    except ValueError as exc:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
-
-    return {"deleted_count": deleted_count}
 
 
 @app.get("/v1/workspace/import-plan")

--- a/docs/archive/2026-04-09-followup-adjustments.md
+++ b/docs/archive/2026-04-09-followup-adjustments.md
@@ -1,0 +1,47 @@
+## Problem / motivation
+
+The `compute_expected_balances` endpoint (Issue #267) currently uses Priority 2 (last closed session) and Priority 3 (zero baseline) as anchors. Priority 1 — balance checkpoint anchors from the Adjustments system — is skipped because Adjustments CRUD is not yet ported to web. Additionally, the desktop "Adjusted" badge on game sessions (shows when adjustments fall within a session's basis period) requires adjustment timeline queries.
+
+Adjustments are Phase 5 in the web port plan. The Supabase schema already has `HostedAccountAdjustmentRecord` in `services/hosted/persistence.py`, and `HostedRecalculationService` reads adjustments during recalc. What's missing is the CRUD layer (repo, service, API endpoints) and the frontend tab.
+
+## Proposed solution
+
+Port the Adjustments system to web:
+1. **Repository**: `HostedAdjustmentRepository` — CRUD for adjustments (balance checkpoints, basis corrections)
+2. **Service**: `HostedWorkspaceAdjustmentService` — business logic, validation
+3. **API endpoints**: GET list, POST create, PATCH update, DELETE
+4. **Frontend tab**: AdjustmentsTab in the Tools area (Phase 5)
+5. **Integrate checkpoint anchors**: Update `compute_expected_balances` to query `get_latest_checkpoint_before()` as Priority 1
+6. **Adjusted badge**: Add adjustment timeline query for game sessions table
+
+Desktop reference: `services/adjustment_service.py`, `repositories/adjustment_repository.py`, `models/adjustment.py`
+
+## Scope
+
+In-scope:
+- Hosted adjustment repository + service + API
+- Adjustments frontend tab (Tools section)
+- Checkpoint anchor integration in `compute_expected_balances`
+- Adjusted badge on game sessions
+
+Out-of-scope:
+- Daily session sync (separate issue)
+- Tax withholding recalc on adjustment (separate issue)
+
+## Acceptance criteria
+
+- Adjustments CRUD works via web UI
+- Balance checkpoints serve as Priority 1 anchor in expected balance computation
+- Adjusted badge appears on game sessions when adjustments fall in the basis period
+- Backend tests for adjustment CRUD + checkpoint anchor integration
+
+## Test plan
+
+Automated tests:
+- Adjustment CRUD repository + service tests
+- `compute_expected_balances` with checkpoint anchor vs without
+- Adjusted badge timeline logic
+
+Manual verification:
+- Create/edit/delete adjustments in web UI
+- Verify expected balances use checkpoint when available

--- a/docs/archive/2026-04-09-followup-daily-sessions-tax.md
+++ b/docs/archive/2026-04-09-followup-daily-sessions-tax.md
@@ -1,0 +1,47 @@
+## Problem / motivation
+
+The desktop app has a Daily Sessions system that aggregates game sessions by date for tax reporting. After every session close/edit/delete, the desktop calls `_sync_daily_sessions_for_pair()` and `_sync_tax_for_affected_dates()` to keep daily aggregates and tax withholding calculations up to date. None of this is ported to web yet.
+
+This is Phase 5+ in the web port plan and is the foundation for tax reporting.
+
+## Proposed solution
+
+Port the daily session sync + tax withholding system to web:
+1. **Daily Sessions service**: Aggregate game sessions by (user, site, date) into daily summaries (total P/L, basis, etc.)
+2. **Tax withholding service**: Compute running YTD P/L and determine when withholding thresholds are hit
+3. **Integration hooks**: Call sync after session create/update/delete in `workspace_game_session_service.py`
+4. **API endpoints**: GET daily sessions list, GET tax summary
+5. **Frontend**: Daily Sessions tab / Tax withholding display columns in game sessions table
+
+Desktop reference: `services/game_session_service.py` (`_sync_daily_sessions_for_pair`, `_sync_tax_for_affected_dates`)
+
+## Scope
+
+In-scope:
+- Daily session aggregation service + repo
+- Tax withholding calculation service
+- Integration with game session mutations
+- API endpoints for daily sessions + tax data
+- Frontend display (daily sessions tab or section, tax columns in game sessions)
+
+Out-of-scope:
+- Tax filing / export (separate concern)
+- W-2G generation
+
+## Acceptance criteria
+
+- Daily session aggregates are maintained automatically when game sessions change
+- Tax withholding thresholds are computed correctly per YTD P/L
+- Tax withholding column appears in game sessions table where applicable
+- Daily sessions are viewable in the web UI
+
+## Test plan
+
+Automated tests:
+- Daily session sync after session create/close/delete
+- Tax withholding threshold computation
+- Edge cases: multiple sessions same day, session deletion mid-year
+
+Manual verification:
+- Close several sessions across dates, verify daily aggregates update
+- Verify tax withholding appears when threshold is exceeded

--- a/docs/archive/2026-04-09-followup-low-balance-prompt.md
+++ b/docs/archive/2026-04-09-followup-low-balance-prompt.md
@@ -1,0 +1,45 @@
+## Problem / motivation
+
+After closing a game session in the desktop app, if the ending balance is below a configurable threshold and the user is NOT doing "End & Start New", the app prompts: "Close the position now?" This shows the impact (dormant SC, basis loss, realized P/L) and if confirmed calls `close_unrealized_position()`.
+
+This feature prevents users from forgetting to close out small remaining positions that would otherwise sit as unrealized indefinitely.
+
+## Proposed solution
+
+Port the low-balance close prompt to web:
+1. **Backend**: `get_low_balance_close_prompt_data()` service method + API endpoint — returns threshold check result, dormant SC amount, basis impact, and P/L impact
+2. **Backend**: `close_unrealized_position()` service method + API endpoint — executes the position close (marks purchases dormant, records basis loss)
+3. **Frontend**: After closing a session via End Session form, if prompt data indicates low balance, show a confirmation dialog with impact details and "Close Position" / "Keep Open" buttons
+
+Desktop reference: `app_facade.py` (`get_low_balance_close_prompt_data`, `close_unrealized_position`)
+
+## Scope
+
+In-scope:
+- Low-balance threshold check service method + endpoint
+- Position close execution method + endpoint
+- Post-close prompt dialog in frontend
+- Tests for threshold check + position close logic
+
+Out-of-scope:
+- Configurable threshold settings UI (use default for now)
+- Unrealized position reporting/dashboard
+
+## Acceptance criteria
+
+- After closing a session with low ending balance, user sees a prompt with impact details
+- Confirming the prompt closes the unrealized position (purchases marked dormant, basis recorded)
+- Declining the prompt leaves everything unchanged
+- Prompt does NOT appear when ending balance is above threshold
+- Prompt does NOT appear during "End & Start New" flow
+
+## Test plan
+
+Automated tests:
+- Low-balance check returns prompt data when below threshold
+- Low-balance check returns empty when above threshold
+- Position close marks correct purchases dormant
+- Position close records correct basis loss
+
+Manual verification:
+- Close session with low balance, verify prompt appears and executes correctly

--- a/docs/archive/2026-04-09-followup-session-side-effects.md
+++ b/docs/archive/2026-04-09-followup-session-side-effects.md
@@ -1,0 +1,46 @@
+## Problem / motivation
+
+The desktop game session service performs two accounting side effects that the web service does not yet implement:
+
+1. **Dormant purchase reactivation on session creation**: When a new session is created, the desktop calls `UPDATE purchases SET status='active' WHERE status='dormant' AND user_id=? AND site_id=?` to reactivate purchases that were marked dormant (e.g., after a position close).
+
+2. **PENDING_CANCEL redemption processing on session close**: When a session is closed, the desktop calls `redemption_service.process_pending_cancels()` to finalize any redemptions in PENDING_CANCEL state.
+
+These are backend-only changes to `workspace_game_session_service.py`.
+
+## Proposed solution
+
+Add both side effects to the hosted game session service:
+1. In `create_game_session`: after creating the session, query for dormant purchases matching (workspace_id, user_id, site_id) and update their status to active.
+2. In `update_game_session`: when status changes to Closed, call the redemption service to process pending cancels for that user+site.
+
+Desktop reference: `services/game_session_service.py` — `create_session()` and `update_session()`
+
+## Scope
+
+In-scope:
+- Dormant purchase reactivation in `create_game_session`
+- PENDING_CANCEL processing in `update_game_session` (on close)
+- Tests for both side effects
+
+Out-of-scope:
+- UI changes (these are invisible backend side effects)
+- Changes to purchase or redemption services themselves
+
+## Acceptance criteria
+
+- Creating a game session reactivates dormant purchases for that user+site
+- Closing a game session processes PENDING_CANCEL redemptions
+- Tests verify both side effects fire at the correct time
+- Tests verify side effects don't fire on non-triggering operations (e.g., edit without status change)
+
+## Test plan
+
+Automated tests:
+- Create session with dormant purchases present -> purchases become active
+- Create session with no dormant purchases -> no error
+- Close session with PENDING_CANCEL redemptions -> redemptions finalized
+- Edit session without closing -> no side effects
+
+Manual verification:
+- None required (backend-only)

--- a/docs/archive/2026-04-09-followup-spreadsheet-ux.md
+++ b/docs/archive/2026-04-09-followup-spreadsheet-ux.md
@@ -1,0 +1,45 @@
+## Problem / motivation
+
+The desktop app has spreadsheet-like UX features on all data tables: Cmd+C to copy selected cells as TSV, "Copy With Headers" context menu, a stats bar showing sum/count/average of selected numeric cells, and extended multi-cell selection. These features are shared across all tabs (game sessions, purchases, redemptions, etc.) via `SpreadsheetUX` and `TableHeaderFilter` base classes.
+
+The web app currently has no equivalent. This should be built as a shared component usable by all entity tables.
+
+## Proposed solution
+
+Build shared spreadsheet-like UX features for the web `EntityTable` component:
+1. **Cell selection**: Click + drag / Shift+click to select table cells (not just rows)
+2. **Copy**: Cmd/Ctrl+C copies selected cells as TSV; "Copy With Headers" option in context menu
+3. **Stats bar**: Footer showing sum, count, and average of selected numeric cells
+4. **Column header filters**: Click column header to filter/sort by that column's values
+
+This should integrate with the existing `EntityTable` component as opt-in features.
+
+## Scope
+
+In-scope:
+- Cell-level selection in EntityTable
+- Clipboard copy (TSV format) with keyboard shortcut
+- Copy With Headers context menu option
+- Stats bar (sum/count/average) for numeric selections
+- Column header click-to-filter/sort
+
+Out-of-scope:
+- Cell editing (this is read-only spreadsheet UX)
+- Excel/CSV export (separate feature)
+- Pivot tables or advanced analytics
+
+## Acceptance criteria
+
+- Users can select individual cells or ranges in any EntityTable
+- Cmd/Ctrl+C copies selected cells as tab-separated values
+- Right-click shows "Copy With Headers" option
+- Stats bar appears when numeric cells are selected, showing sum/count/average
+- Column headers support click-to-filter and sort
+- Features work on all entity tables (purchases, redemptions, game sessions)
+
+## Test plan
+
+Manual verification:
+- Select cells in game sessions table, copy, paste into spreadsheet
+- Verify stats bar shows correct sum/count/average
+- Verify column header filtering narrows displayed rows

--- a/docs/archive/2026-04-09-followup-travel-mode.md
+++ b/docs/archive/2026-04-09-followup-travel-mode.md
@@ -1,0 +1,46 @@
+## Problem / motivation
+
+The desktop app supports "travel mode" — when a user enters session times from a timezone different from their accounting timezone, the app shows a globe icon, converts times to UTC correctly, and warns if end time < start time after UTC conversion. The web app stores timezone fields in the data model but has no UI for timezone selection, conversion display, or travel mode indicators.
+
+This is a cross-cutting concern that affects game sessions, purchases, and redemptions.
+
+## Proposed solution
+
+Add timezone awareness to the web frontend:
+1. **Timezone selector**: Add timezone dropdown to session/purchase/redemption forms (default to workspace accounting TZ)
+2. **Travel mode indicator**: Show globe icon on table rows where entry timezone differs from accounting timezone
+3. **UTC conversion validation**: Block saves where end UTC < start UTC with clear error message
+4. **Multi-day indicator**: Show `(+Nd)` badge on sessions spanning multiple calendar days
+5. **Timezone update prompt**: When editing an entry whose original TZ differs from current selection, prompt for which timestamps to update
+
+## Scope
+
+In-scope:
+- Timezone dropdown in session create/edit forms
+- Travel mode badge in game sessions table
+- UTC validation on session save
+- Multi-day session indicator
+- Timezone update prompt on edit
+
+Out-of-scope:
+- Workspace-level timezone settings management
+- Automatic timezone detection from browser
+- Timezone display in purchases/redemptions (can follow same pattern later)
+
+## Acceptance criteria
+
+- User can select a timezone when creating/editing sessions
+- Travel mode globe appears on sessions entered in non-accounting timezone
+- UTC conversion prevents invalid end-before-start scenarios
+- Multi-day badge shows for sessions spanning >1 calendar day
+- Editing a travel-mode session prompts about timezone updates
+
+## Test plan
+
+Automated tests:
+- UTC conversion validation (end < start detection)
+- Travel mode detection (entry TZ != accounting TZ)
+
+Manual verification:
+- Create session in different timezone, verify globe icon
+- Try to save session where end UTC < start UTC, verify error

--- a/docs/archive/2026-04-09-followup-view-session.md
+++ b/docs/archive/2026-04-09-followup-view-session.md
@@ -1,0 +1,40 @@
+## Problem / motivation
+
+The desktop app has a detailed "View Session" dialog with three tabs: Details (full session info, game stats, balance grid, P/L, tax withholding, linked events), Related (linked purchases and redemptions with clickable navigation), and Adjustments (period adjustments and boundary checkpoints). The web app currently has no read-only detail view for game sessions.
+
+## Proposed solution
+
+Build a View Session detail dialog/panel for the web app:
+1. **Details tab**: Session metadata, game stats (type/name/wager/RTP with Expected/Actual/Session), balance grid (Start/End/Delta for Total/Redeemable/Basis), Net P/L, notes
+2. **Related tab**: Linked purchases and redemptions that fall within the session period, with click-to-navigate
+3. **Adjustments tab**: Period adjustments and boundary checkpoints (depends on Adjustments CRUD being ported)
+
+Action buttons: End Session (if active), Delete, Edit, Close
+
+## Scope
+
+In-scope:
+- View Session dialog/panel with Details tab
+- Related tab showing linked purchases/redemptions
+- Action buttons (End, Edit, Delete)
+
+Out-of-scope:
+- Adjustments tab (depends on Adjustments CRUD issue)
+- "View in Daily Sessions" navigation (depends on Daily Sessions tab)
+- Tax withholding display (depends on tax system)
+
+## Acceptance criteria
+
+- Clicking a game session row opens a detail view
+- Details tab shows all session fields, balance grid, and P/L
+- Related tab shows purchases and redemptions linked to this session
+- Action buttons (End/Edit/Delete) work from the detail view
+- Dialog matches existing modal CSS patterns
+
+## Test plan
+
+Manual verification:
+- Open detail view for active and closed sessions
+- Verify all fields display correctly
+- Verify Related tab shows correct linked events
+- Verify action buttons work (End, Edit, Delete)

--- a/docs/archive/2026-04-09-issue-266-body.md
+++ b/docs/archive/2026-04-09-issue-266-body.md
@@ -1,0 +1,92 @@
+---
+name: "Game Sessions: web frontend tab (Phase 3c)"
+about: Build the Game Sessions tab in the React web app
+labels: enhancement, feature
+---
+
+## Problem / Motivation
+
+The Game Sessions backend (repository, service, API) was shipped in PR #266 / Issue #265. There is no frontend tab yet, so users cannot create, view, edit, or delete game sessions from the web app. Game Sessions is the primary transaction entity with a two-phase lifecycle (Start then End) and is the convergence point for all accounting concepts (FIFO, event links, P/L).
+
+## Proposed Solution
+
+Build a `GameSessionsTab` component following the established `PurchasesTab` / `RedemptionsTab` pattern:
+
+1. **Table view** using `useEntityTable` hook + `EntityTable` component (paginated list from `GET /v1/workspace/game-sessions`)
+2. **Create form** (Start Session) with fields: Date, Time, User, Site, Game Type, Game, Starting Balance, Starting Redeemable, Notes
+3. **Edit/Close form** (End Session) adding: End Date, End Time, Ending Balance, Ending Redeemable, Wager Amount, Status
+4. **Delete** (single + batch) via existing `EntityTable` delete patterns
+5. **Active session guard** — the API already enforces one active per user+site; surface the error message in the UI
+
+## Scope
+
+### In-scope
+- GameSessionsTab component (list, create, edit, delete, batch-delete)
+- Start Session form (create with status=Active)
+- End Session / edit form (update, can close by setting status=Closed + end fields)
+- Column definitions matching desktop parity (date, time, user, site, game, status, balances)
+- Row coloring by status (Active vs Closed) following existing Redemptions pattern
+- Tab registration in AppShell
+
+### Out-of-scope (follow-up Issues)
+- Expected balance auto-fill (`compute_expected_balances` endpoint)
+- P/L column display (computed fields exist but are not yet populated by the service)
+- "End and Start New" workflow
+- Low-balance close prompt
+- Tax withholding display
+- Travel mode / timezone handling
+- Game RTP sync on close
+- Daily session sync
+
+## UX / Fields
+
+### Start Session Form
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| Date | date picker | Yes | |
+| Time | time input | No | defaults to 00:00:00 |
+| User | dropdown (users) | Yes | |
+| Site | dropdown (sites) | Yes | |
+| Game Type | dropdown (game_types) | No | |
+| Game | dropdown (games) | No | filtered by game type if selected |
+| Starting Total SC | decimal input | No | defaults to 0.00 |
+| Starting Redeemable SC | decimal input | No | defaults to 0.00 |
+| Notes | textarea | No | |
+
+### End / Edit Session Form
+All start fields plus:
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| End Date | date picker | No | required when closing |
+| End Time | time input | No | required when closing |
+| Ending Total SC | decimal input | No | defaults to 0.00 |
+| Ending Redeemable SC | decimal input | No | defaults to 0.00 |
+| Wager Amount | decimal input | No | defaults to 0.00 |
+| Status | dropdown | Yes | Active or Closed |
+
+## Implementation Notes
+
+- **API endpoints already exist**: GET, POST, PATCH, DELETE, batch-delete at `/v1/workspace/game-sessions`
+- **Pattern reference**: Follow `PurchasesTab` and `RedemptionsTab` structure exactly
+- **`useEntityTable` config**: set `getItemLabel` for delete confirmation (e.g., `session_date -- user_name`)
+- **Column widths**: Follow existing N-1 pattern from Purchases/Redemptions
+- Match existing modal/dialog CSS classes (`modal-backdrop`, `modal-card`, `confirmation-modal`)
+- Game dropdown should filter by game_type_id when a game type is selected (desktop parity)
+
+## Acceptance Criteria
+
+- [ ] GameSessionsTab appears in the web app navigation
+- [ ] Table displays game sessions with columns: Date, Time, User, Site, Game, Status, Starting Balance, Ending Balance, Notes
+- [ ] Create form (Start Session) produces an Active session via POST
+- [ ] Edit form allows updating all fields and closing a session (status change to Closed)
+- [ ] Active session guard error is displayed when user tries to create a second active session for the same user+site
+- [ ] Single delete and batch delete work correctly (soft-delete)
+- [ ] Row coloring differentiates Active vs Closed sessions
+- [ ] All UI elements use existing CSS classes and patterns (no new class names)
+
+## Test Plan
+
+- Manual: Create, edit, close, delete game sessions through the web UI
+- Manual: Verify active session guard surfaces an error on duplicate active
+- Manual: Verify batch delete works
+- Verify no console errors or broken API calls

--- a/docs/archive/2026-04-09-issue-267-body-v2.md
+++ b/docs/archive/2026-04-09-issue-267-body-v2.md
@@ -1,0 +1,161 @@
+## Problem / Motivation
+
+The Game Sessions backend (repository, service, API) was shipped in PR #266 / Issue #265. There is no frontend tab yet, so users cannot create, view, edit, or delete game sessions from the web app. Game Sessions is the primary transaction entity with a two-phase lifecycle (Start then End) and is the convergence point for all accounting concepts (FIFO, event links, P/L).
+
+The original Issue #267 scoped several core features as follow-ups, but they are essential for desktop parity and should ship together to avoid partial implementations that require rework.
+
+## Proposed Solution
+
+Build a complete `GameSessionsTab` with full desktop parity for session lifecycle management. This includes backend additions (expected balances endpoint, deletion impact endpoint) and the full frontend implementation.
+
+### Backend Additions
+
+1. **`compute_expected_balances` endpoint** — `GET /v1/workspace/game-sessions/expected-balances?user_id=&site_id=&session_date=&session_time=`
+   - Priority 1: Latest balance checkpoint before cutoff (skipped for now — adjustments not yet ported, Phase 5)
+   - Priority 2: Latest closed session ending balances for (user, site) before cutoff
+   - Priority 3: Zero baseline
+   - Then apply all purchase + redemption events (debit/credit model) between anchor and cutoff
+   - Returns `{ expected_total_sc, expected_redeemable_sc }`
+
+2. **`get_deletion_impact` endpoint** — `GET /v1/workspace/game-sessions/{id}/deletion-impact`
+   - For closed sessions: check for subsequent redemptions, warn about balance inconsistency
+   - Returns human-readable impact summary or empty string
+
+### Frontend: GameSessionsTab Component
+
+Following the established `PurchasesTab` / `RedemptionsTab` pattern:
+
+1. **Table view** using `useEntityTable` hook + `EntityTable` component (paginated list from `GET /v1/workspace/game-sessions`)
+2. **Start Session form** (create) with expected balance auto-fill
+3. **End Session form** (close) with auto-calc redeemable + real-time P/L preview
+4. **Edit form** for both Active and Closed sessions
+5. **"End & Start New" flow** — close current session, open pre-filled Start form with ending balances
+6. **Delete** (single + batch) with deletion impact warning for closed sessions
+7. **Active session guard** — surface the API error when user tries to create a second active session for the same user+site
+
+## Scope
+
+### In-scope
+
+**Backend:**
+- `compute_expected_balances` service method + API endpoint (Priority 2/3 — no checkpoint anchors yet)
+- `get_deletion_impact` service method + API endpoint
+- Auto-calc redeemable formula as a shared utility (used by frontend)
+
+**Frontend — Table:**
+- GameSessionsTab component registered in AppShell
+- Columns: Date/Time, Site, User, Game, Start SC, End SC, Start Redeem, End Redeem, Delta Redeem, Delta Basis, Net P/L, Status, Notes
+- P/L column with green (positive) / red (negative) text coloring
+- Row differentiation for Active vs Closed sessions (Active shows "---" for ending/delta/P&L cells)
+- "Active Only" filter toggle
+
+**Frontend — Start Session Form:**
+- Fields: Date, Time, User, Site, Game Type, Game (filtered by type), Starting Total SC, Starting Redeemable SC, Notes
+- Expected balance auto-fill: calls `compute_expected_balances` when user/site/date/time change; grayed out when auto-filled; disables auto-fill per field on manual edit
+- Balance check display: shows match/mismatch vs expected with delta
+- Inline validation (required fields, numeric fields, redeemable <= total)
+
+**Frontend — End Session Form:**
+- All start fields (read-only or editable) plus: End Date, End Time, Ending Total SC, Ending Redeemable SC, Wager Amount, Status
+- Auto-Calc Redeemable toggle: `start_redeem + min(locked_start, wager/playthrough_req) + net_delta_if_negative`, clamped to `[0, end_total]`
+- Real-time P/L preview: Delta Total, Delta Redeemable, Delta Basis, Net P/L (color-coded)
+- RTP display: Expected / Actual / Session (from wager)
+
+**Frontend — End & Start New:**
+- Button in End Session form
+- Closes current session, opens Start Session pre-filled with: same user+site, starting balances = ending balances of just-closed session, game type/game cleared
+
+**Frontend — Edit:**
+- Active sessions: same as Start Session form but pre-filled
+- Closed sessions: full start+end form with all balance fields
+
+**Frontend — Delete:**
+- Single delete + batch delete (soft-delete)
+- Deletion impact warning for closed sessions (calls `get_deletion_impact` before confirming)
+
+### Out-of-scope (genuinely separate systems — follow-up Issues)
+- Balance checkpoint anchors in expected balances (requires Adjustments CRUD — Phase 5)
+- Daily session sync / tax withholding integration (Phase 5+)
+- Low-balance close prompt / unrealized position close (Phase 5+)
+- "View in Daily Sessions" navigation (daily sessions tab not yet built)
+- Travel mode / timezone conversion UI (cross-cutting concern)
+- Dormant purchase reactivation on session creation (accounting pipeline)
+- PENDING_CANCEL redemption processing on session close (accounting pipeline)
+- Adjusted badge (requires adjustment timeline queries)
+- SpreadsheetUX features (copy, stats bar — shared component, separate issue)
+- View Session detail dialog with Related/Adjustments tabs (can be a follow-up)
+
+## UX / Fields
+
+### Start Session Form
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| Date | date picker | Yes | Today button |
+| Time | time input | No | defaults to current time; Now button |
+| User | dropdown (users) | Yes | |
+| Site | dropdown (sites) | Yes | |
+| Game Type | dropdown (game_types) | No | |
+| Game | dropdown (games) | No | filtered by game type; placeholder "Select a game type first" |
+| Starting Total SC | decimal input | No | **auto-filled** from expected balances (grayed when auto); defaults 0.00 |
+| Starting Redeemable SC | decimal input | No | **auto-filled** from expected balances (grayed when auto); defaults 0.00 |
+| Balance Check | read-only display | — | checkmark if match, warning with expected + delta if mismatch |
+| Notes | textarea | No | collapsible |
+
+### End Session Form
+All start fields (read-only for user/site/date/time) plus:
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| End Date | date picker | Yes | Today button |
+| End Time | time input | No | Now button; defaults to current time |
+| Ending Total SC | decimal input | Yes | |
+| Ending Redeemable SC | decimal input | Yes | auto-calc toggle available |
+| Wager Amount | decimal input | Cond. | required when auto-calc redeemable is on |
+| Auto-Calc Redeemable | toggle | — | computes ending redeemable from formula |
+| Status | display | — | changes to Closed on save |
+| P/L Preview | read-only | — | Delta Total, Delta Redeem, Delta Basis, Net P/L (live) |
+
+### Edit Closed Session Form
+Both start and end sections editable with all fields from Start + End forms.
+
+## Implementation Notes
+
+- **API endpoints already exist**: GET list, POST create, PATCH update, DELETE single, POST batch-delete at `/v1/workspace/game-sessions`
+- **New endpoints needed**: GET expected-balances, GET deletion-impact
+- **Pattern reference**: Follow `PurchasesTab` and `RedemptionsTab` structure exactly
+- **`useEntityTable` config**: set `getItemLabel` for delete confirmation (e.g., `session_date -- user_name`)
+- Match existing modal/dialog CSS classes (`modal-backdrop`, `modal-card`, `confirmation-modal`)
+- Game dropdown should filter by `game_type_id` when a game type is selected (desktop parity)
+- Auto-calc redeemable formula uses `site.playthrough_requirement` (default 1.0) — need sites endpoint to return this field
+- P/L computation for preview: `net_taxable_pl = ((discoverable_sc + delta_redeem) * sc_rate) - basis_consumed`
+
+## Acceptance Criteria
+
+- [ ] GameSessionsTab appears in the web app navigation
+- [ ] Table displays game sessions with all columns including P/L (green/red text)
+- [ ] Active sessions show "---" for ending/delta/P&L cells
+- [ ] "Active Only" filter toggle works
+- [ ] Start Session form auto-fills starting balances from `compute_expected_balances` endpoint
+- [ ] Auto-fill disables per-field when user manually edits
+- [ ] Balance check shows match/mismatch vs expected values
+- [ ] End Session form has auto-calc redeemable toggle with correct formula
+- [ ] End Session form shows real-time P/L preview (color-coded)
+- [ ] "End & Start New" closes session and opens pre-filled Start Session form
+- [ ] Edit Active session uses Start Session form (pre-filled)
+- [ ] Edit Closed session uses full start+end form
+- [ ] Deletion impact warning shown for closed sessions before delete confirmation
+- [ ] Active session guard error surfaces in UI on duplicate active for same user+site
+- [ ] Single delete and batch delete work correctly (soft-delete)
+- [ ] Game dropdown filters by selected game type
+- [ ] All UI elements use existing CSS classes and patterns (no new class names)
+
+## Test Plan
+
+- **Backend tests**: `compute_expected_balances` (zero baseline, after closed session, with purchases/redemptions between anchor and cutoff, floor at zero); `get_deletion_impact` (no impact, with subsequent redemptions)
+- **Manual**: Create session with auto-filled balances, verify they match previous session's ending balances
+- **Manual**: End session with auto-calc redeemable, verify formula correctness
+- **Manual**: "End & Start New" flow — verify pre-fill of starting balances
+- **Manual**: Edit active and closed sessions
+- **Manual**: Delete with impact warning, batch delete
+- **Manual**: Active session guard error display
+- **Manual**: P/L column coloring, "Active Only" filter
+- Verify no console errors or broken API calls

--- a/docs/archive/2026-04-09-pr-265-body.md
+++ b/docs/archive/2026-04-09-pr-265-body.md
@@ -1,0 +1,47 @@
+## Summary
+
+Implements the full backend stack for Game Sessions (Issue #265): DTO, repository, service, and API endpoints. This is the Phase 3c dependency layer that must exist before the Game Sessions frontend tab can be built.
+
+Closes #265
+
+## Changes
+
+### New Files
+- **`services/hosted/models.py`** — Added `HostedGameSession` dataclass DTO with validation (required user/site/date, strip/normalize)
+- **`repositories/hosted_game_session_repository.py`** — Full CRUD repository:
+  - `list_by_workspace_id` (DESC, paginated), `count_by_workspace_id`
+  - `list_by_workspace_user_and_site` (ASC chronological)
+  - `get_by_id_and_workspace_id`, `get_active_session` (with exclude_id)
+  - `create`, `update`, `delete` (soft-delete via deleted_at), `delete_many`
+  - JOINs on users, sites, games (outerjoin), game_types (outerjoin)
+- **`services/hosted/workspace_game_session_service.py`** — Business logic service:
+  - Active session guard (one active per user+site, enforced on create and update)
+  - Timestamp dedup via `HostedTimestampService.ensure_unique_timestamp()`
+  - Event link rebuild + FIFO rebuild after every mutation
+  - Pair-aware rebuilds when user/site changes on update
+- **`api/app.py`** — 5 new endpoints:
+  - `GET /v1/workspace/game-sessions` (paginated list)
+  - `POST /v1/workspace/game-sessions` (create)
+  - `PATCH /v1/workspace/game-sessions/{id}` (update)
+  - `DELETE /v1/workspace/game-sessions/{id}` (single delete)
+  - `POST /v1/workspace/game-sessions/batch-delete` (bulk delete)
+
+### Tests (38 new, all passing)
+- **DTO tests** (10): validation of required fields, strip/normalize, as_dict
+- **Repository tests** (14): CRUD, soft-delete, pagination, active session query, edge cases
+- **Service tests** (14): happy paths, active session guard (create + update), batch delete, timestamp dedup, error cases
+
+## Test Results
+- 38 new tests pass
+- 1331 total tests pass, 0 regressions
+- 1 pre-existing UI test failure (unrelated autocomplete test)
+
+## Verification
+- All imports validated (`python3 -c "from ... import ..."`)
+- All 5 API routes confirmed registered in FastAPI app
+- Full pytest suite green
+
+## Pitfalls / Follow-ups
+- **No frontend yet**: Game Sessions tab needs to be built (next Issue)
+- **P/L recalculation on session close**: The service triggers FIFO rebuild but does not yet compute session-level P/L fields (discoverable_sc, delta_redeem, basis_consumed, net_taxable_pl). These computed fields will be populated when the session closure workflow is implemented in the frontend.
+- **Expected balance computation**: `compute_expected_balances` (desktop parity) not yet ported to the hosted service — will be needed for the session start form.

--- a/repositories/hosted_redemption_repository.py
+++ b/repositories/hosted_redemption_repository.py
@@ -59,6 +59,49 @@ class HostedRedemptionRepository:
         rows = session.execute(query).all()
         return [self._row_to_model(row) for row in rows]
 
+    def list_by_workspace_user_and_site(
+        self,
+        session,
+        workspace_id: str,
+        user_id: str,
+        site_id: str,
+    ) -> list[HostedRedemption]:
+        """Return redemptions for a user+site pair ordered chronologically (ASC)."""
+        user_alias = aliased(HostedUserRecord)
+        site_alias = aliased(HostedSiteRecord)
+        method_alias = aliased(HostedRedemptionMethodRecord)
+        rt_alias = aliased(HostedRealizedTransactionRecord)
+        query = (
+            select(
+                HostedRedemptionRecord,
+                user_alias.name.label("user_name"),
+                site_alias.name.label("site_name"),
+                method_alias.name.label("method_name"),
+                rt_alias.cost_basis.label("cost_basis"),
+                rt_alias.net_pl.label("net_pl"),
+            )
+            .join(user_alias, HostedRedemptionRecord.user_id == user_alias.id)
+            .join(site_alias, HostedRedemptionRecord.site_id == site_alias.id)
+            .outerjoin(method_alias, HostedRedemptionRecord.redemption_method_id == method_alias.id)
+            .outerjoin(
+                rt_alias,
+                (HostedRedemptionRecord.id == rt_alias.redemption_id)
+                & (HostedRedemptionRecord.workspace_id == rt_alias.workspace_id),
+            )
+            .where(
+                HostedRedemptionRecord.workspace_id == workspace_id,
+                HostedRedemptionRecord.user_id == user_id,
+                HostedRedemptionRecord.site_id == site_id,
+            )
+            .order_by(
+                HostedRedemptionRecord.redemption_date.asc(),
+                HostedRedemptionRecord.redemption_time.asc(),
+                HostedRedemptionRecord.id.asc(),
+            )
+        )
+        rows = session.execute(query).all()
+        return [self._row_to_model(row) for row in rows]
+
     def count_by_workspace_id(self, session, workspace_id: str) -> int:
         return session.scalar(
             select(func.count())

--- a/repositories/hosted_site_repository.py
+++ b/repositories/hosted_site_repository.py
@@ -29,6 +29,23 @@ class HostedSiteRepository:
         records = session.scalars(query).all()
         return [self._record_to_model(record) for record in records]
 
+    def get_by_id_and_workspace_id(
+        self,
+        session,
+        *,
+        site_id: str,
+        workspace_id: str,
+    ) -> HostedSite | None:
+        record = session.scalar(
+            select(HostedSiteRecord).where(
+                HostedSiteRecord.id == site_id,
+                HostedSiteRecord.workspace_id == workspace_id,
+            )
+        )
+        if record is None:
+            return None
+        return self._record_to_model(record)
+
     def count_by_workspace_id(self, session, workspace_id: str) -> int:
         return session.scalar(
             select(func.count())

--- a/services/hosted/workspace_game_session_service.py
+++ b/services/hosted/workspace_game_session_service.py
@@ -2,8 +2,13 @@
 
 from __future__ import annotations
 
+from decimal import Decimal
+
 from repositories.hosted_account_repository import HostedAccountRepository
 from repositories.hosted_game_session_repository import HostedGameSessionRepository
+from repositories.hosted_purchase_repository import HostedPurchaseRepository
+from repositories.hosted_redemption_repository import HostedRedemptionRepository
+from repositories.hosted_site_repository import HostedSiteRepository
 from repositories.hosted_workspace_repository import HostedWorkspaceRepository
 from services.hosted.hosted_event_link_service import HostedEventLinkService
 from services.hosted.hosted_recalculation_service import HostedRecalculationService
@@ -17,6 +22,9 @@ class HostedWorkspaceGameSessionService:
         self.account_repository = HostedAccountRepository()
         self.workspace_repository = HostedWorkspaceRepository()
         self.game_session_repository = HostedGameSessionRepository()
+        self.purchase_repository = HostedPurchaseRepository()
+        self.redemption_repository = HostedRedemptionRepository()
+        self.site_repository = HostedSiteRepository()
         self.recalculation_service = HostedRecalculationService()
         self.event_link_service = HostedEventLinkService()
         self.timestamp_service = HostedTimestampService()
@@ -463,6 +471,186 @@ class HostedWorkspaceGameSessionService:
 
             session.commit()
             return deleted_count
+
+    # -------------------------------------------------------- expected balances
+
+    def compute_expected_balances(
+        self,
+        *,
+        supabase_user_id: str,
+        user_id: str,
+        site_id: str,
+        session_date: str,
+        session_time: str = "00:00:00",
+    ) -> dict[str, str]:
+        """Compute expected starting SC and redeemable balances for a new session.
+
+        Algorithm (Priority 2/3 — no checkpoint anchors yet):
+        1. Find anchor: latest Closed session ending before the cutoff.
+        2. If no closed session, start from (0, 0).
+        3. Apply purchase and redemption events between anchor and cutoff.
+        4. Floor at 0.
+        """
+        with self.session_factory() as session:
+            workspace = self._require_workspace(session, supabase_user_id)
+            wid = workspace.id
+
+            # Site sc_rate for dollar→SC conversion on redemptions
+            site_sc_rate = Decimal("1")
+            site = self.site_repository.get_by_id_and_workspace_id(
+                session, site_id=site_id, workspace_id=wid,
+            )
+            if site is not None:
+                try:
+                    parsed = Decimal(str(site.sc_rate))
+                    if parsed > 0:
+                        site_sc_rate = parsed
+                except Exception:
+                    pass
+
+            cutoff = f"{session_date}T{session_time or '00:00:00'}"
+
+            # --- Priority 2: latest closed session before cutoff ----
+            all_sessions = self.game_session_repository.list_by_workspace_user_and_site(
+                session, wid, user_id, site_id,
+            )
+            anchor_dt: str | None = None
+            expected_total = Decimal("0")
+            expected_redeemable = Decimal("0")
+
+            for gs in all_sessions:
+                if gs.status != "Closed" or not gs.end_date:
+                    continue
+                gs_end_dt = f"{gs.end_date}T{gs.end_time or '00:00:00'}"
+                if gs_end_dt < cutoff and (anchor_dt is None or gs_end_dt > anchor_dt):
+                    anchor_dt = gs_end_dt
+                    expected_total = Decimal(str(gs.ending_balance or "0"))
+                    expected_redeemable = Decimal(str(gs.ending_redeemable or "0"))
+
+            # --- Timeline events after anchor, before cutoff --------
+            purchases = self.purchase_repository.list_by_workspace_user_and_site(
+                session, wid, user_id, site_id,
+            )
+            redemptions = self.redemption_repository.list_by_workspace_user_and_site(
+                session, wid, user_id, site_id,
+            )
+
+            def redemption_amount_sc(amount_str: str) -> Decimal:
+                return Decimal(str(amount_str or "0")) / site_sc_rate
+
+            # Build timeline: (sort_key, event_type_order, id, type, record)
+            timeline = []
+            for p in purchases:
+                p_dt = f"{p.purchase_date}T{p.purchase_time or '00:00:00'}"
+                if anchor_dt is not None and p_dt <= anchor_dt:
+                    continue
+                if p_dt >= cutoff:
+                    continue
+                timeline.append((p_dt, 0, p.id or "", "purchase", p))
+
+            for r in redemptions:
+                r_status = getattr(r, "status", "PENDING") or "PENDING"
+                r_dt = f"{r.redemption_date}T{r.redemption_time or '00:00:00'}"
+                # Debit event at redemption time
+                if (anchor_dt is None or r_dt > anchor_dt) and r_dt < cutoff:
+                    timeline.append((r_dt, 1, r.id or "", "redemption_debit", r))
+                # Credit event at cancellation time (two-event delta model)
+                if r_status == "CANCELED":
+                    canceled_at = getattr(r, "canceled_at", None)
+                    if canceled_at:
+                        # canceled_at is UTC ISO; extract comparable string
+                        cancel_dt = canceled_at[:19].replace(" ", "T")
+                        if (anchor_dt is None or cancel_dt > anchor_dt) and cancel_dt < cutoff:
+                            timeline.append((cancel_dt, 2, r.id or "", "redemption_credit", r))
+
+            timeline.sort(key=lambda e: (e[0], e[1], e[2]))
+
+            for _, _, _, event_type, record in timeline:
+                if event_type == "purchase":
+                    expected_total = Decimal(str(record.starting_sc_balance or "0"))
+                    if getattr(record, "starting_redeemable_balance", None) is not None:
+                        expected_redeemable = Decimal(str(record.starting_redeemable_balance))
+                elif event_type == "redemption_debit":
+                    amt = redemption_amount_sc(record.amount)
+                    expected_total -= amt
+                    expected_redeemable -= amt
+                elif event_type == "redemption_credit":
+                    amt = redemption_amount_sc(record.amount)
+                    expected_total += amt
+                    expected_redeemable += amt
+
+            expected_total = max(Decimal("0"), expected_total)
+            expected_redeemable = max(Decimal("0"), expected_redeemable)
+
+            return {
+                "expected_start_total": f"{expected_total:.2f}",
+                "expected_start_redeemable": f"{expected_redeemable:.2f}",
+            }
+
+    # -------------------------------------------------------- deletion impact
+
+    def get_deletion_impact(
+        self,
+        *,
+        supabase_user_id: str,
+        game_session_id: str,
+    ) -> dict[str, object]:
+        """Check if deleting a closed session would affect subsequent redemptions.
+
+        Returns a dict with ``has_impact`` (bool) and ``message`` (str).
+        """
+        with self.session_factory() as session:
+            workspace = self._require_workspace(session, supabase_user_id)
+            wid = workspace.id
+
+            gs = self.game_session_repository.get_by_id_and_workspace_id(
+                session, game_session_id=game_session_id, workspace_id=wid,
+            )
+            if gs is None or gs.status != "Closed" or not gs.end_date:
+                return {"has_impact": False, "message": ""}
+
+            end_dt = f"{gs.end_date}T{gs.end_time or '00:00:00'}"
+
+            # Count non-canceled redemptions after this session's end
+            redemptions = self.redemption_repository.list_by_workspace_user_and_site(
+                session, wid, gs.user_id, gs.site_id,
+            )
+            subsequent = [
+                r for r in redemptions
+                if f"{r.redemption_date}T{r.redemption_time or '00:00:00'}" > end_dt
+                and getattr(r, "status", "PENDING") not in ("CANCELED",)
+            ]
+            if not subsequent:
+                return {"has_impact": False, "message": ""}
+
+            count = len(subsequent)
+            total_dollars = sum(Decimal(str(r.amount or "0")) for r in subsequent)
+
+            # Find the previous closed session's ending balance
+            all_sessions = self.game_session_repository.list_by_workspace_user_and_site(
+                session, wid, gs.user_id, gs.site_id,
+            )
+            prev_balance = Decimal("0")
+            start_dt = f"{gs.session_date}T{gs.session_time or '00:00:00'}"
+            for s in all_sessions:
+                if s.id == gs.id or s.status != "Closed" or not s.end_date:
+                    continue
+                s_end_dt = f"{s.end_date}T{s.end_time or '00:00:00'}"
+                if s_end_dt < start_dt:
+                    prev_balance = Decimal(str(s.ending_balance or "0"))
+
+            ending_balance = Decimal(str(gs.ending_balance or "0"))
+            msg = (
+                f"Session: {gs.site_name or 'Unknown'} / {gs.user_name or 'Unknown'}\n"
+                f"Session ended with {ending_balance:,.2f} SC\n"
+                f"Found {count} redemption(s) after this session "
+                f"totaling ${total_dollars:,.2f}\n\n"
+                f"If you delete this session:\n"
+                f"\u2022 Expected balance drops to {prev_balance:,.2f} SC\n"
+                f"\u2022 Redemptions may temporarily exceed expected balance\n"
+                f"\u2022 You won't be able to edit redemptions until you fix the gap"
+            )
+            return {"has_impact": True, "message": msg}
 
     # ------------------------------------------------------------------ helpers
 

--- a/tests/services/hosted/test_hosted_game_session_expected_balances.py
+++ b/tests/services/hosted/test_hosted_game_session_expected_balances.py
@@ -1,0 +1,394 @@
+"""Tests for compute_expected_balances and get_deletion_impact."""
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from services.hosted.account_bootstrap_service import HostedAccountBootstrapService
+from services.hosted.persistence import HostedBase
+from services.hosted.workspace_card_service import HostedWorkspaceCardService
+from services.hosted.workspace_game_session_service import HostedWorkspaceGameSessionService
+from services.hosted.workspace_purchase_service import HostedWorkspacePurchaseService
+from services.hosted.workspace_redemption_service import HostedWorkspaceRedemptionService
+from services.hosted.workspace_site_service import HostedWorkspaceSiteService
+from services.hosted.workspace_user_service import HostedWorkspaceUserService
+
+
+OWNER = "owner-balances"
+
+
+def _session_factory():
+    engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+    HostedBase.metadata.create_all(engine)
+    return engine, sessionmaker(bind=engine, expire_on_commit=False)
+
+
+def _bootstrap(sf):
+    """Bootstrap account, workspace, user, site, card."""
+    HostedAccountBootstrapService(sf).bootstrap_account_workspace(
+        supabase_user_id=OWNER, owner_email="owner@test.com",
+    )
+    user = HostedWorkspaceUserService(sf).create_user(supabase_user_id=OWNER, name="Alice")
+    site = HostedWorkspaceSiteService(sf).create_site(supabase_user_id=OWNER, name="CasinoA")
+    card = HostedWorkspaceCardService(sf).create_card(
+        supabase_user_id=OWNER, name="Visa", user_id=user.id,
+    )
+    return user, site, card
+
+
+# ── compute_expected_balances ───────────────────────────────────────────────
+
+
+def test_zero_baseline_no_data():
+    """Priority 3: no sessions or events → (0, 0)."""
+    engine, sf = _session_factory()
+    user, site, _ = _bootstrap(sf)
+    service = HostedWorkspaceGameSessionService(sf)
+    try:
+        result = service.compute_expected_balances(
+            supabase_user_id=OWNER,
+            user_id=user.id,
+            site_id=site.id,
+            session_date="2026-06-01",
+            session_time="12:00:00",
+        )
+    finally:
+        engine.dispose()
+    assert result["expected_start_total"] == "0.00"
+    assert result["expected_start_redeemable"] == "0.00"
+
+
+def test_anchor_from_closed_session():
+    """Priority 2: uses last closed session's ending balances."""
+    engine, sf = _session_factory()
+    user, site, _ = _bootstrap(sf)
+    gs_service = HostedWorkspaceGameSessionService(sf)
+    try:
+        # Create and close a session
+        gs_service.create_game_session(
+            supabase_user_id=OWNER,
+            user_id=user.id,
+            site_id=site.id,
+            session_date="2026-01-10",
+            session_time="10:00:00",
+            end_date="2026-01-10",
+            end_time="18:00:00",
+            starting_balance="0.00",
+            ending_balance="250.00",
+            starting_redeemable="0.00",
+            ending_redeemable="80.00",
+            status_value="Closed",
+        )
+
+        result = gs_service.compute_expected_balances(
+            supabase_user_id=OWNER,
+            user_id=user.id,
+            site_id=site.id,
+            session_date="2026-01-15",
+            session_time="10:00:00",
+        )
+    finally:
+        engine.dispose()
+    assert result["expected_start_total"] == "250.00"
+    assert result["expected_start_redeemable"] == "80.00"
+
+
+def test_purchase_after_anchor_updates_total():
+    """A purchase between anchor session and cutoff sets expected_total."""
+    engine, sf = _session_factory()
+    user, site, card = _bootstrap(sf)
+    gs_service = HostedWorkspaceGameSessionService(sf)
+    purchase_service = HostedWorkspacePurchaseService(sf)
+    try:
+        # Closed session
+        gs_service.create_game_session(
+            supabase_user_id=OWNER,
+            user_id=user.id,
+            site_id=site.id,
+            session_date="2026-01-10",
+            session_time="10:00:00",
+            end_date="2026-01-10",
+            end_time="18:00:00",
+            starting_balance="0.00",
+            ending_balance="200.00",
+            starting_redeemable="0.00",
+            ending_redeemable="50.00",
+            status_value="Closed",
+        )
+
+        # Purchase after session → starting_sc_balance = 350 (post-purchase snapshot)
+        purchase_service.create_purchase(
+            supabase_user_id=OWNER,
+            user_id=user.id,
+            site_id=site.id,
+            amount="150.00",
+            purchase_date="2026-01-12",
+            purchase_time="09:00:00",
+            card_id=card.id,
+            starting_sc_balance="350.00",
+        )
+
+        result = gs_service.compute_expected_balances(
+            supabase_user_id=OWNER,
+            user_id=user.id,
+            site_id=site.id,
+            session_date="2026-01-15",
+            session_time="10:00:00",
+        )
+    finally:
+        engine.dispose()
+    assert result["expected_start_total"] == "350.00"
+    # Purchase's starting_redeemable_balance defaults to "0.00" (checkpoint),
+    # which supersedes the session anchor.
+    assert result["expected_start_redeemable"] == "0.00"
+
+
+def test_redemption_after_anchor_decreases_balances():
+    """A pending redemption after anchor reduces both total and redeemable."""
+    engine, sf = _session_factory()
+    user, site, card = _bootstrap(sf)
+    gs_service = HostedWorkspaceGameSessionService(sf)
+    purchase_service = HostedWorkspacePurchaseService(sf)
+    redemption_service = HostedWorkspaceRedemptionService(sf)
+    try:
+        # Need a purchase first (for FIFO basis on redemption)
+        purchase_service.create_purchase(
+            supabase_user_id=OWNER,
+            user_id=user.id,
+            site_id=site.id,
+            amount="500.00",
+            purchase_date="2026-01-01",
+            card_id=card.id,
+            starting_sc_balance="0.00",
+        )
+
+        # Closed session
+        gs_service.create_game_session(
+            supabase_user_id=OWNER,
+            user_id=user.id,
+            site_id=site.id,
+            session_date="2026-01-10",
+            session_time="10:00:00",
+            end_date="2026-01-10",
+            end_time="18:00:00",
+            starting_balance="0.00",
+            ending_balance="300.00",
+            starting_redeemable="0.00",
+            ending_redeemable="100.00",
+            status_value="Closed",
+        )
+
+        # Redemption of $50 (sc_rate=1 → 50 SC)
+        redemption_service.create_redemption(
+            supabase_user_id=OWNER,
+            user_id=user.id,
+            site_id=site.id,
+            amount="50.00",
+            redemption_date="2026-01-12",
+            redemption_time="09:00:00",
+        )
+
+        result = gs_service.compute_expected_balances(
+            supabase_user_id=OWNER,
+            user_id=user.id,
+            site_id=site.id,
+            session_date="2026-01-15",
+            session_time="10:00:00",
+        )
+    finally:
+        engine.dispose()
+    assert result["expected_start_total"] == "250.00"
+    assert result["expected_start_redeemable"] == "50.00"
+
+
+def test_floor_at_zero():
+    """Expected balances never go negative."""
+    engine, sf = _session_factory()
+    user, site, card = _bootstrap(sf)
+    gs_service = HostedWorkspaceGameSessionService(sf)
+    purchase_service = HostedWorkspacePurchaseService(sf)
+    redemption_service = HostedWorkspaceRedemptionService(sf)
+    try:
+        # Seed a purchase for FIFO
+        purchase_service.create_purchase(
+            supabase_user_id=OWNER,
+            user_id=user.id,
+            site_id=site.id,
+            amount="1000.00",
+            purchase_date="2025-12-01",
+            card_id=card.id,
+            starting_sc_balance="0.00",
+        )
+
+        # Small session
+        gs_service.create_game_session(
+            supabase_user_id=OWNER,
+            user_id=user.id,
+            site_id=site.id,
+            session_date="2026-01-10",
+            session_time="10:00:00",
+            end_date="2026-01-10",
+            end_time="18:00:00",
+            starting_balance="0.00",
+            ending_balance="10.00",
+            starting_redeemable="0.00",
+            ending_redeemable="5.00",
+            status_value="Closed",
+        )
+
+        # Giant redemption exceeds balances
+        redemption_service.create_redemption(
+            supabase_user_id=OWNER,
+            user_id=user.id,
+            site_id=site.id,
+            amount="999.00",
+            redemption_date="2026-01-12",
+            redemption_time="09:00:00",
+        )
+
+        result = gs_service.compute_expected_balances(
+            supabase_user_id=OWNER,
+            user_id=user.id,
+            site_id=site.id,
+            session_date="2026-01-15",
+            session_time="10:00:00",
+        )
+    finally:
+        engine.dispose()
+    assert result["expected_start_total"] == "0.00"
+    assert result["expected_start_redeemable"] == "0.00"
+
+
+def test_ignores_active_sessions():
+    """Active sessions do NOT serve as anchors."""
+    engine, sf = _session_factory()
+    user, site, _ = _bootstrap(sf)
+    gs_service = HostedWorkspaceGameSessionService(sf)
+    try:
+        gs_service.create_game_session(
+            supabase_user_id=OWNER,
+            user_id=user.id,
+            site_id=site.id,
+            session_date="2026-01-10",
+            session_time="10:00:00",
+            starting_balance="500.00",
+            ending_balance="500.00",
+            status_value="Active",
+        )
+
+        result = gs_service.compute_expected_balances(
+            supabase_user_id=OWNER,
+            user_id=user.id,
+            site_id=site.id,
+            session_date="2026-01-15",
+            session_time="10:00:00",
+        )
+    finally:
+        engine.dispose()
+    # Active sessions ignored → falls through to zero baseline
+    assert result["expected_start_total"] == "0.00"
+    assert result["expected_start_redeemable"] == "0.00"
+
+
+# ── get_deletion_impact ─────────────────────────────────────────────────────
+
+
+def test_no_impact_for_active_session():
+    """Active sessions have no deletion impact."""
+    engine, sf = _session_factory()
+    user, site, _ = _bootstrap(sf)
+    gs_service = HostedWorkspaceGameSessionService(sf)
+    try:
+        gs = gs_service.create_game_session(
+            supabase_user_id=OWNER,
+            user_id=user.id,
+            site_id=site.id,
+            session_date="2026-01-10",
+            session_time="10:00:00",
+            status_value="Active",
+        )
+        result = gs_service.get_deletion_impact(
+            supabase_user_id=OWNER,
+            game_session_id=gs.id,
+        )
+    finally:
+        engine.dispose()
+    assert result["has_impact"] is False
+
+
+def test_no_impact_when_no_subsequent_redemptions():
+    """Closed session with no redemptions after it → no impact."""
+    engine, sf = _session_factory()
+    user, site, _ = _bootstrap(sf)
+    gs_service = HostedWorkspaceGameSessionService(sf)
+    try:
+        gs = gs_service.create_game_session(
+            supabase_user_id=OWNER,
+            user_id=user.id,
+            site_id=site.id,
+            session_date="2026-01-10",
+            session_time="10:00:00",
+            end_date="2026-01-10",
+            end_time="18:00:00",
+            ending_balance="200.00",
+            status_value="Closed",
+        )
+        result = gs_service.get_deletion_impact(
+            supabase_user_id=OWNER,
+            game_session_id=gs.id,
+        )
+    finally:
+        engine.dispose()
+    assert result["has_impact"] is False
+
+
+def test_impact_when_subsequent_redemptions_exist():
+    """Closed session with redemptions after it → returns impact message."""
+    engine, sf = _session_factory()
+    user, site, card = _bootstrap(sf)
+    gs_service = HostedWorkspaceGameSessionService(sf)
+    purchase_service = HostedWorkspacePurchaseService(sf)
+    redemption_service = HostedWorkspaceRedemptionService(sf)
+    try:
+        # Need a purchase for FIFO
+        purchase_service.create_purchase(
+            supabase_user_id=OWNER,
+            user_id=user.id,
+            site_id=site.id,
+            amount="500.00",
+            purchase_date="2025-12-01",
+            card_id=card.id,
+            starting_sc_balance="0.00",
+        )
+
+        gs = gs_service.create_game_session(
+            supabase_user_id=OWNER,
+            user_id=user.id,
+            site_id=site.id,
+            session_date="2026-01-10",
+            session_time="10:00:00",
+            end_date="2026-01-10",
+            end_time="18:00:00",
+            ending_balance="200.00",
+            status_value="Closed",
+        )
+
+        # Redemption AFTER the session ends
+        redemption_service.create_redemption(
+            supabase_user_id=OWNER,
+            user_id=user.id,
+            site_id=site.id,
+            amount="100.00",
+            redemption_date="2026-01-15",
+            redemption_time="09:00:00",
+        )
+
+        result = gs_service.get_deletion_impact(
+            supabase_user_id=OWNER,
+            game_session_id=gs.id,
+        )
+    finally:
+        engine.dispose()
+    assert result["has_impact"] is True
+    assert "1 redemption(s)" in result["message"]
+    assert "$100.00" in result["message"]

--- a/web/src/components/AppShell.jsx
+++ b/web/src/components/AppShell.jsx
@@ -15,6 +15,7 @@ import GameTypesTab from "./GameTypesTab/GameTypesTab";
 import GamesTab from "./GamesTab/GamesTab";
 import PurchasesTab from "./PurchasesTab/PurchasesTab";
 import RedemptionsTab from "./RedemptionsTab/RedemptionsTab";
+import GameSessionsTab from "./GameSessionsTab/GameSessionsTab";
 
 const setupTabs = [
   { key: "users", label: "Users", icon: "users", enabled: true },
@@ -29,7 +30,8 @@ const setupTabs = [
 
 const topLevelTabs = [
   { key: "purchases", label: "Purchases", icon: "purchases" },
-  { key: "redemptions", label: "Redemptions", icon: "redemptions" }
+  { key: "redemptions", label: "Redemptions", icon: "redemptions" },
+  { key: "game-sessions", label: "Sessions", icon: "gameSessions" }
 ];
 
 const allValidKeys = new Set([...setupTabs.map((t) => t.key), ...topLevelTabs.map((t) => t.key)]);
@@ -270,6 +272,12 @@ export default function AppShell({ auth }) {
         ) : null}
         {activeTab === "redemptions" ? (
           <RedemptionsTab
+            apiBaseUrl={auth.apiBaseUrl}
+            hostedWorkspaceReady={auth.hostedWorkspaceReady}
+          />
+        ) : null}
+        {activeTab === "game-sessions" ? (
+          <GameSessionsTab
             apiBaseUrl={auth.apiBaseUrl}
             hostedWorkspaceReady={auth.hostedWorkspaceReady}
           />

--- a/web/src/components/GameSessionsTab/GameSessionModal.jsx
+++ b/web/src/components/GameSessionsTab/GameSessionModal.jsx
@@ -1,0 +1,649 @@
+import { useRef, useEffect, useCallback, useState } from "react";
+import { getGameSessionColumnValue } from "./gameSessionsUtils";
+import { getAccessToken, authHeaders } from "../../services/api";
+import TypeaheadSelect from "../common/TypeaheadSelect";
+
+export default function GameSessionModal({
+  mode,
+  gameSession,
+  form,
+  setForm,
+  onClose,
+  onSubmit,
+  onRequestEdit,
+  onRequestDelete,
+  onEndAndStartNew,
+  submitError,
+  users,
+  sites,
+  games,
+  gameTypes,
+  apiBaseUrl,
+}) {
+  const readOnly = mode === "view";
+  const isCreate = mode === "create";
+  const isEdit = mode === "edit";
+  const isActive = form.status === "Active";
+  const isClosed = form.status === "Closed";
+
+  const title = isCreate
+    ? "Start Session"
+    : isEdit
+      ? isActive ? "Edit Active Session" : "Edit Closed Session"
+      : "View Session";
+
+  // Validation
+  const userInvalid = !form.user_id;
+  const siteInvalid = !form.site_id;
+  const dateInvalid = !form.session_date;
+  const startBalInvalid = form.starting_balance === "" || isNaN(Number(form.starting_balance));
+  const endDateInvalid = isClosed && !form.end_date;
+  const endBalInvalid = isClosed && (form.ending_balance === "" || isNaN(Number(form.ending_balance)));
+
+  const formInvalid = userInvalid || siteInvalid || dateInvalid || startBalInvalid
+    || (isClosed && (endDateInvalid || endBalInvalid));
+
+  const closeLabel = readOnly ? "Close" : "Cancel";
+
+  // Auto-focus User field
+  const userRef = useRef(null);
+  useEffect(() => {
+    if (!readOnly && userRef.current) {
+      const input = userRef.current.querySelector ? userRef.current.querySelector("input") : userRef.current;
+      if (input) input.focus();
+    }
+  }, [readOnly]);
+
+  // Filter games by game_type
+  const filteredGames = form.game_type_id
+    ? games.filter((g) => g.game_type_id === form.game_type_id)
+    : games;
+
+  // ── Expected Balances Auto-Fill (one-shot on create) ────────────────────
+  const autoFillDone = useRef(false);
+
+  useEffect(() => {
+    if (!isCreate || autoFillDone.current) return;
+    if (!form.user_id || !form.site_id || !form.session_date) return;
+
+    const controller = new AbortController();
+    const timer = setTimeout(async () => {
+      try {
+        const token = await getAccessToken();
+        if (!token || controller.signal.aborted) return;
+        const params = new URLSearchParams({
+          user_id: form.user_id,
+          site_id: form.site_id,
+          session_date: form.session_date,
+          session_time: form.session_time || "00:00:00",
+        });
+        const res = await fetch(
+          `${apiBaseUrl}/v1/workspace/game-sessions/expected-balances?${params}`,
+          { headers: authHeaders(token), signal: controller.signal },
+        );
+        if (!res.ok || controller.signal.aborted) return;
+        const data = await res.json();
+        autoFillDone.current = true;
+        setForm((prev) => ({
+          ...prev,
+          starting_balance: data.expected_start_total || prev.starting_balance,
+          starting_redeemable: data.expected_start_redeemable || prev.starting_redeemable,
+        }));
+      } catch {
+        /* ignore */
+      }
+    }, 300);
+
+    return () => {
+      clearTimeout(timer);
+      controller.abort();
+    };
+  }, [isCreate, form.user_id, form.site_id, form.session_date, form.session_time, apiBaseUrl, setForm]);
+
+  // ── Balance Check (always-on, mirrors PurchaseModal pattern) ──────────────
+  const [balanceCheck, setBalanceCheck] = useState(null); // { status, message }
+
+  useEffect(() => {
+    if (readOnly) return;
+    if (!form.user_id || !form.site_id || !form.session_date || !form.starting_balance) {
+      setBalanceCheck(null);
+      return;
+    }
+
+    const controller = new AbortController();
+    const timer = setTimeout(async () => {
+      try {
+        const token = await getAccessToken();
+        if (!token || controller.signal.aborted) return;
+        const params = new URLSearchParams({
+          user_id: form.user_id,
+          site_id: form.site_id,
+          session_date: form.session_date,
+          session_time: form.session_time || "00:00:00",
+        });
+        const res = await fetch(
+          `${apiBaseUrl}/v1/workspace/game-sessions/expected-balances?${params}`,
+          { headers: authHeaders(token), signal: controller.signal },
+        );
+        if (!res.ok || controller.signal.aborted) {
+          setBalanceCheck(null);
+          return;
+        }
+        const data = await res.json();
+        const expectedTotal = Number(data.expected_start_total);
+        const enteredTotal = Number(form.starting_balance);
+        const delta = enteredTotal - expectedTotal;
+
+        if (Math.abs(delta) <= 0.01) {
+          setBalanceCheck({
+            status: "match",
+            message: `Starting SC matches expected (${expectedTotal.toFixed(2)} SC)`,
+          });
+        } else if (delta > 0.01) {
+          setBalanceCheck({
+            status: "higher",
+            message: `+ ${delta.toFixed(2)} SC above expected (${expectedTotal.toFixed(2)} SC)`,
+          });
+        } else {
+          setBalanceCheck({
+            status: "lower",
+            message: `WARNING: ${Math.abs(delta).toFixed(2)} SC below expected (${expectedTotal.toFixed(2)} SC)`,
+          });
+        }
+      } catch {
+        if (!controller.signal.aborted) setBalanceCheck(null);
+      }
+    }, 300);
+
+    return () => {
+      clearTimeout(timer);
+      controller.abort();
+    };
+  }, [readOnly, form.user_id, form.site_id, form.session_date, form.session_time, form.starting_balance, apiBaseUrl]);
+
+  // ── P/L Preview (for Closed sessions) ─────────────────────────────────────
+  const plPreview = (() => {
+    if (!isClosed) return null;
+    const startBal = Number(form.starting_balance || 0);
+    const endBal = Number(form.ending_balance || 0);
+    const startRedeem = Number(form.starting_redeemable || 0);
+    const endRedeem = Number(form.ending_redeemable || 0);
+    const purchases = Number(form.purchases_during || 0);
+    const redemptions = Number(form.redemptions_during || 0);
+    // discoverable_sc = ending - starting - purchases + redemptions
+    const discoverableSC = endBal - startBal - purchases + redemptions;
+    // delta_redeem = ending_redeemable - starting_redeemable
+    const deltaRedeem = endRedeem - startRedeem;
+    // Simplified P/L = discoverable_sc + delta_redeem (sc_rate=1 for preview)
+    const netPL = discoverableSC + deltaRedeem;
+    return { discoverableSC, deltaRedeem, netPL };
+  })();
+
+  // ── End & Start New ───────────────────────────────────────────────────────
+  const [endAndStartPending, setEndAndStartPending] = useState(false);
+
+  const handleEndAndStartNew = useCallback(async () => {
+    if (!isEdit || !isActive) return;
+    // First close the current session by submitting with Closed status
+    setEndAndStartPending(true);
+
+    // Build the close payload
+    setForm((prev) => ({
+      ...prev,
+      status: "Closed",
+      end_date: prev.end_date || prev.session_date,
+      end_time: prev.end_time || new Date().toTimeString().slice(0, 8),
+    }));
+  }, [isEdit, isActive, setForm]);
+
+  // Once the form is set to Closed and endAndStartPending, trigger submit
+  useEffect(() => {
+    if (!endAndStartPending || form.status !== "Closed") return;
+    // Submit the close, then trigger the End & Start New callback
+    const doSubmit = async () => {
+      try {
+        await onSubmit();
+        if (onEndAndStartNew) {
+          onEndAndStartNew(form);
+        }
+      } catch {
+        // submitError will be shown in the modal
+      } finally {
+        setEndAndStartPending(false);
+      }
+    };
+    doSubmit();
+  }, [endAndStartPending, form.status]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // ── Deletion Impact ───────────────────────────────────────────────────────
+  const [deletionImpact, setDeletionImpact] = useState(null);
+
+  const handleDeleteWithImpactCheck = useCallback(async () => {
+    if (!gameSession?.id) {
+      onRequestDelete();
+      return;
+    }
+    try {
+      const token = await getAccessToken();
+      if (!token) { onRequestDelete(); return; }
+      const res = await fetch(
+        `${apiBaseUrl}/v1/workspace/game-sessions/${gameSession.id}/deletion-impact`,
+        { headers: authHeaders(token) },
+      );
+      if (!res.ok) { onRequestDelete(); return; }
+      const data = await res.json();
+      if (data.has_impact) {
+        setDeletionImpact(data.message);
+      } else {
+        onRequestDelete();
+      }
+    } catch {
+      onRequestDelete();
+    }
+  }, [gameSession?.id, apiBaseUrl, onRequestDelete]);
+
+  // ── View mode ─────────────────────────────────────────────────────────────
+  if (readOnly && gameSession) {
+    return (
+      <div className="modal-backdrop" role="presentation" onClick={onClose}>
+        <section
+          className="modal-card entity-modal"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="gs-modal-title"
+          onClick={(event) => event.stopPropagation()}
+        >
+          <div className="modal-header">
+            <div>
+              <h2 id="gs-modal-title">View Session</h2>
+            </div>
+            <button className="ghost-button" type="button" onClick={onClose}>{closeLabel}</button>
+          </div>
+
+          <div className="modal-detail-body">
+            <dl className="detail-grid modal-detail-grid">
+              <div><dt>Date</dt><dd>{gameSession.session_date}</dd></div>
+              <div><dt>Time</dt><dd>{gameSession.session_time || "—"}</dd></div>
+              <div><dt>User</dt><dd>{gameSession.user_name || "—"}</dd></div>
+              <div><dt>Site</dt><dd>{gameSession.site_name || "—"}</dd></div>
+              <div><dt>Game</dt><dd>{gameSession.game_name || "—"}</dd></div>
+              <div><dt>Game Type</dt><dd>{gameSession.game_type_name || "—"}</dd></div>
+              <div>
+                <dt>Status</dt>
+                <dd>
+                  <span className={gameSession.status === "Active" ? "status-chip active" : "status-chip inactive"}>
+                    {gameSession.status}
+                  </span>
+                </dd>
+              </div>
+              {gameSession.status === "Closed" && (
+                <>
+                  <div><dt>End Date</dt><dd>{gameSession.end_date || "—"}</dd></div>
+                  <div><dt>End Time</dt><dd>{gameSession.end_time || "—"}</dd></div>
+                </>
+              )}
+              <div><dt>Starting SC</dt><dd>{getGameSessionColumnValue(gameSession, "starting_balance")}</dd></div>
+              <div><dt>Ending SC</dt><dd>{getGameSessionColumnValue(gameSession, "ending_balance")}</dd></div>
+              <div><dt>Starting Redeemable</dt><dd>{getGameSessionColumnValue(gameSession, "starting_redeemable")}</dd></div>
+              <div><dt>Ending Redeemable</dt><dd>{getGameSessionColumnValue(gameSession, "ending_redeemable")}</dd></div>
+              <div><dt>Purchases During</dt><dd>{getGameSessionColumnValue(gameSession, "purchases_during") || "—"}</dd></div>
+              <div><dt>Redemptions During</dt><dd>{getGameSessionColumnValue(gameSession, "redemptions_during") || "—"}</dd></div>
+              {gameSession.net_taxable_pl != null && (
+                <div><dt>Net P/L</dt><dd>{getGameSessionColumnValue(gameSession, "net_taxable_pl")}</dd></div>
+              )}
+            </dl>
+
+            <div className="modal-detail-notes">
+              <p className="field-label">Notes</p>
+              <div className="notes-display">{gameSession.notes || "—"}</div>
+            </div>
+          </div>
+
+          <div className="modal-actions modal-actions-split">
+            <div className="toolbar-row">
+              <button className="ghost-button" type="button" onClick={handleDeleteWithImpactCheck}>Delete</button>
+            </div>
+            <div className="toolbar-row">
+              <button className="primary-button" type="button" onClick={onRequestEdit}>Edit Session</button>
+            </div>
+          </div>
+
+          {deletionImpact && (
+            <div className="modal-backdrop" role="presentation" onClick={() => setDeletionImpact(null)}>
+              <section
+                className="modal-card entity-modal"
+                role="dialog"
+                aria-modal="true"
+                onClick={(event) => event.stopPropagation()}
+                style={{ maxWidth: "480px" }}
+              >
+                <div className="modal-header">
+                  <h2>Deletion Impact</h2>
+                  <button className="ghost-button" type="button" onClick={() => setDeletionImpact(null)}>Close</button>
+                </div>
+                <div className="modal-detail-body" style={{ whiteSpace: "pre-wrap" }}>
+                  {deletionImpact}
+                </div>
+                <div className="modal-actions modal-actions-split">
+                  <button className="ghost-button" type="button" onClick={() => setDeletionImpact(null)}>Cancel</button>
+                  <button
+                    className="ghost-button"
+                    type="button"
+                    style={{ color: "var(--danger)" }}
+                    onClick={() => { setDeletionImpact(null); onRequestDelete(); }}
+                  >
+                    Delete Anyway
+                  </button>
+                </div>
+              </section>
+            </div>
+          )}
+        </section>
+      </div>
+    );
+  }
+
+  // ── Create / Edit mode ────────────────────────────────────────────────────
+  return (
+    <div className="modal-backdrop" role="presentation" onClick={onClose}>
+      <section
+        className="modal-card entity-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="gs-modal-title"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="modal-header">
+          <div>
+            <h2 id="gs-modal-title">{title}</h2>
+          </div>
+          <button className="ghost-button" type="button" onClick={onClose}>
+            {closeLabel}
+          </button>
+        </div>
+
+        <div className="purchase-form">
+          {/* ── Date / Time ── */}
+          <div className="pf-datetime-row">
+            <label className="field-label" htmlFor="gs-date-input">Date</label>
+            <input
+              id="gs-date-input"
+              className={dateInvalid ? "text-input invalid" : "text-input"}
+              type="date"
+              value={form.session_date}
+              readOnly={readOnly}
+              onChange={(e) => setForm((c) => ({ ...c, session_date: e.target.value }))}
+            />
+            <label className="field-label" htmlFor="gs-time-input">Time</label>
+            <input
+              id="gs-time-input"
+              className="text-input"
+              type="time"
+              step="1"
+              value={form.session_time}
+              readOnly={readOnly}
+              onChange={(e) => setForm((c) => ({ ...c, session_time: e.target.value }))}
+            />
+          </div>
+
+          {/* ── Session Details ── */}
+          <div className="pf-section">
+            <p className="pf-section-title"><span>🎰</span> Session Details</p>
+            <div className="pf-grid">
+              <label className="field-label" htmlFor="gs-user-input" style={{ gridRow: 1, gridColumn: 1 }}>User</label>
+              <div className="pf-cell" ref={userRef} style={{ gridRow: 1, gridColumn: 2 }}>
+                <TypeaheadSelect
+                  id="gs-user-input"
+                  options={users.map((u) => ({ value: u.id, label: u.name }))}
+                  value={form.user_id}
+                  onChange={(v) => setForm((c) => ({ ...c, user_id: v }))}
+                  placeholder="Select…"
+                  disabled={readOnly}
+                  invalid={userInvalid}
+                  title={userInvalid ? "Required" : undefined}
+                />
+              </div>
+              <label className="field-label" htmlFor="gs-site-input" style={{ gridRow: 2, gridColumn: 1 }}>Site</label>
+              <div className="pf-cell" style={{ gridRow: 2, gridColumn: 2 }}>
+                <TypeaheadSelect
+                  id="gs-site-input"
+                  options={sites.map((s) => ({ value: s.id, label: s.name }))}
+                  value={form.site_id}
+                  onChange={(v) => setForm((c) => ({ ...c, site_id: v }))}
+                  placeholder="Select…"
+                  disabled={readOnly}
+                  invalid={siteInvalid}
+                  title={siteInvalid ? "Required" : undefined}
+                />
+              </div>
+              <label className="field-label" htmlFor="gs-game-type-input" style={{ gridRow: 3, gridColumn: 1 }}>Game Type</label>
+              <div className="pf-cell" style={{ gridRow: 3, gridColumn: 2 }}>
+                <TypeaheadSelect
+                  id="gs-game-type-input"
+                  options={gameTypes.map((gt) => ({ value: gt.id, label: gt.name }))}
+                  value={form.game_type_id}
+                  onChange={(v) => setForm((c) => ({ ...c, game_type_id: v, game_id: v === c.game_type_id ? c.game_id : "" }))}
+                  placeholder="Optional"
+                  disabled={readOnly}
+                />
+              </div>
+
+              <label className="field-label" htmlFor="gs-start-bal-input" style={{ gridRow: 1, gridColumn: 3 }}>Starting SC</label>
+              <div className="pf-cell" style={{ gridRow: 1, gridColumn: 4 }}>
+                <input
+                  id="gs-start-bal-input"
+                  className={startBalInvalid ? "text-input invalid" : "text-input"}
+                  type="number"
+                  min="0"
+                  step="0.01"
+                  placeholder="0.00"
+                  title={startBalInvalid ? "Required" : undefined}
+                  value={form.starting_balance}
+                  readOnly={readOnly}
+                  onChange={(e) => setForm((c) => ({ ...c, starting_balance: e.target.value }))}
+                />
+              </div>
+              <label className="field-label" htmlFor="gs-start-redeem-input" style={{ gridRow: 2, gridColumn: 3 }}>Starting Redeem</label>
+              <div className="pf-cell" style={{ gridRow: 2, gridColumn: 4 }}>
+                <input
+                  id="gs-start-redeem-input"
+                  className="text-input"
+                  type="number"
+                  min="0"
+                  step="0.01"
+                  placeholder="0.00"
+                  value={form.starting_redeemable}
+                  readOnly={readOnly}
+                  onChange={(e) => setForm((c) => ({ ...c, starting_redeemable: e.target.value }))}
+                />
+              </div>
+              <label className="field-label" htmlFor="gs-game-input" style={{ gridRow: 3, gridColumn: 3 }}>Game</label>
+              <div className="pf-cell" style={{ gridRow: 3, gridColumn: 4 }}>
+                <TypeaheadSelect
+                  id="gs-game-input"
+                  options={filteredGames.map((g) => ({ value: g.id, label: g.name }))}
+                  value={form.game_id}
+                  onChange={(v) => setForm((c) => ({ ...c, game_id: v }))}
+                  placeholder={form.game_type_id ? "Select…" : "Optional"}
+                  disabled={readOnly}
+                />
+              </div>
+            </div>
+          </div>
+
+          {/* ── Balance Check ── */}
+          {balanceCheck && (
+            <div className={`pf-balance-check pf-balance-${balanceCheck.status}`}>
+              {balanceCheck.message}
+            </div>
+          )}
+
+          {/* ── End Session Section (Closed or being closed) ── */}
+          {(isClosed || (isEdit && isActive)) && (
+            <div className="pf-section">
+              <p className="pf-section-title"><span>🏁</span> {isActive ? "Close Session" : "Session End"}</p>
+              <div className="pf-grid">
+                <label className="field-label" htmlFor="gs-end-date-input" style={{ gridRow: 1, gridColumn: 1 }}>End Date</label>
+                <div className="pf-cell" style={{ gridRow: 1, gridColumn: 2 }}>
+                  <input
+                    id="gs-end-date-input"
+                    className={endDateInvalid ? "text-input invalid" : "text-input"}
+                    type="date"
+                    value={form.end_date}
+                    readOnly={readOnly}
+                    onChange={(e) => setForm((c) => ({ ...c, end_date: e.target.value }))}
+                  />
+                </div>
+                <label className="field-label" htmlFor="gs-end-time-input" style={{ gridRow: 2, gridColumn: 1 }}>End Time</label>
+                <div className="pf-cell" style={{ gridRow: 2, gridColumn: 2 }}>
+                  <input
+                    id="gs-end-time-input"
+                    className="text-input"
+                    type="time"
+                    step="1"
+                    value={form.end_time}
+                    readOnly={readOnly}
+                    onChange={(e) => setForm((c) => ({ ...c, end_time: e.target.value }))}
+                  />
+                </div>
+
+                <label className="field-label" htmlFor="gs-end-bal-input" style={{ gridRow: 1, gridColumn: 3 }}>Ending SC</label>
+                <div className="pf-cell" style={{ gridRow: 1, gridColumn: 4 }}>
+                  <input
+                    id="gs-end-bal-input"
+                    className={endBalInvalid ? "text-input invalid" : "text-input"}
+                    type="number"
+                    min="0"
+                    step="0.01"
+                    placeholder="0.00"
+                    title={endBalInvalid ? "Required" : undefined}
+                    value={form.ending_balance}
+                    readOnly={readOnly}
+                    onChange={(e) => setForm((c) => ({ ...c, ending_balance: e.target.value }))}
+                  />
+                </div>
+                <label className="field-label" htmlFor="gs-end-redeem-input" style={{ gridRow: 2, gridColumn: 3 }}>Ending Redeem</label>
+                <div className="pf-cell" style={{ gridRow: 2, gridColumn: 4 }}>
+                  <input
+                    id="gs-end-redeem-input"
+                    className="text-input"
+                    type="number"
+                    min="0"
+                    step="0.01"
+                    placeholder="0.00"
+                    value={form.ending_redeemable}
+                    readOnly={readOnly}
+                    onChange={(e) => setForm((c) => ({ ...c, ending_redeemable: e.target.value }))}
+                  />
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* ── Purchases / Redemptions During ── */}
+          {isClosed && (
+            <div className="pf-section">
+              <p className="pf-section-title"><span>📊</span> Activity During Session</p>
+              <div className="pf-grid">
+                <label className="field-label" htmlFor="gs-purch-during" style={{ gridRow: 1, gridColumn: 1 }}>Purchases</label>
+                <div className="pf-cell" style={{ gridRow: 1, gridColumn: 2 }}>
+                  <input
+                    id="gs-purch-during"
+                    className="text-input"
+                    type="number"
+                    min="0"
+                    step="0.01"
+                    placeholder="0.00"
+                    value={form.purchases_during}
+                    readOnly={readOnly}
+                    onChange={(e) => setForm((c) => ({ ...c, purchases_during: e.target.value }))}
+                  />
+                </div>
+                <label className="field-label" htmlFor="gs-redeem-during" style={{ gridRow: 1, gridColumn: 3 }}>Redemptions</label>
+                <div className="pf-cell" style={{ gridRow: 1, gridColumn: 4 }}>
+                  <input
+                    id="gs-redeem-during"
+                    className="text-input"
+                    type="number"
+                    min="0"
+                    step="0.01"
+                    placeholder="0.00"
+                    value={form.redemptions_during}
+                    readOnly={readOnly}
+                    onChange={(e) => setForm((c) => ({ ...c, redemptions_during: e.target.value }))}
+                  />
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* ── P/L Preview ── */}
+          {plPreview && (
+            <div className={`pf-balance-check ${plPreview.netPL >= 0 ? "pf-balance-match" : "pf-balance-lower"}`}>
+              P/L Preview: {plPreview.netPL >= 0 ? "+" : ""}{plPreview.netPL.toFixed(2)} SC
+              {" "}(Discoverable: {plPreview.discoverableSC.toFixed(2)}, Δ Redeem: {plPreview.deltaRedeem.toFixed(2)})
+            </div>
+          )}
+
+          {/* ── Notes ── */}
+          <div className="pf-notes-row">
+            <label className="field-label" htmlFor="gs-notes-input">Notes</label>
+            <textarea
+              id="gs-notes-input"
+              className="notes-input"
+              placeholder="Optional"
+              rows={2}
+              value={form.notes}
+              readOnly={readOnly}
+              onChange={(e) => setForm((c) => ({ ...c, notes: e.target.value }))}
+            />
+          </div>
+        </div>
+
+        {submitError ? <p className="submit-error">{submitError}</p> : null}
+
+        <div className="modal-actions modal-actions-split">
+          <div className="toolbar-row">
+            {isEdit && isActive && (
+              <button
+                className="ghost-button"
+                type="button"
+                onClick={handleEndAndStartNew}
+                disabled={endAndStartPending || !form.ending_balance}
+                title="Close this session and immediately start a new one"
+              >
+                End &amp; Start New
+              </button>
+            )}
+          </div>
+          <div className="toolbar-row">
+            {isEdit && isActive && (
+              <button
+                className="ghost-button"
+                type="button"
+                onClick={() => {
+                  setForm((c) => ({
+                    ...c,
+                    status: "Closed",
+                    end_date: c.end_date || c.session_date,
+                    end_time: c.end_time || new Date().toTimeString().slice(0, 8),
+                  }));
+                }}
+              >
+                Close Session
+              </button>
+            )}
+            <button
+              className="primary-button"
+              type="button"
+              onClick={onSubmit}
+              disabled={formInvalid || endAndStartPending}
+            >
+              {isCreate ? "Start Session" : "Save Session"}
+            </button>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/web/src/components/GameSessionsTab/GameSessionsTab.jsx
+++ b/web/src/components/GameSessionsTab/GameSessionsTab.jsx
@@ -1,0 +1,207 @@
+import { useCallback, useState } from "react";
+import useEntityTable from "../../hooks/useEntityTable";
+import EntityTable from "../common/EntityTable";
+import HighlightMatch from "../common/HighlightMatch";
+import GameSessionModal from "./GameSessionModal";
+import { buildGenericFilterOptions } from "../../utils/tableUtils";
+import {
+  initialGameSessionForm,
+  initialGameSessionColumnFilters,
+  gameSessionTableColumns,
+  gameSessionsPageSize,
+  gameSessionsFallbackPageSize,
+} from "./gameSessionsConstants";
+import { normalizeGameSessionForm, getGameSessionColumnValue } from "./gameSessionsUtils";
+
+// ── Entity config ───────────────────────────────────────────────────────────
+
+const gameSessionsConfig = {
+  entityName: "game_sessions",
+  entitySingular: "game session",
+  apiEndpoint: "/v1/workspace/game-sessions",
+  responseKey: "game_sessions",
+  batchDeleteIdKey: "game_session_ids",
+  columns: gameSessionTableColumns,
+  initialForm: initialGameSessionForm,
+  initialColumnFilters: initialGameSessionColumnFilters,
+  pageSize: gameSessionsPageSize,
+  fallbackPageSize: gameSessionsFallbackPageSize,
+  getColumnValue: getGameSessionColumnValue,
+  getCellDisplayValue: getGameSessionColumnValue,
+  searchFilter: (gs, text) =>
+    (gs.user_name || "").toLowerCase().includes(text)
+    || (gs.site_name || "").toLowerCase().includes(text)
+    || (gs.game_name || "").toLowerCase().includes(text)
+    || (gs.session_date || "").toLowerCase().includes(text)
+    || (gs.status || "").toLowerCase().includes(text)
+    || (gs.notes || "").toLowerCase().includes(text),
+  numericSortColumns: [
+    "starting_balance", "ending_balance",
+    "starting_redeemable", "ending_redeemable",
+    "net_taxable_pl", "wager_amount",
+  ],
+  getItemLabel: (gs) => `${gs.session_date || "unknown"} — ${gs.user_name || "unknown"} @ ${gs.site_name || "unknown"}`,
+  normalizeForm: normalizeGameSessionForm,
+  itemToForm: (gs) => ({
+    user_id: gs.user_id || "",
+    site_id: gs.site_id || "",
+    session_date: gs.session_date || "",
+    session_time: gs.session_time || "",
+    game_id: gs.game_id || "",
+    game_type_id: gs.game_type_id || "",
+    end_date: gs.end_date || "",
+    end_time: gs.end_time || "",
+    starting_balance: gs.starting_balance ?? "",
+    ending_balance: gs.ending_balance ?? "",
+    starting_redeemable: gs.starting_redeemable ?? "",
+    ending_redeemable: gs.ending_redeemable ?? "",
+    wager_amount: gs.wager_amount ?? "",
+    rtp: gs.rtp ?? "",
+    purchases_during: gs.purchases_during ?? "",
+    redemptions_during: gs.redemptions_during ?? "",
+    status: gs.status || "Active",
+    notes: gs.notes || "",
+  }),
+  formToPayload: (form, mode) => ({
+    user_id: form.user_id || null,
+    site_id: form.site_id || null,
+    session_date: form.session_date || null,
+    session_time: form.session_time || null,
+    game_id: form.game_id || null,
+    game_type_id: form.game_type_id || null,
+    end_date: form.end_date || null,
+    end_time: form.end_time || null,
+    starting_balance: form.starting_balance || "0.00",
+    ending_balance: form.ending_balance || "0.00",
+    starting_redeemable: form.starting_redeemable || "0.00",
+    ending_redeemable: form.ending_redeemable || "0.00",
+    wager_amount: form.wager_amount || "0.00",
+    rtp: form.rtp ? parseFloat(form.rtp) : null,
+    purchases_during: form.purchases_during || "0.00",
+    redemptions_during: form.redemptions_during || "0.00",
+    status: form.status || "Active",
+    notes: form.notes || null,
+  }),
+  buildFilterOptions: (items) => {
+    const options = {};
+    for (const col of gameSessionTableColumns) {
+      if (col.key === "status") {
+        options[col.key] = [
+          { value: "Active", label: "Active", path: ["Active"], searchValue: "Active" },
+          { value: "Closed", label: "Closed", path: ["Closed"], searchValue: "Closed" },
+        ];
+      } else {
+        options[col.key] = buildGenericFilterOptions(items, col.key, getGameSessionColumnValue);
+      }
+    }
+    return options;
+  },
+  buildSuggestions: () => ({}),
+  extraLoaders: [
+    { key: "users", endpoint: "/v1/workspace/users?limit=500&offset=0", responseKey: "users" },
+    { key: "sites", endpoint: "/v1/workspace/sites?limit=500&offset=0", responseKey: "sites" },
+    { key: "games", endpoint: "/v1/workspace/games?limit=500&offset=0", responseKey: "games" },
+    { key: "gameTypes", endpoint: "/v1/workspace/game-types?limit=500&offset=0", responseKey: "game_types" },
+  ],
+};
+
+// ── Cell renderer ───────────────────────────────────────────────────────────
+
+function renderGameSessionCell(gs, columnKey, search) {
+  if (columnKey === "status") {
+    const label = getGameSessionColumnValue(gs, "status");
+    const cls = label === "Active" ? "status-chip active" : "status-chip inactive";
+    return (
+      <span className={cls}>
+        <HighlightMatch text={label} query={search} />
+      </span>
+    );
+  }
+  if (columnKey === "net_taxable_pl") {
+    const val = getGameSessionColumnValue(gs, columnKey);
+    const num = Number(gs.net_taxable_pl);
+    const cls = isNaN(num) ? "" : num >= 0 ? "pl-positive" : "pl-negative";
+    return <span className={cls}>{val}</span>;
+  }
+  if (["starting_balance", "ending_balance", "starting_redeemable", "ending_redeemable"].includes(columnKey)) {
+    return <span>{getGameSessionColumnValue(gs, columnKey)}</span>;
+  }
+  if (columnKey === "user_name" || columnKey === "site_name" || columnKey === "game_name") {
+    return <HighlightMatch text={getGameSessionColumnValue(gs, columnKey)} query={search} />;
+  }
+  if (columnKey === "notes") {
+    return <HighlightMatch text={getGameSessionColumnValue(gs, columnKey)} query={search} />;
+  }
+  return <HighlightMatch text={getGameSessionColumnValue(gs, columnKey)} query={search} />;
+}
+
+// ── Component ───────────────────────────────────────────────────────────────
+
+export default function GameSessionsTab({ apiBaseUrl, hostedWorkspaceReady }) {
+  const [activeOnly, setActiveOnly] = useState(false);
+
+  const quickFilter = useCallback(
+    (gs) => {
+      if (activeOnly && gs.status !== "Active") return false;
+      return true;
+    },
+    [activeOnly],
+  );
+
+  const table = useEntityTable(gameSessionsConfig, { apiBaseUrl, hostedWorkspaceReady, quickFilter });
+
+  const quickFilterRow = (
+    <label className="quick-filter-check" title="Show only active (open) sessions">
+      <input type="checkbox" checked={activeOnly} onChange={(e) => setActiveOnly(e.target.checked)} />
+      Active Only
+    </label>
+  );
+
+  return (
+    <EntityTable
+      table={table}
+      entityName="game_sessions"
+      entitySingular="game session"
+      columns={gameSessionTableColumns}
+      getCellDisplayValue={getGameSessionColumnValue}
+      renderCell={renderGameSessionCell}
+      defaultColumnWidths={["110px", "100px", "100px", "100px", "80px", "100px", "100px", "110px", "110px", "100px"]}
+      defaultHeaderGridTemplate="36px 110px 100px 100px 100px 80px 100px 100px 110px 110px 100px 1fr"
+      extraToolbarRow={quickFilterRow}
+    >
+      {table.modalMode ? (
+        <GameSessionModal
+          mode={table.modalMode}
+          gameSession={table.selectedItem}
+          form={table.form}
+          setForm={table.setForm}
+          submitError={table.submitError}
+          users={table.extraData.users || []}
+          sites={table.extraData.sites || []}
+          games={table.extraData.games || []}
+          gameTypes={table.extraData.gameTypes || []}
+          apiBaseUrl={apiBaseUrl}
+          onClose={table.requestCloseModal}
+          onRequestEdit={() => table.selectedItem && table.openModal("edit", table.selectedItem)}
+          onRequestDelete={() => table.selectedItem && table.handleDelete([table.selectedItem])}
+          onSubmit={table.submitModal}
+          onEndAndStartNew={(closedSession) => {
+            // After closing the current session, open a "create" modal pre-filled
+            // with the closed session's ending state
+            table.openModal("create");
+            table.setForm((prev) => ({
+              ...prev,
+              user_id: closedSession.user_id || "",
+              site_id: closedSession.site_id || "",
+              game_id: closedSession.game_id || "",
+              game_type_id: closedSession.game_type_id || "",
+              starting_balance: closedSession.ending_balance || "",
+              starting_redeemable: closedSession.ending_redeemable || "",
+            }));
+            table.handleRefresh();
+          }}
+        />
+      ) : null}
+    </EntityTable>
+  );
+}

--- a/web/src/components/GameSessionsTab/gameSessionsConstants.js
+++ b/web/src/components/GameSessionsTab/gameSessionsConstants.js
@@ -1,0 +1,61 @@
+function todayISO() {
+  const d = new Date();
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+
+function nowTimeISO() {
+  const d = new Date();
+  return `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}:${String(d.getSeconds()).padStart(2, "0")}`;
+}
+
+export const initialGameSessionForm = {
+  user_id: "",
+  site_id: "",
+  session_date: todayISO(),
+  session_time: nowTimeISO(),
+  game_id: "",
+  game_type_id: "",
+  end_date: "",
+  end_time: "",
+  starting_balance: "",
+  ending_balance: "",
+  starting_redeemable: "",
+  ending_redeemable: "",
+  wager_amount: "",
+  rtp: "",
+  purchases_during: "",
+  redemptions_during: "",
+  status: "Active",
+  notes: "",
+};
+
+export const initialGameSessionColumnFilters = {
+  session_date: [],
+  user_name: [],
+  site_name: [],
+  game_name: [],
+  status: [],
+  starting_balance: [],
+  ending_balance: [],
+  starting_redeemable: [],
+  ending_redeemable: [],
+  net_taxable_pl: [],
+  notes: [],
+};
+
+export const gameSessionTableColumns = [
+  { key: "session_date", label: "Date", sortable: true },
+  { key: "user_name", label: "User", sortable: true },
+  { key: "site_name", label: "Site", sortable: true },
+  { key: "game_name", label: "Game", sortable: true },
+  { key: "status", label: "Status", sortable: true },
+  { key: "starting_balance", label: "Start SC", sortable: true },
+  { key: "ending_balance", label: "End SC", sortable: true },
+  { key: "starting_redeemable", label: "Start Redeem", sortable: true },
+  { key: "ending_redeemable", label: "End Redeem", sortable: true },
+  { key: "net_taxable_pl", label: "Net P/L", sortable: true },
+  { key: "notes", label: "Notes", sortable: true },
+];
+
+export const gameSessionsPageSize = 100;
+export const gameSessionsFallbackPageSize = 500;

--- a/web/src/components/GameSessionsTab/gameSessionsUtils.js
+++ b/web/src/components/GameSessionsTab/gameSessionsUtils.js
@@ -1,0 +1,60 @@
+function formatCurrency(value) {
+  if (value === null || value === undefined || value === "") return "—";
+  const num = Number(value);
+  if (isNaN(num)) return String(value);
+  return `$${num.toFixed(2)}`;
+}
+
+function formatSC(value) {
+  if (value === null || value === undefined || value === "") return "—";
+  const num = Number(value);
+  if (isNaN(num)) return String(value);
+  return num.toFixed(2);
+}
+
+export function normalizeGameSessionForm(form) {
+  return {
+    user_id: form.user_id || "",
+    site_id: form.site_id || "",
+    session_date: form.session_date || "",
+    session_time: form.session_time || "",
+    game_id: form.game_id || "",
+    game_type_id: form.game_type_id || "",
+    end_date: form.end_date || "",
+    end_time: form.end_time || "",
+    starting_balance: form.starting_balance ?? "",
+    ending_balance: form.ending_balance ?? "",
+    starting_redeemable: form.starting_redeemable ?? "",
+    ending_redeemable: form.ending_redeemable ?? "",
+    wager_amount: form.wager_amount ?? "",
+    rtp: form.rtp ?? "",
+    purchases_during: form.purchases_during ?? "",
+    redemptions_during: form.redemptions_during ?? "",
+    status: form.status || "Active",
+    notes: form.notes || "",
+  };
+}
+
+export function getGameSessionColumnValue(session, columnKey) {
+  if (columnKey === "session_date") {
+    const date = session.session_date || "—";
+    const time = session.session_time || "";
+    return time && time !== "00:00:00" ? `${date} ${time}` : date;
+  }
+  if (columnKey === "status") {
+    return session.status || "Active";
+  }
+  if (columnKey === "user_name") return session.user_name || "—";
+  if (columnKey === "site_name") return session.site_name || "—";
+  if (columnKey === "game_name") return session.game_name || "—";
+  if (columnKey === "starting_balance") return formatSC(session.starting_balance);
+  if (columnKey === "ending_balance") return formatSC(session.ending_balance);
+  if (columnKey === "starting_redeemable") return formatSC(session.starting_redeemable);
+  if (columnKey === "ending_redeemable") return formatSC(session.ending_redeemable);
+  if (columnKey === "net_taxable_pl") {
+    if (session.net_taxable_pl === null || session.net_taxable_pl === undefined) return "—";
+    return formatCurrency(session.net_taxable_pl);
+  }
+  if (columnKey === "notes") return (session.notes || "").slice(0, 100) || "—";
+  return String(session[columnKey] || "");
+}

--- a/web/src/components/common/Icon.jsx
+++ b/web/src/components/common/Icon.jsx
@@ -140,6 +140,14 @@ export default function Icon({ name, className }) {
           <path d="M12 20v-8" />
         </svg>
       );
+    case "gameSessions":
+      return (
+        <svg {...svgProps}>
+          <rect x="3" y="4" width="18" height="16" rx="2" />
+          <path d="M3 10h18" />
+          <path d="M10 4v16" />
+        </svg>
+      );
     case "upload":
       return (
         <svg {...svgProps}>


### PR DESCRIPTION
Closes #267

## Changes
- GameSessionsTab (4-file pattern: Tab, Modal, constants, utils)
- Expected-balances API endpoint (Priority 2/3 anchor algorithm)
- Deletion-impact API endpoint
- Balance check indicator (always-on, mirrors PurchaseModal pattern)
- Auto-fill starting balances on create (one-shot)
- P/L preview for closed sessions
- End & Start New flow
- Active session guard UI
- Fix route ordering: static paths before parameterized {game_session_id}
- 9 backend tests for expected balances computation
- Sessions tab registered in AppShell with gameSessions icon