### PR TITLE
feat: Expenses CRUD — full web port (Phase 4e)

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -41,6 +41,9 @@ from services.hosted.workspace_redemption_service import (
 from services.hosted.workspace_game_session_service import (
     HostedWorkspaceGameSessionService,
 )
+from services.hosted.workspace_expense_service import (
+    HostedWorkspaceExpenseService,
+)
 
 
 app = FastAPI(title="Sezzions Hosted API", version="0.1.0")
@@ -315,6 +318,32 @@ class HostedWorkspaceGameSessionBatchDeleteRequest(BaseModel):
     game_session_ids: list[str]
 
 
+class HostedWorkspaceExpenseCreateRequest(BaseModel):
+    expense_date: str
+    amount: str
+    vendor: str
+    expense_time: str | None = None
+    description: str | None = None
+    category: str | None = None
+    user_id: str | None = None
+    notes: str | None = None
+
+
+class HostedWorkspaceExpenseUpdateRequest(BaseModel):
+    expense_date: str
+    amount: str
+    vendor: str
+    expense_time: str | None = None
+    description: str | None = None
+    category: str | None = None
+    user_id: str | None = None
+    notes: str | None = None
+
+
+class HostedWorkspaceExpenseBatchDeleteRequest(BaseModel):
+    expense_ids: list[str]
+
+
 cors_config = load_hosted_backend_config(required=False, require_db_password=False)
 app.add_middleware(
     CORSMiddleware,
@@ -446,6 +475,16 @@ def get_hosted_workspace_game_session_service() -> HostedWorkspaceGameSessionSer
 
     session_factory = get_hosted_session_factory(config.sqlalchemy_url)
     return HostedWorkspaceGameSessionService(session_factory)
+
+
+def get_hosted_workspace_expense_service() -> HostedWorkspaceExpenseService:
+    try:
+        config = load_hosted_backend_config(require_db_password=True)
+    except HostedConfigurationError as exc:
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(exc)) from exc
+
+    session_factory = get_hosted_session_factory(config.sqlalchemy_url)
+    return HostedWorkspaceExpenseService(session_factory)
 
 
 def get_hosted_uploaded_sqlite_inspection_service() -> HostedUploadedSQLiteInspectionService:
@@ -1931,6 +1970,141 @@ def workspace_game_sessions_deletion_impact(
         )
     except LookupError as exc:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+
+
+# ── Expenses ─────────────────────────────────────────────────────────────────
+
+
+@app.get("/v1/workspace/expenses")
+def workspace_expenses_list(
+    limit: int = Query(100, ge=1, le=500),
+    offset: int = Query(0, ge=0),
+    session: AuthenticatedSession = Depends(get_authenticated_session),
+    service: HostedWorkspaceExpenseService = Depends(
+        get_hosted_workspace_expense_service
+    ),
+) -> dict[str, object]:
+    try:
+        page = service.list_expenses_page(
+            supabase_user_id=session.user_id,
+            limit=limit,
+            offset=offset,
+        )
+    except LookupError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+
+    return {
+        "expenses": [
+            e.as_dict() if hasattr(e, "as_dict") else e
+            for e in page["expenses"]
+        ],
+        "offset": page["offset"],
+        "limit": page["limit"],
+        "next_offset": page["next_offset"],
+        "total_count": page["total_count"],
+        "has_more": page["has_more"],
+    }
+
+
+@app.post("/v1/workspace/expenses")
+def workspace_expenses_create(
+    payload: HostedWorkspaceExpenseCreateRequest = Body(...),
+    session: AuthenticatedSession = Depends(get_authenticated_session),
+    service: HostedWorkspaceExpenseService = Depends(
+        get_hosted_workspace_expense_service
+    ),
+) -> dict[str, object]:
+    try:
+        expense = service.create_expense(
+            supabase_user_id=session.user_id,
+            expense_date=payload.expense_date,
+            expense_time=payload.expense_time,
+            amount=payload.amount,
+            vendor=payload.vendor,
+            description=payload.description,
+            category=payload.category,
+            user_id=payload.user_id,
+            notes=payload.notes,
+        )
+    except LookupError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+    return expense.as_dict() if hasattr(expense, "as_dict") else expense
+
+
+@app.patch("/v1/workspace/expenses/{expense_id}")
+def workspace_expenses_update(
+    expense_id: str = Path(...),
+    payload: HostedWorkspaceExpenseUpdateRequest = Body(...),
+    session: AuthenticatedSession = Depends(get_authenticated_session),
+    service: HostedWorkspaceExpenseService = Depends(
+        get_hosted_workspace_expense_service
+    ),
+) -> dict[str, object]:
+    try:
+        expense = service.update_expense(
+            supabase_user_id=session.user_id,
+            expense_id=expense_id,
+            expense_date=payload.expense_date,
+            expense_time=payload.expense_time,
+            amount=payload.amount,
+            vendor=payload.vendor,
+            description=payload.description,
+            category=payload.category,
+            user_id=payload.user_id,
+            notes=payload.notes,
+        )
+    except LookupError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+    return expense.as_dict() if hasattr(expense, "as_dict") else expense
+
+
+@app.delete(
+    "/v1/workspace/expenses/{expense_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+def workspace_expenses_delete(
+    expense_id: str = Path(...),
+    session: AuthenticatedSession = Depends(get_authenticated_session),
+    service: HostedWorkspaceExpenseService = Depends(
+        get_hosted_workspace_expense_service
+    ),
+) -> Response:
+    try:
+        service.delete_expense(
+            supabase_user_id=session.user_id,
+            expense_id=expense_id,
+        )
+    except LookupError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@app.post("/v1/workspace/expenses/batch-delete")
+def workspace_expenses_batch_delete(
+    payload: HostedWorkspaceExpenseBatchDeleteRequest = Body(...),
+    session: AuthenticatedSession = Depends(get_authenticated_session),
+    service: HostedWorkspaceExpenseService = Depends(
+        get_hosted_workspace_expense_service
+    ),
+) -> dict[str, int]:
+    try:
+        deleted_count = service.delete_expenses(
+            supabase_user_id=session.user_id,
+            expense_ids=payload.expense_ids,
+        )
+    except LookupError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+    return {"deleted_count": deleted_count}
 
 
 @app.get("/v1/workspace/import-plan")

--- a/docs/archive/2026-04-12-expenses-issue-body.md
+++ b/docs/archive/2026-04-12-expenses-issue-body.md
@@ -1,0 +1,51 @@
+## Problem / Motivation
+
+Phase 4e of the web port: the Expenses entity needs a full CRUD implementation on the web app, matching the desktop app's existing expense tracking feature.
+
+The desktop app (`desktop/ui/tabs/expenses_tab.py`) already supports:
+- Expense CRUD with Date, Time, Amount, Vendor, Category, User (optional FK), Description, and Notes
+- 19 IRS-aligned expense categories (dropdown with custom text support)
+- Vendor autocomplete from existing expense vendors
+- Notes autocomplete from existing expense notes
+- Collapsible notes section in the dialog
+- 2-column grid layout: Amount + Category on row 1, Vendor + User on row 2
+
+## Proposed Solution
+
+Port the full Expenses entity to the web app:
+
+**Backend:**
+- `HostedExpense` dataclass in `services/hosted/models.py`
+- Update existing `HostedExpenseRecord` ORM (add `notes` column, change user FK to `SET NULL`)
+- `HostedExpenseRepository` with standard CRUD + LEFT JOIN to users
+- `HostedWorkspaceExpenseService` with list/create/update/delete/batch-delete
+- 5 API endpoints in `api/app.py`: GET list, POST create, PATCH update, DELETE single, POST batch-delete
+
+**Frontend:**
+- `ExpensesTab/` directory: `ExpensesTab.jsx`, `ExpenseModal.jsx`, `expensesConstants.js`, `expensesUtils.js`
+- Desktop-parity modal layout (date/time row, 2-col grid, vendor autocomplete, category TypeaheadSelect, optional user)
+- Vendor + notes autocomplete from existing data via `buildSuggestions`
+- Wire into `AppShell.jsx` as top-level nav tab with "expenses" icon
+
+## Scope
+
+- [x] HostedExpense model with validation
+- [x] ORM record updates (notes column, SET NULL FK)
+- [x] Expense repository (CRUD + JOIN)
+- [x] Expense service (workspace-scoped CRUD)
+- [x] API endpoints (5 standard endpoints)
+- [x] Frontend: ExpensesTab + ExpenseModal + constants + utils
+- [x] AppShell wiring + Icon
+
+## Acceptance Criteria
+
+- Expenses tab appears in top-level navigation
+- Full CRUD: create, view, edit, delete, batch-delete
+- Desktop parity: 19 IRS categories, vendor autocomplete, optional user FK, date/time, amount, description, notes
+- User FK uses SET NULL (not CASCADE) matching desktop behavior
+- All existing tests pass (1342 passed)
+
+## Test Plan
+
+- Existing test suite passes with no regressions
+- Manual verification: navigate to Expenses tab, create/edit/view/delete expenses

--- a/docs/archive/2026-04-12-expenses-pr-body.md
+++ b/docs/archive/2026-04-12-expenses-pr-body.md
@@ -1,0 +1,42 @@
+## Summary
+
+Full Expenses CRUD port to the web app (Phase 4e), matching desktop parity.
+
+Closes #276
+
+## Changes
+
+### Backend
+- **Model**: `HostedExpense` dataclass in `services/hosted/models.py` with validation (vendor required, amount >= 0, date required)
+- **ORM**: Updated existing `HostedExpenseRecord` — added `notes` column, changed user FK from `CASCADE` to `SET NULL` (matching desktop behavior)
+- **Repository**: New `repositories/hosted_expense_repository.py` — standard CRUD with LEFT JOIN to users for `user_name` display
+- **Service**: New `services/hosted/workspace_expense_service.py` — workspace-scoped list/create/update/delete/batch-delete
+- **API**: 5 endpoints in `api/app.py` — GET list, POST create, PATCH update, DELETE single, POST batch-delete
+
+### Frontend
+- **ExpensesTab**: `useEntityTable` hook integration with search, sort, filter, pagination
+- **ExpenseModal**: Desktop-parity layout — date/time row, 2-column grid (Amount + Category / Vendor + User), description, notes
+- **Categories**: 19 IRS-aligned expense categories via TypeaheadSelect dropdown
+- **Autocomplete**: Vendor + notes autocomplete from existing expense data via `buildSuggestions`
+- **Navigation**: Wired into `AppShell.jsx` as top-level nav tab with "expenses" icon
+
+## Desktop Parity
+
+| Feature | Desktop | Web |
+|---------|---------|-----|
+| 19 IRS categories | Editable QComboBox | TypeaheadSelect |
+| Vendor autocomplete | PredictiveLineEdit | Dropdown suggestions |
+| Notes autocomplete | PredictivePlainTextEdit | Dropdown suggestions |
+| Optional user FK | QComboBox (SET NULL) | TypeaheadSelect (SET NULL) |
+| 2-column grid layout | QGridLayout | CSS pf-grid |
+| Date/Time row | QHBoxLayout | pf-datetime-row |
+
+## Test Results
+
+- 1342 passed, 1 skipped, 0 failures
+
+## Pitfalls / Follow-ups
+
+- The `hosted_expenses` table may need a migration on existing databases to add the `notes` column (currently only defined in SQLAlchemy ORM; existing production DBs may not have it)
+- Vendor autocomplete uses simple substring match; could be enhanced with prefix-first matching to mirror desktop `PredictiveLineEdit` behavior
+- No integration tests for the new expense API endpoints yet (existing test suite covers model/ORM compatibility)

--- a/repositories/hosted_expense_repository.py
+++ b/repositories/hosted_expense_repository.py
@@ -1,0 +1,192 @@
+"""Persistence helpers for hosted workspace-owned expenses."""
+
+from __future__ import annotations
+
+from sqlalchemy import delete, func, select
+from sqlalchemy.orm import aliased
+
+from services.hosted.models import HostedExpense
+from services.hosted.persistence import (
+    HostedExpenseRecord,
+    HostedUserRecord,
+)
+
+
+class HostedExpenseRepository:
+    def list_by_workspace_id(
+        self,
+        session,
+        workspace_id: str,
+        *,
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> list[HostedExpense]:
+        user_alias = aliased(HostedUserRecord)
+        query = (
+            select(
+                HostedExpenseRecord,
+                user_alias.name.label("user_name"),
+            )
+            .outerjoin(user_alias, HostedExpenseRecord.user_id == user_alias.id)
+            .where(HostedExpenseRecord.workspace_id == workspace_id)
+            .order_by(
+                HostedExpenseRecord.expense_date.desc(),
+                HostedExpenseRecord.expense_time.desc(),
+                HostedExpenseRecord.id.desc(),
+            )
+            .offset(offset)
+        )
+        if limit is not None:
+            query = query.limit(limit)
+
+        rows = session.execute(query).all()
+        return [self._row_to_model(row) for row in rows]
+
+    def count_by_workspace_id(self, session, workspace_id: str) -> int:
+        return session.scalar(
+            select(func.count())
+            .select_from(HostedExpenseRecord)
+            .where(HostedExpenseRecord.workspace_id == workspace_id)
+        ) or 0
+
+    def get_by_id_and_workspace_id(
+        self,
+        session,
+        *,
+        expense_id: str,
+        workspace_id: str,
+    ) -> HostedExpense | None:
+        user_alias = aliased(HostedUserRecord)
+        row = session.execute(
+            select(
+                HostedExpenseRecord,
+                user_alias.name.label("user_name"),
+            )
+            .outerjoin(user_alias, HostedExpenseRecord.user_id == user_alias.id)
+            .where(
+                HostedExpenseRecord.id == expense_id,
+                HostedExpenseRecord.workspace_id == workspace_id,
+            )
+        ).first()
+        if row is None:
+            return None
+        return self._row_to_model(row)
+
+    def create(
+        self,
+        session,
+        *,
+        workspace_id: str,
+        expense_date: str,
+        amount: str,
+        vendor: str,
+        expense_time: str | None = None,
+        expense_entry_time_zone: str | None = None,
+        description: str | None = None,
+        category: str | None = None,
+        user_id: str | None = None,
+        notes: str | None = None,
+    ) -> HostedExpense:
+        record = HostedExpenseRecord(
+            workspace_id=workspace_id,
+            expense_date=expense_date,
+            expense_time=expense_time,
+            expense_entry_time_zone=expense_entry_time_zone,
+            amount=amount,
+            vendor=vendor,
+            description=description,
+            category=category,
+            user_id=user_id,
+            notes=notes,
+        )
+        session.add(record)
+        session.flush()
+        return self.get_by_id_and_workspace_id(
+            session, expense_id=record.id, workspace_id=workspace_id
+        )
+
+    def update(
+        self,
+        session,
+        *,
+        expense_id: str,
+        workspace_id: str,
+        expense_date: str,
+        amount: str,
+        vendor: str,
+        expense_time: str | None = None,
+        expense_entry_time_zone: str | None = None,
+        description: str | None = None,
+        category: str | None = None,
+        user_id: str | None = None,
+        notes: str | None = None,
+    ) -> HostedExpense | None:
+        record = session.scalar(
+            select(HostedExpenseRecord).where(
+                HostedExpenseRecord.id == expense_id,
+                HostedExpenseRecord.workspace_id == workspace_id,
+            )
+        )
+        if record is None:
+            return None
+
+        record.expense_date = expense_date
+        record.expense_time = expense_time
+        record.expense_entry_time_zone = expense_entry_time_zone
+        record.amount = amount
+        record.vendor = vendor
+        record.description = description
+        record.category = category
+        record.user_id = user_id
+        record.notes = notes
+        session.flush()
+        return self.get_by_id_and_workspace_id(
+            session, expense_id=record.id, workspace_id=workspace_id
+        )
+
+    def delete(self, session, *, expense_id: str, workspace_id: str) -> bool:
+        record = session.scalar(
+            select(HostedExpenseRecord).where(
+                HostedExpenseRecord.id == expense_id,
+                HostedExpenseRecord.workspace_id == workspace_id,
+            )
+        )
+        if record is None:
+            return False
+
+        session.delete(record)
+        session.flush()
+        return True
+
+    def delete_many(self, session, *, expense_ids: list[str], workspace_id: str) -> int:
+        normalized_ids = list(dict.fromkeys(expense_ids))
+        if not normalized_ids:
+            return 0
+
+        result = session.execute(
+            delete(HostedExpenseRecord).where(
+                HostedExpenseRecord.workspace_id == workspace_id,
+                HostedExpenseRecord.id.in_(normalized_ids),
+            )
+        )
+        session.flush()
+        return int(result.rowcount or 0)
+
+    @staticmethod
+    def _row_to_model(row) -> HostedExpense:
+        record = row[0] if hasattr(row, "__getitem__") else row
+        user_name = row.user_name if hasattr(row, "user_name") else None
+        return HostedExpense(
+            id=record.id,
+            workspace_id=record.workspace_id,
+            expense_date=record.expense_date,
+            expense_time=record.expense_time,
+            expense_entry_time_zone=record.expense_entry_time_zone,
+            amount=record.amount,
+            vendor=record.vendor,
+            description=record.description,
+            category=record.category,
+            user_id=record.user_id,
+            notes=record.notes,
+            user_name=user_name,
+        )

--- a/services/hosted/models.py
+++ b/services/hosted/models.py
@@ -588,3 +588,64 @@ class HostedGameSession:
             "status": self.status,
             "notes": self.notes,
         }
+
+
+@dataclass
+class HostedExpense:
+    """A business expense owned by a hosted workspace."""
+
+    expense_date: str
+    amount: str
+    vendor: str
+    workspace_id: Optional[str] = None
+    expense_time: str = "00:00:00"
+    expense_entry_time_zone: Optional[str] = None
+    description: Optional[str] = None
+    category: Optional[str] = None
+    user_id: Optional[str] = None
+    notes: Optional[str] = None
+    id: Optional[str] = None
+    # Joined display names (read-only)
+    user_name: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if not self.expense_date or not self.expense_date.strip():
+            raise ValueError("Expense date is required")
+        self.expense_date = self.expense_date.strip()
+        if not self.vendor or not self.vendor.strip():
+            raise ValueError("Vendor is required")
+        self.vendor = self.vendor.strip()
+        if not self.amount:
+            raise ValueError("Amount is required")
+        from decimal import Decimal, InvalidOperation
+        try:
+            amt = Decimal(str(self.amount))
+        except (InvalidOperation, ValueError) as exc:
+            raise ValueError("Amount must be a valid number") from exc
+        if amt < 0:
+            raise ValueError("Amount cannot be negative")
+        self.amount = str(amt)
+        if self.expense_time is not None:
+            self.expense_time = self.expense_time.strip() or "00:00:00"
+        if self.description is not None:
+            self.description = self.description.strip() or None
+        if self.category is not None:
+            self.category = self.category.strip() or None
+        if self.notes is not None:
+            self.notes = self.notes.strip() or None
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "id": self.id,
+            "workspace_id": self.workspace_id,
+            "expense_date": self.expense_date,
+            "expense_time": self.expense_time,
+            "expense_entry_time_zone": self.expense_entry_time_zone,
+            "amount": self.amount,
+            "vendor": self.vendor,
+            "description": self.description,
+            "category": self.category,
+            "user_id": self.user_id,
+            "user_name": self.user_name,
+            "notes": self.notes,
+        }

--- a/services/hosted/persistence.py
+++ b/services/hosted/persistence.py
@@ -375,8 +375,9 @@ class HostedExpenseRecord(HostedBase):
     vendor: Mapped[str] = mapped_column(String(255), nullable=False)
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
     category: Mapped[str | None] = mapped_column(String(255), nullable=True)
-    user_id: Mapped[str | None] = mapped_column(ForeignKey("hosted_users.id", ondelete="CASCADE"), nullable=True, index=True)
+    user_id: Mapped[str | None] = mapped_column(ForeignKey("hosted_users.id", ondelete="SET NULL"), nullable=True, index=True)
     expense_entry_time_zone: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    notes: Mapped[str | None] = mapped_column(Text, nullable=True)
     created_at: Mapped[str | None] = mapped_column(String(64), nullable=True)
     updated_at: Mapped[str | None] = mapped_column(String(64), nullable=True)
 

--- a/services/hosted/workspace_expense_service.py
+++ b/services/hosted/workspace_expense_service.py
@@ -1,0 +1,189 @@
+"""Hosted workspace-managed expenses service."""
+
+from __future__ import annotations
+
+from repositories.hosted_account_repository import HostedAccountRepository
+from repositories.hosted_expense_repository import HostedExpenseRepository
+from repositories.hosted_workspace_repository import HostedWorkspaceRepository
+from services.hosted.models import HostedExpense, HostedWorkspace
+
+
+class HostedWorkspaceExpenseService:
+    def __init__(self, session_factory) -> None:
+        self.session_factory = session_factory
+        self.account_repository = HostedAccountRepository()
+        self.workspace_repository = HostedWorkspaceRepository()
+        self.expense_repository = HostedExpenseRepository()
+
+    def list_expenses_page(
+        self,
+        *,
+        supabase_user_id: str,
+        limit: int,
+        offset: int = 0,
+    ) -> dict[str, object]:
+        with self.session_factory() as session:
+            workspace = self._require_workspace(session, supabase_user_id)
+            total_count = self.expense_repository.count_by_workspace_id(session, workspace.id)
+            expenses = self.expense_repository.list_by_workspace_id(
+                session,
+                workspace.id,
+                limit=limit,
+                offset=offset,
+            )
+            next_offset = offset + len(expenses)
+            has_more = next_offset < total_count
+            return {
+                "expenses": expenses,
+                "offset": offset,
+                "limit": limit,
+                "next_offset": next_offset,
+                "total_count": total_count,
+                "has_more": has_more,
+            }
+
+    def create_expense(
+        self,
+        *,
+        supabase_user_id: str,
+        expense_date: str,
+        amount: str,
+        vendor: str,
+        expense_time: str | None = None,
+        expense_entry_time_zone: str | None = None,
+        description: str | None = None,
+        category: str | None = None,
+        user_id: str | None = None,
+        notes: str | None = None,
+    ) -> HostedExpense:
+        # Validate via model
+        HostedExpense(
+            expense_date=expense_date,
+            amount=amount,
+            vendor=vendor,
+        )
+
+        with self.session_factory() as session:
+            workspace = self._require_workspace(session, supabase_user_id)
+
+            created = self.expense_repository.create(
+                session,
+                workspace_id=workspace.id,
+                expense_date=expense_date,
+                expense_time=expense_time,
+                expense_entry_time_zone=expense_entry_time_zone,
+                amount=amount,
+                vendor=vendor,
+                description=description,
+                category=category,
+                user_id=user_id,
+                notes=notes,
+            )
+
+            session.commit()
+            return created
+
+    def update_expense(
+        self,
+        *,
+        supabase_user_id: str,
+        expense_id: str,
+        expense_date: str,
+        amount: str,
+        vendor: str,
+        expense_time: str | None = None,
+        expense_entry_time_zone: str | None = None,
+        description: str | None = None,
+        category: str | None = None,
+        user_id: str | None = None,
+        notes: str | None = None,
+    ) -> HostedExpense:
+        # Validate via model
+        HostedExpense(
+            expense_date=expense_date,
+            amount=amount,
+            vendor=vendor,
+        )
+
+        with self.session_factory() as session:
+            workspace = self._require_workspace(session, supabase_user_id)
+
+            updated = self.expense_repository.update(
+                session,
+                expense_id=expense_id,
+                workspace_id=workspace.id,
+                expense_date=expense_date,
+                expense_time=expense_time,
+                expense_entry_time_zone=expense_entry_time_zone,
+                amount=amount,
+                vendor=vendor,
+                description=description,
+                category=category,
+                user_id=user_id,
+                notes=notes,
+            )
+            if updated is None:
+                raise LookupError("Hosted expense was not found in the authenticated workspace.")
+
+            session.commit()
+            return updated
+
+    def delete_expense(
+        self,
+        *,
+        supabase_user_id: str,
+        expense_id: str,
+    ) -> None:
+        with self.session_factory() as session:
+            workspace = self._require_workspace(session, supabase_user_id)
+
+            deleted = self.expense_repository.delete(
+                session,
+                expense_id=expense_id,
+                workspace_id=workspace.id,
+            )
+            if not deleted:
+                raise LookupError("Hosted expense was not found in the authenticated workspace.")
+
+            session.commit()
+
+    def delete_expenses(
+        self,
+        *,
+        supabase_user_id: str,
+        expense_ids: list[str],
+    ) -> int:
+        normalized_ids = list(dict.fromkeys(expense_ids))
+        if not normalized_ids:
+            raise ValueError("At least one hosted expense id is required.")
+
+        with self.session_factory() as session:
+            workspace = self._require_workspace(session, supabase_user_id)
+
+            deleted_count = self.expense_repository.delete_many(
+                session,
+                expense_ids=normalized_ids,
+                workspace_id=workspace.id,
+            )
+            if deleted_count != len(normalized_ids):
+                raise LookupError(
+                    "One or more hosted expenses were not found in the authenticated workspace."
+                )
+
+            session.commit()
+            return deleted_count
+
+    def _require_workspace(self, session, supabase_user_id: str) -> HostedWorkspace:
+        account = self.account_repository.get_by_supabase_user_id(session, supabase_user_id)
+        if account is None:
+            raise LookupError(
+                "Hosted workspace bootstrap must complete before managing expenses."
+            )
+
+        workspace = self.workspace_repository.get_by_account_id(session, account.id)
+        if workspace is None:
+            raise LookupError(
+                "Hosted workspace bootstrap must complete before managing expenses."
+            )
+
+        return workspace

--- a/web/src/components/AppShell.jsx
+++ b/web/src/components/AppShell.jsx
@@ -16,6 +16,7 @@ import GamesTab from "./GamesTab/GamesTab";
 import PurchasesTab from "./PurchasesTab/PurchasesTab";
 import RedemptionsTab from "./RedemptionsTab/RedemptionsTab";
 import GameSessionsTab from "./GameSessionsTab/GameSessionsTab";
+import ExpensesTab from "./ExpensesTab/ExpensesTab";
 
 const setupTabs = [
   { key: "users", label: "Users", icon: "users", enabled: true },
@@ -31,7 +32,8 @@ const setupTabs = [
 const topLevelTabs = [
   { key: "purchases", label: "Purchases", icon: "purchases" },
   { key: "redemptions", label: "Redemptions", icon: "redemptions" },
-  { key: "game-sessions", label: "Sessions", icon: "gameSessions" }
+  { key: "game-sessions", label: "Sessions", icon: "gameSessions" },
+  { key: "expenses", label: "Expenses", icon: "expenses" },
 ];
 
 const allValidKeys = new Set([...setupTabs.map((t) => t.key), ...topLevelTabs.map((t) => t.key)]);
@@ -278,6 +280,12 @@ export default function AppShell({ auth }) {
         ) : null}
         {activeTab === "game-sessions" ? (
           <GameSessionsTab
+            apiBaseUrl={auth.apiBaseUrl}
+            hostedWorkspaceReady={auth.hostedWorkspaceReady}
+          />
+        ) : null}
+        {activeTab === "expenses" ? (
+          <ExpensesTab
             apiBaseUrl={auth.apiBaseUrl}
             hostedWorkspaceReady={auth.hostedWorkspaceReady}
           />

--- a/web/src/components/ExpensesTab/ExpenseModal.jsx
+++ b/web/src/components/ExpensesTab/ExpenseModal.jsx
@@ -177,6 +177,7 @@ export default function ExpenseModal({
                   min="0"
                   step="0.01"
                   placeholder="0.00"
+                  tabIndex={1}
                   title={amountInvalid ? "Required" : undefined}
                   value={form.amount}
                   readOnly={readOnly}
@@ -187,6 +188,7 @@ export default function ExpenseModal({
               <div className="pf-cell" style={{gridRow: 1, gridColumn: 4}}>
                 <TypeaheadSelect
                   id="expense-category-input"
+                  tabIndex={3}
                   options={categoryOptions}
                   value={form.category}
                   onChange={(category) => setForm((current) => ({ ...current, category }))}
@@ -204,6 +206,7 @@ export default function ExpenseModal({
                   className={vendorInvalid ? "text-input invalid" : "text-input"}
                   type="text"
                   placeholder="Vendor name…"
+                  tabIndex={2}
                   title={vendorInvalid ? "Required" : undefined}
                   value={form.vendor}
                   readOnly={readOnly}
@@ -234,6 +237,7 @@ export default function ExpenseModal({
               <div className="pf-cell" style={{gridRow: 2, gridColumn: 4}}>
                 <TypeaheadSelect
                   id="expense-user-input"
+                  tabIndex={4}
                   options={(users || []).map((u) => ({ value: u.id, label: u.name }))}
                   value={form.user_id}
                   onChange={(userId) => setForm((current) => ({ ...current, user_id: userId }))}
@@ -253,6 +257,7 @@ export default function ExpenseModal({
               className="notes-input"
               placeholder="Optional"
               rows={2}
+              tabIndex={5}
               value={form.description}
               readOnly={readOnly}
               onChange={(event) => setForm((current) => ({ ...current, description: event.target.value }))}
@@ -267,6 +272,7 @@ export default function ExpenseModal({
               className="notes-input"
               placeholder="Optional"
               rows={2}
+              tabIndex={6}
               value={form.notes}
               readOnly={readOnly}
               onChange={(event) => setForm((current) => ({ ...current, notes: event.target.value }))}

--- a/web/src/components/ExpensesTab/ExpenseModal.jsx
+++ b/web/src/components/ExpensesTab/ExpenseModal.jsx
@@ -1,0 +1,311 @@
+import { useRef, useEffect, useState, useMemo } from "react";
+import { getExpenseColumnValue } from "./expensesUtils";
+import { EXPENSE_CATEGORIES } from "./expensesConstants";
+import TypeaheadSelect from "../common/TypeaheadSelect";
+
+export default function ExpenseModal({
+  mode,
+  expense,
+  form,
+  setForm,
+  onClose,
+  onSubmit,
+  onRequestEdit,
+  onRequestDelete,
+  submitError,
+  users,
+  suggestions,
+}) {
+  const readOnly = mode === "view";
+  const title = mode === "create" ? "Add Expense" : mode === "edit" ? "Edit Expense" : "View Expense";
+  const amountRaw = form.amount;
+  const amountInvalid = !amountRaw || isNaN(Number(amountRaw)) || Number(amountRaw) < 0;
+  const vendorInvalid = !form.vendor || !form.vendor.trim();
+  const dateInvalid = !form.expense_date;
+  const formInvalid = amountInvalid || vendorInvalid || dateInvalid;
+  const closeLabel = readOnly ? "Close" : "Cancel";
+
+  // Auto-focus vendor field on mount
+  const vendorRef = useRef(null);
+  useEffect(() => {
+    if (!readOnly && vendorRef.current) {
+      vendorRef.current.focus();
+    }
+  }, [readOnly]);
+
+  // Category options for TypeaheadSelect
+  const categoryOptions = useMemo(() => {
+    const builtIn = EXPENSE_CATEGORIES.map((c) => ({ value: c, label: c }));
+    // Add any custom categories from suggestions that aren't already in the list
+    const extraCategories = (suggestions?.categories || [])
+      .filter((c) => !EXPENSE_CATEGORIES.includes(c))
+      .map((c) => ({ value: c, label: c }));
+    return [...builtIn, ...extraCategories];
+  }, [suggestions?.categories]);
+
+  // Vendor autocomplete suggestions
+  const vendorSuggestions = useMemo(
+    () => (suggestions?.vendors || []),
+    [suggestions?.vendors],
+  );
+
+  // Filtered vendor suggestions based on input
+  const [vendorFocused, setVendorFocused] = useState(false);
+  const filteredVendors = useMemo(() => {
+    if (!form.vendor || !form.vendor.trim()) return vendorSuggestions.slice(0, 8);
+    const lower = form.vendor.toLowerCase();
+    return vendorSuggestions.filter((v) => v.toLowerCase().includes(lower)).slice(0, 8);
+  }, [form.vendor, vendorSuggestions]);
+
+  // Notes autocomplete suggestions
+  const notesSuggestions = useMemo(
+    () => (suggestions?.notes || []),
+    [suggestions?.notes],
+  );
+  const [notesFocused, setNotesFocused] = useState(false);
+  const filteredNotes = useMemo(() => {
+    if (!form.notes || !form.notes.trim()) return notesSuggestions.slice(0, 5);
+    const lower = form.notes.toLowerCase();
+    return notesSuggestions.filter((n) => n.toLowerCase().includes(lower)).slice(0, 5);
+  }, [form.notes, notesSuggestions]);
+
+  // View mode
+  if (readOnly && expense) {
+    return (
+      <div className="modal-backdrop" role="presentation" onClick={onClose}>
+        <section
+          className="modal-card entity-modal"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="expense-modal-title"
+          onClick={(event) => event.stopPropagation()}
+        >
+          <div className="modal-header">
+            <div>
+              <h2 id="expense-modal-title">View Expense</h2>
+            </div>
+            <button className="ghost-button" type="button" onClick={onClose}>{closeLabel}</button>
+          </div>
+
+          <div className="modal-detail-body">
+            <dl className="detail-grid modal-detail-grid">
+              <div><dt>Date</dt><dd>{expense.expense_date}</dd></div>
+              <div><dt>Time</dt><dd>{expense.expense_time || "—"}</dd></div>
+              <div><dt>Amount</dt><dd>{getExpenseColumnValue(expense, "amount")}</dd></div>
+              <div><dt>Vendor</dt><dd>{expense.vendor || "—"}</dd></div>
+              <div><dt>Category</dt><dd>{expense.category || "—"}</dd></div>
+              <div><dt>User</dt><dd>{expense.user_name || "—"}</dd></div>
+            </dl>
+
+            <div className="modal-detail-notes">
+              <p className="field-label">Description</p>
+              <div className="notes-display">{expense.description || "-"}</div>
+            </div>
+
+            <div className="modal-detail-notes">
+              <p className="field-label">Notes</p>
+              <div className="notes-display">{expense.notes || "-"}</div>
+            </div>
+          </div>
+
+          <div className="modal-actions modal-actions-split">
+            <div className="toolbar-row">
+              <button className="ghost-button" type="button" onClick={onRequestDelete}>Delete</button>
+            </div>
+            <div className="toolbar-row">
+              <button className="primary-button" type="button" onClick={onRequestEdit}>Edit Expense</button>
+            </div>
+          </div>
+        </section>
+      </div>
+    );
+  }
+
+  // Create / Edit mode
+  return (
+    <div className="modal-backdrop" role="presentation" onClick={onClose}>
+      <section
+        className="modal-card entity-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="expense-modal-title"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="modal-header">
+          <div>
+            <h2 id="expense-modal-title">{title}</h2>
+          </div>
+          <button className="ghost-button" type="button" onClick={onClose}>
+            {closeLabel}
+          </button>
+        </div>
+
+        <div className="purchase-form">
+          {/* ── Date / Time — compact inline, pre-filled ── */}
+          <div className="pf-datetime-row">
+            <label className="field-label" htmlFor="expense-date-input">Date</label>
+            <input
+              id="expense-date-input"
+              className={dateInvalid ? "text-input invalid" : "text-input"}
+              type="date"
+              value={form.expense_date}
+              readOnly={readOnly}
+              onChange={(event) => setForm((current) => ({ ...current, expense_date: event.target.value }))}
+            />
+            <label className="field-label" htmlFor="expense-time-input">Time</label>
+            <input
+              id="expense-time-input"
+              className="text-input"
+              type="time"
+              step="1"
+              value={form.expense_time}
+              readOnly={readOnly}
+              onChange={(event) => setForm((current) => ({ ...current, expense_time: event.target.value }))}
+            />
+          </div>
+
+          {/* ── Expense Details — 4-column grid matching desktop layout ── */}
+          <div className="pf-section">
+            <p className="pf-section-title"><span>💵</span> Expense Details</p>
+            <div className="pf-grid">
+              <label className="field-label" htmlFor="expense-amount-input" style={{gridRow: 1, gridColumn: 1}}>Amount ($)</label>
+              <div className="pf-cell" style={{gridRow: 1, gridColumn: 2}}>
+                <input
+                  id="expense-amount-input"
+                  className={amountInvalid ? "text-input invalid" : "text-input"}
+                  type="number"
+                  min="0"
+                  step="0.01"
+                  placeholder="0.00"
+                  title={amountInvalid ? "Required" : undefined}
+                  value={form.amount}
+                  readOnly={readOnly}
+                  onChange={(event) => setForm((current) => ({ ...current, amount: event.target.value }))}
+                />
+              </div>
+              <label className="field-label" htmlFor="expense-category-input" style={{gridRow: 1, gridColumn: 3}}>Category</label>
+              <div className="pf-cell" style={{gridRow: 1, gridColumn: 4}}>
+                <TypeaheadSelect
+                  id="expense-category-input"
+                  options={categoryOptions}
+                  value={form.category}
+                  onChange={(category) => setForm((current) => ({ ...current, category }))}
+                  placeholder="Choose…"
+                  disabled={readOnly}
+                  allowClear
+                />
+              </div>
+
+              <label className="field-label" htmlFor="expense-vendor-input" style={{gridRow: 2, gridColumn: 1}}>Vendor</label>
+              <div className="pf-cell" style={{gridRow: 2, gridColumn: 2, position: "relative"}}>
+                <input
+                  id="expense-vendor-input"
+                  ref={vendorRef}
+                  className={vendorInvalid ? "text-input invalid" : "text-input"}
+                  type="text"
+                  placeholder="Vendor name…"
+                  title={vendorInvalid ? "Required" : undefined}
+                  value={form.vendor}
+                  readOnly={readOnly}
+                  onChange={(event) => setForm((current) => ({ ...current, vendor: event.target.value }))}
+                  onFocus={() => setVendorFocused(true)}
+                  onBlur={() => setTimeout(() => setVendorFocused(false), 150)}
+                  autoComplete="off"
+                />
+                {vendorFocused && filteredVendors.length > 0 && !readOnly ? (
+                  <ul className="typeahead-dropdown">
+                    {filteredVendors.map((v) => (
+                      <li
+                        key={v}
+                        className="typeahead-option"
+                        onMouseDown={(e) => {
+                          e.preventDefault();
+                          setForm((current) => ({ ...current, vendor: v }));
+                          setVendorFocused(false);
+                        }}
+                      >
+                        {v}
+                      </li>
+                    ))}
+                  </ul>
+                ) : null}
+              </div>
+              <label className="field-label" htmlFor="expense-user-input" style={{gridRow: 2, gridColumn: 3}}>User</label>
+              <div className="pf-cell" style={{gridRow: 2, gridColumn: 4}}>
+                <TypeaheadSelect
+                  id="expense-user-input"
+                  options={(users || []).map((u) => ({ value: u.id, label: u.name }))}
+                  value={form.user_id}
+                  onChange={(userId) => setForm((current) => ({ ...current, user_id: userId }))}
+                  placeholder="Optional"
+                  disabled={readOnly}
+                  allowClear
+                />
+              </div>
+            </div>
+          </div>
+
+          {/* ── Description — always visible, compact ── */}
+          <div className="pf-notes-row">
+            <label className="field-label" htmlFor="expense-description-input">Description</label>
+            <textarea
+              id="expense-description-input"
+              className="notes-input"
+              placeholder="Optional"
+              rows={2}
+              value={form.description}
+              readOnly={readOnly}
+              onChange={(event) => setForm((current) => ({ ...current, description: event.target.value }))}
+            />
+          </div>
+
+          {/* ── Notes — always visible, compact ── */}
+          <div className="pf-notes-row" style={{position: "relative"}}>
+            <label className="field-label" htmlFor="expense-notes-input">Notes</label>
+            <textarea
+              id="expense-notes-input"
+              className="notes-input"
+              placeholder="Optional"
+              rows={2}
+              value={form.notes}
+              readOnly={readOnly}
+              onChange={(event) => setForm((current) => ({ ...current, notes: event.target.value }))}
+              onFocus={() => setNotesFocused(true)}
+              onBlur={() => setTimeout(() => setNotesFocused(false), 150)}
+            />
+            {notesFocused && filteredNotes.length > 0 && !readOnly ? (
+              <ul className="typeahead-dropdown">
+                {filteredNotes.map((n) => (
+                  <li
+                    key={n}
+                    className="typeahead-option"
+                    onMouseDown={(e) => {
+                      e.preventDefault();
+                      setForm((current) => ({ ...current, notes: n }));
+                      setNotesFocused(false);
+                    }}
+                  >
+                    {n.length > 80 ? n.slice(0, 80) + "…" : n}
+                  </li>
+                ))}
+              </ul>
+            ) : null}
+          </div>
+        </div>
+
+        {submitError ? <p className="submit-error">{submitError}</p> : null}
+
+        <div className="modal-actions modal-actions-end">
+          <button
+            className="primary-button"
+            type="button"
+            onClick={onSubmit}
+            disabled={formInvalid}
+          >
+            Save Expense
+          </button>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/web/src/components/ExpensesTab/ExpensesTab.jsx
+++ b/web/src/components/ExpensesTab/ExpensesTab.jsx
@@ -1,0 +1,137 @@
+import { useMemo } from "react";
+import useEntityTable from "../../hooks/useEntityTable";
+import EntityTable from "../common/EntityTable";
+import HighlightMatch from "../common/HighlightMatch";
+import ExpenseModal from "./ExpenseModal";
+import { buildGenericFilterOptions } from "../../utils/tableUtils";
+import {
+  initialExpenseForm,
+  initialExpenseColumnFilters,
+  expenseTableColumns,
+  expensesPageSize,
+  expensesFallbackPageSize,
+} from "./expensesConstants";
+import { normalizeExpenseForm, getExpenseColumnValue } from "./expensesUtils";
+
+// ── Entity config ───────────────────────────────────────────────────────────
+
+const expensesConfig = {
+  entityName: "expenses",
+  entitySingular: "expense",
+  apiEndpoint: "/v1/workspace/expenses",
+  responseKey: "expenses",
+  batchDeleteIdKey: "expense_ids",
+  columns: expenseTableColumns,
+  initialForm: initialExpenseForm,
+  initialColumnFilters: initialExpenseColumnFilters,
+  pageSize: expensesPageSize,
+  fallbackPageSize: expensesFallbackPageSize,
+  getColumnValue: getExpenseColumnValue,
+  getCellDisplayValue: getExpenseColumnValue,
+  searchFilter: (expense, text) =>
+    (expense.vendor || "").toLowerCase().includes(text)
+    || (expense.category || "").toLowerCase().includes(text)
+    || (expense.user_name || "").toLowerCase().includes(text)
+    || (expense.expense_date || "").toLowerCase().includes(text)
+    || (expense.description || "").toLowerCase().includes(text)
+    || (expense.notes || "").toLowerCase().includes(text)
+    || (expense.amount || "").includes(text),
+  numericSortColumns: ["amount"],
+  getItemLabel: (e) => `${e.expense_date || "unknown"} — ${e.vendor || "unknown"}`,
+  normalizeForm: normalizeExpenseForm,
+  itemToForm: (expense) => ({
+    expense_date: expense.expense_date || "",
+    expense_time: expense.expense_time || "",
+    amount: expense.amount ?? "",
+    vendor: expense.vendor || "",
+    description: expense.description || "",
+    category: expense.category || "",
+    user_id: expense.user_id || "",
+    notes: expense.notes || "",
+  }),
+  formToPayload: (form) => ({
+    expense_date: form.expense_date || null,
+    amount: form.amount || null,
+    vendor: form.vendor?.trim() || null,
+    expense_time: form.expense_time || null,
+    description: form.description?.trim() || null,
+    category: form.category || null,
+    user_id: form.user_id || null,
+    notes: form.notes?.trim() || null,
+  }),
+  buildFilterOptions: (items) => {
+    const options = {};
+    for (const col of expenseTableColumns) {
+      options[col.key] = buildGenericFilterOptions(items, col.key, getExpenseColumnValue);
+    }
+    return options;
+  },
+  buildSuggestions: (items) => {
+    const vendors = [...new Set(items.map((e) => e.vendor).filter(Boolean))].sort();
+    const categories = [...new Set(items.map((e) => e.category).filter(Boolean))].sort();
+    const notes = [...new Set(
+      items.map((e) => e.notes || e.description).filter(Boolean),
+    )].slice(0, 50);
+    return { vendors, categories, notes };
+  },
+  extraLoaders: [
+    { key: "users", endpoint: "/v1/workspace/users?limit=500&offset=0", responseKey: "users" },
+  ],
+};
+
+// ── Cell renderer ───────────────────────────────────────────────────────────
+
+function renderExpenseCell(expense, columnKey, search) {
+  if (columnKey === "user_name") {
+    return <HighlightMatch text={getExpenseColumnValue(expense, columnKey)} query={search} />;
+  }
+  if (columnKey === "amount") {
+    return <span>{getExpenseColumnValue(expense, columnKey)}</span>;
+  }
+  if (columnKey === "notes") {
+    const text = expense.notes || expense.description || "";
+    return <HighlightMatch text={(text).slice(0, 100) || "-"} query={search} />;
+  }
+  return <HighlightMatch text={getExpenseColumnValue(expense, columnKey)} query={search} />;
+}
+
+// ── Component ───────────────────────────────────────────────────────────────
+
+export default function ExpensesTab({ apiBaseUrl, hostedWorkspaceReady }) {
+  const table = useEntityTable(expensesConfig, { apiBaseUrl, hostedWorkspaceReady });
+
+  const suggestions = useMemo(
+    () => expensesConfig.buildSuggestions(table.items || []),
+    [table.items],
+  );
+
+  return (
+    <EntityTable
+      table={table}
+      entityName="expenses"
+      entitySingular="expense"
+      columns={expenseTableColumns}
+      getCellDisplayValue={getExpenseColumnValue}
+      renderCell={renderExpenseCell}
+      defaultColumnWidths={["110px", "180px", "160px", "120px", "110px", "1fr"]}
+      defaultHeaderGridTemplate="36px 110px 180px 160px 120px 110px 1fr"
+    >
+      {table.modalMode ? (
+        <ExpenseModal
+          mode={table.modalMode}
+          expense={table.selectedItem}
+          form={table.form}
+          setForm={table.setForm}
+          submitError={table.submitError}
+          users={table.extraData.users || []}
+          suggestions={suggestions}
+          apiBaseUrl={apiBaseUrl}
+          onClose={table.requestCloseModal}
+          onRequestEdit={() => table.selectedItem && table.openModal("edit", table.selectedItem)}
+          onRequestDelete={() => table.selectedItem && table.handleDelete([table.selectedItem])}
+          onSubmit={table.submitModal}
+        />
+      ) : null}
+    </EntityTable>
+  );
+}

--- a/web/src/components/ExpensesTab/expensesConstants.js
+++ b/web/src/components/ExpensesTab/expensesConstants.js
@@ -1,0 +1,63 @@
+function todayISO() {
+  const d = new Date();
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+
+function nowTimeISO() {
+  const d = new Date();
+  return `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}:${String(d.getSeconds()).padStart(2, "0")}`;
+}
+
+export const EXPENSE_CATEGORIES = [
+  "Advertising",
+  "Car and Truck Expenses",
+  "Commissions and Fees",
+  "Contract Labor",
+  "Depreciation",
+  "Insurance (Business)",
+  "Interest (Mortgage/Other)",
+  "Legal and Professional Services",
+  "Office Expense",
+  "Rent or Lease (Vehicles/Equipment)",
+  "Rent or Lease (Other Business Property)",
+  "Repairs and Maintenance",
+  "Supplies",
+  "Taxes and Licenses",
+  "Travel",
+  "Meals (Deductible)",
+  "Utilities",
+  "Wages (Not Contract Labor)",
+  "Other Expenses",
+];
+
+export const initialExpenseForm = {
+  expense_date: todayISO(),
+  expense_time: nowTimeISO(),
+  amount: "",
+  vendor: "",
+  description: "",
+  category: "",
+  user_id: "",
+  notes: "",
+};
+
+export const initialExpenseColumnFilters = {
+  expense_date: [],
+  category: [],
+  vendor: [],
+  user_name: [],
+  amount: [],
+  notes: [],
+};
+
+export const expenseTableColumns = [
+  { key: "expense_date", label: "Date", sortable: true },
+  { key: "category", label: "Category", sortable: true },
+  { key: "vendor", label: "Vendor", sortable: true },
+  { key: "user_name", label: "User", sortable: true },
+  { key: "amount", label: "Amount", sortable: true },
+  { key: "notes", label: "Notes", sortable: true },
+];
+
+export const expensesPageSize = 100;
+export const expensesFallbackPageSize = 500;

--- a/web/src/components/ExpensesTab/expensesUtils.js
+++ b/web/src/components/ExpensesTab/expensesUtils.js
@@ -1,0 +1,29 @@
+function formatCurrency(value) {
+  if (value === null || value === undefined || value === "") return "—";
+  const num = Number(value);
+  if (isNaN(num)) return String(value);
+  return `$${num.toFixed(2)}`;
+}
+
+export function normalizeExpenseForm(form) {
+  return {
+    expense_date: form.expense_date || "",
+    expense_time: form.expense_time || "",
+    amount: form.amount ?? "",
+    vendor: form.vendor || "",
+    description: form.description || "",
+    category: form.category || "",
+    user_id: form.user_id || "",
+    notes: form.notes || "",
+  };
+}
+
+export function getExpenseColumnValue(expense, columnKey) {
+  if (columnKey === "expense_date") return expense.expense_date || "—";
+  if (columnKey === "category") return expense.category || "—";
+  if (columnKey === "vendor") return expense.vendor || "—";
+  if (columnKey === "user_name") return expense.user_name || "—";
+  if (columnKey === "amount") return formatCurrency(expense.amount);
+  if (columnKey === "notes") return expense.notes || expense.description || "—";
+  return String(expense[columnKey] || "");
+}

--- a/web/src/components/common/Icon.jsx
+++ b/web/src/components/common/Icon.jsx
@@ -148,6 +148,13 @@ export default function Icon({ name, className }) {
           <path d="M10 4v16" />
         </svg>
       );
+    case "expenses":
+      return (
+        <svg {...svgProps}>
+          <path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z" />
+          <path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z" />
+        </svg>
+      );
     case "upload":
       return (
         <svg {...svgProps}>


### PR DESCRIPTION
## Summary

Full Expenses CRUD port to the web app (Phase 4e), matching desktop parity.

Closes #276

## Changes

### Backend
- **Model**: `HostedExpense` dataclass in `services/hosted/models.py` with validation (vendor required, amount >= 0, date required)
- **ORM**: Updated existing `HostedExpenseRecord` — added `notes` column, changed user FK from `CASCADE` to `SET NULL` (matching desktop behavior)
- **Repository**: New `repositories/hosted_expense_repository.py` — standard CRUD with LEFT JOIN to users for `user_name` display
- **Service**: New `services/hosted/workspace_expense_service.py` — workspace-scoped list/create/update/delete/batch-delete
- **API**: 5 endpoints in `api/app.py` — GET list, POST create, PATCH update, DELETE single, POST batch-delete

### Frontend
- **ExpensesTab**: `useEntityTable` hook integration with search, sort, filter, pagination
- **ExpenseModal**: Desktop-parity layout — date/time row, 2-column grid (Amount + Category / Vendor + User), description, notes
- **Categories**: 19 IRS-aligned expense categories via TypeaheadSelect dropdown
- **Autocomplete**: Vendor + notes autocomplete from existing expense data via `buildSuggestions`
- **Navigation**: Wired into `AppShell.jsx` as top-level nav tab with "expenses" icon

## Desktop Parity

| Feature | Desktop | Web |
|---------|---------|-----|
| 19 IRS categories | Editable QComboBox | TypeaheadSelect |
| Vendor autocomplete | PredictiveLineEdit | Dropdown suggestions |
| Notes autocomplete | PredictivePlainTextEdit | Dropdown suggestions |
| Optional user FK | QComboBox (SET NULL) | TypeaheadSelect (SET NULL) |
| 2-column grid layout | QGridLayout | CSS pf-grid |
| Date/Time row | QHBoxLayout | pf-datetime-row |

## Test Results

- 1342 passed, 1 skipped, 0 failures

## Pitfalls / Follow-ups

- The `hosted_expenses` table may need a migration on existing databases to add the `notes` column (currently only defined in SQLAlchemy ORM; existing production DBs may not have it)
- Vendor autocomplete uses simple substring match; could be enhanced with prefix-first matching to mirror desktop `PredictiveLineEdit` behavior
- No integration tests for the new expense API endpoints yet (existing test suite covers model/ORM compatibility)
