### PR TITLE
bug: exclude CANCELED redemptions from Unprocessed filter

### DIFF
--- a/desktop/ui/tabs/redemptions_tab.py
+++ b/desktop/ui/tabs/redemptions_tab.py
@@ -540,8 +540,10 @@ class RedemptionsTab(QtWidgets.QWidget):
                 r_status = getattr(r, 'status', 'PENDING') or 'PENDING'
                 if bool(r.receipt_date) or r_status in ('CANCELED', 'PENDING_CANCEL'):
                     continue
-            if unprocessed_only and bool(r.processed):
-                continue
+            if unprocessed_only:
+                r_status = getattr(r, 'status', 'PENDING') or 'PENDING'
+                if bool(r.processed) or r_status == 'CANCELED':
+                    continue
             quick_filtered.append(r)
 
         if search_text:


### PR DESCRIPTION
Closes #284

## Summary
CANCELED redemptions appeared in the Unprocessed filter because the filter only excluded `processed=True` rows. Fully canceled redemptions are definitionally done and should not appear. `PENDING_CANCEL` intentionally remains visible.

## Changes
- `desktop/ui/tabs/redemptions_tab.py` — added `or r_status == 'CANCELED'` to the Unprocessed filter exclusion condition

## Test Plan
- CANCELED redemptions no longer appear when Unprocessed filter is checked
- PENDING_CANCEL redemptions still appear
- PENDING unprocessed redemptions still appear
- All 1380 tests pass